### PR TITLE
[HOTFIX] Remove distributed pip install from conda package build

### DIFF
--- a/conda/recipes/dask-cuda/build.sh
+++ b/conda/recipes/dask-cuda/build.sh
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
 
-pip install git+https://github.com/dask/distributed.git@master
 python setup.py install --single-version-externally-managed --record=record.txt

--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - setuptools
   run:
     - python x.x
-    - dask-core >=2.3.1
+    - dask-core >=2.3.0
     - distributed >=2.3.1
     - numpy >=1.16.0
     - numba >=0.40.1

--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -22,8 +22,8 @@ requirements:
     - setuptools
   run:
     - python x.x
-    - dask-core >=2.3.0
-    - distributed >=2.3.0
+    - dask-core >=2.3.1
+    - distributed >=2.3.1
     - numpy >=1.16.0
     - numba >=0.40.1
 


### PR DESCRIPTION
Including the `pip install` during the conda build effectively packages `distributed` with `dask-cuda`. Instead, `distributed` should only be a dependency.

Also, this PR bumped the `dask-core` & `distributed` version to `2.3.1`

This is a hotfix because v0.9 runtime containers cannot use any dask functionality without `distributed=2.3.1`.