### PR TITLE
Add space after package and before version spec

### DIFF
--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -18,12 +18,12 @@ build:
 requirements:
   build:
     - python x.x
-    - dask-core>=1.1.4
-    - distributed>=1.25.2
+    - dask-core >=1.1.4
+    - distributed >=1.25.2
   run:
     - python x.x
-    - dask-core>=1.1.4
-    - distributed>=1.25.2
+    - dask-core >=1.1.4
+    - distributed >=1.25.2
 
 test:
   imports:


### PR DESCRIPTION
Conda and Conda-Build often assume that the version spec can be split from the package by whitespace. To avoid some unpleasant issues that may be caused by not having this space, go ahead and add one in the version spec.

cc @raydouglass @mrocklin @kkraus14