### PR TITLE
Update cudf, dask, dask-cudf, distributed version requirements

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -23,9 +23,9 @@ export HOME=$WORKSPACE
 # Switch to project root; also root of repo checkout
 cd $WORKSPACE
 
-# Get latest tag and number of commits since tag
-export GIT_DESCRIBE_TAG=`git describe --abbrev=0 --tags`
-export GIT_DESCRIBE_NUMBER=`git rev-list ${GIT_DESCRIBE_TAG}..HEAD --count`
+# Parse git describe
+export GIT_DESCRIBE_TAG=`git describe --tags`
+export MINOR_VERSION=`echo $GIT_DESCRIBE_TAG | grep -o -E '([0-9]+\.[0-9]+)'`
 
 # Enable NumPy's __array_function__ protocol (needed for NumPy 1.16.x,
 # will possibly be enabled by default starting on 1.17)
@@ -50,8 +50,8 @@ g++ --version
 conda config --set ssl_verify False
 
 conda install \
-    'cudf=0.9' \
-    'dask-cudf=0.9'
+    "cudf=$MINOR_VERSION.*" \
+    "dask-cudf=$MINOR_VERSION.*"
 
 ################################################################################
 # SETUP - Install additional packages

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -50,10 +50,8 @@ g++ --version
 conda config --set ssl_verify False
 
 conda install \
-    'cudf=0.8' \
-    'dask-cudf=0.8'
-
-pip install git+https://github.com/dask/distributed.git@master
+    'cudf=0.9' \
+    'dask-cudf=0.9'
 
 ################################################################################
 # SETUP - Install additional packages

--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -22,8 +22,8 @@ requirements:
     - setuptools
   run:
     - python x.x
-    - dask-core >=1.2.1
-    - distributed >=1.28.0
+    - dask-core >=2.1.0
+    - distributed >=2.1.0
     - numpy >=1.16.0
     - numba >=0.40.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dask>=1.2.1
-distributed>=1.28.0
+dask>=2.1.0
+distributed>=2.1.0
 numpy>=1.16.0
 numba>=0.40.1


### PR DESCRIPTION
It seems that CI is failing because it's using the wrong version of distributed, even though the looks seem to show that it's up-to-date. Hopefully this will fix that.

cc @mike-wendt 