### PR TITLE
Replace use of ncores= keywords with nthreads=

### DIFF
--- a/dask_cuda/dask_cuda_worker.py
+++ b/dask_cuda/dask_cuda_worker.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 import atexit
 import logging
+import multiprocessing
 import os
 
 import click
@@ -14,7 +15,7 @@ from distributed.utils import (
     parse_bytes,
     warn_on_duration,
 )
-from distributed.worker import _ncores, parse_memory_limit
+from distributed.worker import parse_memory_limit
 from distributed.security import Security
 from distributed.cli.utils import check_python_3, install_signal_handlers
 from distributed.comm.addressing import uri_from_host_port
@@ -186,7 +187,7 @@ def main(
         nprocs = get_n_gpus()
 
     if not nthreads:
-        nthreads = min(1, _ncores // nprocs)
+        nthreads = min(1, multiprocessing.cpu_count() // nprocs)
 
     if pid_file:
         with open(pid_file, "w") as f:
@@ -261,7 +262,7 @@ def main(
         t(
             scheduler,
             scheduler_file=scheduler_file,
-            ncores=nthreads,
+            nthreads=nthreads,
             services=services,
             loop=loop,
             resources=resources,

--- a/dask_cuda/tests/test_spill.py
+++ b/dask_cuda/tests/test_spill.py
@@ -49,7 +49,7 @@ def assert_device_host_file_size(dhf, total_bytes, chunk_overhead=1024):
 def test_device_spill(params):
     @gen_cluster(
         client=True,
-        ncores=[("127.0.0.1", 1)],
+        nthreads=[("127.0.0.1", 1)],
         Worker=Worker,
         worker_kwargs={
             "memory_limit": params["memory_limit"],


### PR DESCRIPTION
This mirrors a name change upstream in dask.distributed

@dillon-cullinan 

Also fixed upstream at https://github.com/dask/distributed/pull/2791