### PR TITLE
[REVIEW] Use latest tag in update-version

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -14,7 +14,7 @@ set -e
 RELEASE_TYPE=$1
 
 # Get current version and calculate next versions
-CURRENT_TAG=`git describe --abbrev=0 --tags | tr -d 'v'`
+CURRENT_TAG=`git tag | grep -xE 'v[0-9\.]+' | sort --version-sort | tail -n 1 | tr -d 'v'`
 CURRENT_MAJOR=`echo $CURRENT_TAG | awk '{split($0, a, "."); print a[1]}'`
 CURRENT_MINOR=`echo $CURRENT_TAG | awk '{split($0, a, "."); print a[2]}'`
 CURRENT_PATCH=`echo $CURRENT_TAG | awk '{split($0, a, "."); print a[3]}'`
@@ -39,8 +39,6 @@ else
   exit 1
 fi
 
-# Move to root of repo
-cd ../..
 echo "Preparing '$RELEASE_TYPE' release [$CURRENT_TAG -> $NEXT_FULL_TAG]"
 
 # Inplace sed replace; workaround for Linux and Mac


### PR DESCRIPTION
Change update-version script to ignore dev/alpha/rc versions and use only the latest version

Also updated where changes are made