### PR TITLE
LocalCUDACluster calls _correct_state() to ensure workers started

### DIFF
--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -104,6 +104,7 @@ class LocalCUDACluster(LocalCluster):
 
         self.cuda_visible_devices = CUDA_VISIBLE_DEVICES
         self.scale(n_workers)
+        self.sync(self._correct_state)
 
     def new_worker_spec(self):
         try:


### PR DESCRIPTION
This fix ensures `LocalCUDACluster` properly informs on workers immediately after creation. A proper fix should be in dask/distributed, but as a quick workaround I'm adding this here.

@cjnolet this should fix your issue and allow pinning dask-cuda=0.8 back in.

cc @mrocklin @dantegd @raydouglass 