### PR TITLE
FIX Remove all CUDA labels

### DIFF
--- a/ci/cpu/upload-anaconda.sh
+++ b/ci/cpu/upload-anaconda.sh
@@ -9,7 +9,7 @@ CUDA_REL=${CUDA_VERSION%.*}
 
 SOURCE_BRANCH=master
 
-LABEL_OPTION="--label main --label cuda9.2 --label cuda10.0"
+LABEL_OPTION="--label main"
 echo "LABEL_OPTION=${LABEL_OPTION}"
 
 # Restrict uploads to master branch


### PR DESCRIPTION
The `cuda9.2` and `cuda10.0` labels are no longer needed and cause issues/confusion (see #159)

We now use community convention of `cudatoolkit=9.2` (or the appropriate CUDA version) during installs for setting the required CUDA version of a conda environment

This allows for multiple libraries requiring CUDA to work in the same environment