### PR TITLE
Automatically determine CPU affinity

### DIFF
--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - python x.x
     - dask-core >=2.4.0
     - distributed >=2.4.0
+    - pynvml >=8.0.3
     - numpy >=1.16.0
     - numba >=0.40.1
 

--- a/dask_cuda/__init__.py
+++ b/dask_cuda/__init__.py
@@ -2,5 +2,6 @@ from .local_cuda_cluster import LocalCUDACluster
 from .dgx import DGX
 
 from ._version import get_versions
-__version__ = get_versions()['version']
+
+__version__ = get_versions()["version"]
 del get_versions

--- a/dask_cuda/dask_cuda_worker.py
+++ b/dask_cuda/dask_cuda_worker.py
@@ -20,7 +20,12 @@ from distributed.proctitle import (
 
 from .device_host_file import DeviceHostFile
 from .local_cuda_cluster import cuda_visible_devices
-from .utils import get_n_gpus, get_device_total_memory
+from .utils import (
+    CPUAffinity,
+    get_cpu_affinity_list,
+    get_n_gpus,
+    get_device_total_memory,
+)
 
 from toolz import valmap
 from tornado.ioloop import IOLoop, TimeoutError
@@ -244,6 +249,7 @@ def main(
             preload=(preload or []) + ["dask_cuda.initialize_context"],
             security=sec,
             env={"CUDA_VISIBLE_DEVICES": cuda_visible_devices(i)},
+            plugins={CPUAffinity(get_cpu_affinity_list(i))},
             name=name if nprocs == 1 or not name else name + "-" + str(i),
             data=(
                 DeviceHostFile,

--- a/dask_cuda/dask_cuda_worker.py
+++ b/dask_cuda/dask_cuda_worker.py
@@ -20,12 +20,7 @@ from distributed.proctitle import (
 
 from .device_host_file import DeviceHostFile
 from .local_cuda_cluster import cuda_visible_devices
-from .utils import (
-    CPUAffinity,
-    get_cpu_affinity,
-    get_n_gpus,
-    get_device_total_memory,
-)
+from .utils import CPUAffinity, get_cpu_affinity, get_n_gpus, get_device_total_memory
 
 from toolz import valmap
 from tornado.ioloop import IOLoop, TimeoutError

--- a/dask_cuda/dask_cuda_worker.py
+++ b/dask_cuda/dask_cuda_worker.py
@@ -22,7 +22,7 @@ from .device_host_file import DeviceHostFile
 from .local_cuda_cluster import cuda_visible_devices
 from .utils import (
     CPUAffinity,
-    get_cpu_affinity_list,
+    get_cpu_affinity,
     get_n_gpus,
     get_device_total_memory,
 )
@@ -249,7 +249,7 @@ def main(
             preload=(preload or []) + ["dask_cuda.initialize_context"],
             security=sec,
             env={"CUDA_VISIBLE_DEVICES": cuda_visible_devices(i)},
-            plugins={CPUAffinity(get_cpu_affinity_list(i))},
+            plugins={CPUAffinity(get_cpu_affinity(i))},
             name=name if nprocs == 1 or not name else name + "-" + str(i),
             data=(
                 DeviceHostFile,

--- a/dask_cuda/dgx.py
+++ b/dask_cuda/dgx.py
@@ -4,15 +4,7 @@ from dask.distributed import Nanny, SpecCluster, Scheduler
 from distributed.system import MEMORY_LIMIT
 
 from .local_cuda_cluster import cuda_visible_devices
-from .utils import get_cpu_affinity_list
-
-
-class CPUAffinity:
-    def __init__(self, cores):
-        self.cores = cores
-
-    def setup(self, worker=None):
-        os.sched_setaffinity(0, self.cores)
+from .utils import CPUAffinity, get_cpu_affinity_list
 
 
 def DGX(

--- a/dask_cuda/dgx.py
+++ b/dask_cuda/dgx.py
@@ -4,6 +4,7 @@ from dask.distributed import Nanny, SpecCluster, Scheduler
 from distributed.system import MEMORY_LIMIT
 
 from .local_cuda_cluster import cuda_visible_devices
+from .utils import get_cpu_affinity_list
 
 
 class CPUAffinity:
@@ -12,18 +13,6 @@ class CPUAffinity:
 
     def setup(self, worker=None):
         os.sched_setaffinity(0, self.cores)
-
-
-affinity = {  # nvidia-smi topo -m
-    0: list(range(0, 20)) + list(range(40, 60)),
-    1: list(range(0, 20)) + list(range(40, 60)),
-    2: list(range(0, 20)) + list(range(40, 60)),
-    3: list(range(0, 20)) + list(range(40, 60)),
-    4: list(range(20, 40)) + list(range(60, 79)),
-    5: list(range(20, 40)) + list(range(60, 79)),
-    6: list(range(20, 40)) + list(range(60, 79)),
-    7: list(range(20, 40)) + list(range(60, 79)),
-}
 
 
 def DGX(
@@ -91,7 +80,7 @@ def DGX(
                 "data": dict,
                 "preload": ["dask_cuda.initialize_context"],
                 "dashboard_address": ":0",
-                "plugins": [CPUAffinity(affinity[i])],
+                "plugins": [CPUAffinity(get_cpu_affinity_list(i))],
                 "silence_logs": silence_logs,
                 "memory_limit": memory_limit,
             },

--- a/dask_cuda/dgx.py
+++ b/dask_cuda/dgx.py
@@ -4,7 +4,7 @@ from dask.distributed import Nanny, SpecCluster, Scheduler
 from distributed.system import MEMORY_LIMIT
 
 from .local_cuda_cluster import cuda_visible_devices
-from .utils import CPUAffinity, get_cpu_affinity_list
+from .utils import CPUAffinity, get_cpu_affinity
 
 
 def DGX(
@@ -72,7 +72,7 @@ def DGX(
                 "data": dict,
                 "preload": ["dask_cuda.initialize_context"],
                 "dashboard_address": ":0",
-                "plugins": [CPUAffinity(get_cpu_affinity_list(i))],
+                "plugins": [CPUAffinity(get_cpu_affinity(i))],
                 "silence_logs": silence_logs,
                 "memory_limit": memory_limit,
             },

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -7,7 +7,12 @@ from distributed.utils import parse_bytes
 from distributed.system import MEMORY_LIMIT
 
 from .device_host_file import DeviceHostFile
-from .utils import get_n_gpus, get_device_total_memory
+from .utils import (
+    CPUAffinity,
+    get_cpu_affinity_list,
+    get_n_gpus,
+    get_device_total_memory,
+)
 
 
 def cuda_visible_devices(i, visible=None):
@@ -122,7 +127,8 @@ class LocalCUDACluster(LocalCluster):
                     "CUDA_VISIBLE_DEVICES": cuda_visible_devices(
                         ii, self.cuda_visible_devices
                     )
-                }
+                },
+                "plugins": {CPUAffinity(get_cpu_affinity_list(ii))},
             }
         )
 

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -9,7 +9,7 @@ from distributed.system import MEMORY_LIMIT
 from .device_host_file import DeviceHostFile
 from .utils import (
     CPUAffinity,
-    get_cpu_affinity_list,
+    get_cpu_affinity,
     get_n_gpus,
     get_device_total_memory,
 )
@@ -128,7 +128,7 @@ class LocalCUDACluster(LocalCluster):
                         ii, self.cuda_visible_devices
                     )
                 },
-                "plugins": {CPUAffinity(get_cpu_affinity_list(ii))},
+                "plugins": {CPUAffinity(get_cpu_affinity(ii))},
             }
         )
 

--- a/dask_cuda/tests/test_utils.py
+++ b/dask_cuda/tests/test_utils.py
@@ -2,7 +2,7 @@ import pytest
 
 import os
 
-from dask_cuda.utils import bitmask_to_list, get_cpu_affinity_list, get_n_gpus
+from dask_cuda.utils import get_cpu_affinity_list, get_n_gpus, unpack_bitmask
 
 
 def test_get_n_gpus():
@@ -30,8 +30,8 @@ def test_get_n_gpus():
         {"input": [0, 18446744073709551615], "output": [i + 64 for i in range(64)]},
     ],
 )
-def test_bitmask_to_list(params):
-    assert bitmask_to_list(params["input"]) == params["output"]
+def test_unpack_bitmask(params):
+    assert unpack_bitmask(params["input"]) == params["output"]
 
 
 def test_cpu_affinity():

--- a/dask_cuda/tests/test_utils.py
+++ b/dask_cuda/tests/test_utils.py
@@ -2,7 +2,7 @@ import pytest
 
 import os
 
-from dask_cuda.utils import get_cpu_affinity_list, get_n_gpus, unpack_bitmask
+from dask_cuda.utils import get_cpu_affinity, get_n_gpus, unpack_bitmask
 
 
 def test_get_n_gpus():
@@ -36,6 +36,6 @@ def test_unpack_bitmask(params):
 
 def test_cpu_affinity():
     for i in range(get_n_gpus()):
-        affinity = get_cpu_affinity_list(i)
+        affinity = get_cpu_affinity(i)
         os.sched_setaffinity(0, affinity)
         assert list(os.sched_getaffinity(0)) == affinity

--- a/dask_cuda/tests/test_utils.py
+++ b/dask_cuda/tests/test_utils.py
@@ -26,19 +26,12 @@ def test_get_n_gpus():
             "input": [17293823668613283840, 65535],
             "output": [i + 20 for i in range(20)] + [i + 60 for i in range(20)],
         },
-        {
-            "input": [18446744073709551615, 0],
-            "output": [i for i in range(64)],
-        },
-        {
-            "input": [0, 18446744073709551615],
-            "output": [i + 64 for i in range(64)],
-        },
+        {"input": [18446744073709551615, 0], "output": [i for i in range(64)]},
+        {"input": [0, 18446744073709551615], "output": [i + 64 for i in range(64)]},
     ],
 )
 def test_bitmask_to_list(params):
     assert bitmask_to_list(params["input"]) == params["output"]
-
 
 
 def test_cpu_affinity():

--- a/dask_cuda/tests/test_utils.py
+++ b/dask_cuda/tests/test_utils.py
@@ -1,6 +1,8 @@
+import pytest
+
 import os
 
-from dask_cuda.utils import get_n_gpus
+from dask_cuda.utils import bitmask_to_list, get_cpu_affinity_list, get_n_gpus
 
 
 def test_get_n_gpus():
@@ -11,3 +13,36 @@ def test_get_n_gpus():
         assert get_n_gpus() == 3
     finally:
         del os.environ["CUDA_VISIBLE_DEVICES"]
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {
+            "input": [1152920405096267775, 0],
+            "output": [i for i in range(20)] + [i + 40 for i in range(20)],
+        },
+        {
+            "input": [17293823668613283840, 65535],
+            "output": [i + 20 for i in range(20)] + [i + 60 for i in range(20)],
+        },
+        {
+            "input": [18446744073709551615, 0],
+            "output": [i for i in range(64)],
+        },
+        {
+            "input": [0, 18446744073709551615],
+            "output": [i + 64 for i in range(64)],
+        },
+    ],
+)
+def test_bitmask_to_list(params):
+    assert bitmask_to_list(params["input"]) == params["output"]
+
+
+
+def test_cpu_affinity():
+    for i in range(get_n_gpus()):
+        affinity = get_cpu_affinity_list(i)
+        os.sched_setaffinity(0, affinity)
+        assert list(os.sched_getaffinity(0)) == affinity

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -63,7 +63,24 @@ def get_cpu_count():
     return cpu_count()
 
 
-def get_cpu_affinity_list(device_index):
+def get_cpu_affinity(device_index):
+    """Get a list containing the CPU indices to which a GPU is directly connected.
+
+    Parameters
+    ----------
+    device_index: int
+        Device index of the GPU
+
+    Examples
+    --------
+    >>> from dask_cuda.utils import get_cpu_affinity
+    >>> get_cpu_affinity(0)  # DGX-1 has GPUs 0-3 connected to CPUs [0-19, 20-39]
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+     40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59]
+    >>> get_cpu_affinity(5)  # DGX-1 has GPUs 5-7 connected to CPUs [20-39, 60-79]
+    [20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+     60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79]
+    """
     nvmlInit()
 
     # Result is a list of 64-bit integers, thus ceil(CPU_COUNT / 64)

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -7,6 +7,16 @@ from numba import cuda
 from pynvml import nvmlInit, nvmlDeviceGetHandleByIndex, nvmlDeviceGetCpuAffinity
 
 
+class CPUAffinity:
+    def __init__(self, cores):
+        self.cores = cores
+
+    def setup(self, worker=None):
+        print("before", os.sched_getaffinity(0))
+        os.sched_setaffinity(0, self.cores)
+        print("after ", os.sched_getaffinity(0))
+
+
 def bitmask_to_list(x, mask_bits=64):
     res = []
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 dask>=2.4.0
 distributed>=2.4.0
+pynvml>=8.0.3
 numpy>=1.16.0
 numba>=0.40.1


### PR DESCRIPTION
This PR allows automatically determining and setting CPU affinity for all GPUs during initialization.

cc @benjha as this is one of the issues we discussed on our call last week.