### PR TITLE
[gpuCI] Auto-merge branch-0.9 to branch-0.10 [skip ci]

### DIFF
--- a/ci/cpu/upload-anaconda.sh
+++ b/ci/cpu/upload-anaconda.sh
@@ -5,11 +5,7 @@
 set -e
 
 export UPLOADFILE=`conda build conda/recipes/dask-cuda --python=$PYTHON --output`
-CUDA_REL=${CUDA:0:3}
-if [ "${CUDA:0:2}" == '10' ]; then
-  # CUDA 10 release
-  CUDA_REL=${CUDA:0:4}
-fi
+CUDA_REL=${CUDA_VERSION%.*}
 
 SOURCE_BRANCH=master
 

--- a/dask_cuda/dgx.py
+++ b/dask_cuda/dgx.py
@@ -87,7 +87,7 @@ def DGX(
                 },
                 "interface": interface + str(i // 2),
                 "protocol": "ucx",
-                "ncores": threads_per_worker,
+                "nthreads": threads_per_worker,
                 "data": dict,
                 "preload": ["dask_cuda.initialize_context"],
                 "dashboard_address": ":0",

--- a/dask_cuda/tests/test_spill.py
+++ b/dask_cuda/tests/test_spill.py
@@ -223,7 +223,7 @@ async def test_cupy_cluster_device_spill(loop, params):
 def test_cudf_device_spill(params):
     @gen_cluster(
         client=True,
-        ncores=[("127.0.0.1", 1)],
+        nthreads=[("127.0.0.1", 1)],
         Worker=Worker,
         timeout=60,
         worker_kwargs={


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.9` that creates a PR to keep `branch-0.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.