### PR TITLE
Remove comma preventing importing dask_cuda

### DIFF
--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -50,7 +50,7 @@ class LocalCUDACluster(LocalCluster):
             n_workers=n_workers,
             threads_per_worker=threads_per_worker,
             memory_limit=memory_limit,
-            **kwargs,
+            **kwargs
         )
 
     @gen.coroutine


### PR DESCRIPTION
This has been fixed in branch-0.7, but we should fix it in branch-0.6 as well.