### PR TITLE
[Review] Setting UCX options through dask global config

### DIFF
--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -25,7 +25,7 @@ requirements:
   run:
     - python x.x
     - dask-core >=2.4.0
-    - distributed >=2.4.0
+    - distributed >=2.7.0
     - pynvml >=8.0.3
     - numpy >=1.16.0
     - numba >=0.40.1

--- a/dask_cuda/dask_cuda_worker.py
+++ b/dask_cuda/dask_cuda_worker.py
@@ -18,6 +18,7 @@ from distributed.proctitle import (
     enable_proctitle_on_current,
 )
 
+from .initialize import initialize
 from .device_host_file import DeviceHostFile
 from .local_cuda_cluster import cuda_visible_devices
 from .utils import CPUAffinity, get_cpu_affinity, get_n_gpus, get_device_total_memory
@@ -146,6 +147,28 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 @click.argument(
     "preload_argv", nargs=-1, type=click.UNPROCESSED, callback=validate_preload_argv
 )
+@click.option(
+    "--enable-tcp-over-ucx/--disable-tcp-over-ucx",
+    default=False,
+    help="Enable TCP communication over UCX",
+)
+@click.option(
+    "--enable-infiniband/--disable-infiniband",
+    default=False,
+    help="Enable InfiniBand communication",
+)
+@click.option(
+    "--enable-nvlink/--disable-nvlink",
+    default=False,
+    help="Enable NVLink communication",
+)
+@click.option(
+    "--net-devices",
+    type=str,
+    default=None,
+    help="Network interface to establish UCX connection, "
+    "usually the Ethernet interface, like 'eth0' or 'enp1s0f0'",
+)
 def main(
     scheduler,
     host,
@@ -166,6 +189,10 @@ def main(
     tls_ca_file,
     tls_cert,
     tls_key,
+    enable_tcp_over_ucx,
+    enable_infiniband,
+    enable_nvlink,
+    net_devices,
     **kwargs,
 ):
     enable_proctitle_on_current()
@@ -231,6 +258,14 @@ def main(
             raise ValueError("Can not specify both interface and host")
         else:
             host = get_ip_interface(interface)
+
+    initialize(
+        create_cuda_context=True,
+        enable_tcp_over_ucx=enable_tcp_over_ucx,
+        enable_infiniband=enable_infiniband,
+        enable_nvlink=enable_nvlink,
+        net_devices=net_devices,
+    )
 
     nannies = [
         t(

--- a/dask_cuda/initialize.py
+++ b/dask_cuda/initialize.py
@@ -28,6 +28,7 @@ import logging
 import os
 import warnings
 
+import dask
 import numba.cuda
 
 
@@ -70,18 +71,7 @@ def initialize(
                 if net_devices is not None and net_devices != "":
                     options["NET_DEVICES"] = net_devices
 
-            ucp.reset()
-            ucp.init(options=options)
-
-            ucx_env = {}
-            for k, v in ucp.get_config().items():
-                # Skip values that aren't actual environment variables (i.e., not strings)
-                if isinstance(v, str):
-                    ucx_env["UCX_" + k] = v
-
-            # Set also UCX environment variables: required by Dask client. It may be best ti
-            # to have the client asking the scheduler for the proper variables.
-            os.environ.update(ucx_env)
+            dask.config.set({"ucx": options})
 
 
 @click.command()

--- a/dask_cuda/initialize.py
+++ b/dask_cuda/initialize.py
@@ -110,10 +110,8 @@ def dask_setup(
     enable_nvlink,
     net_devices,
 ):
-    initialize(
-        create_cuda_context=create_cuda_context,
-        enable_tcp_over_ucx=enable_tcp_over_ucx,
-        enable_infiniband=enable_infiniband,
-        enable_nvlink=enable_nvlink,
-        net_devices=net_devices,
-    )
+    if create_cuda_context:
+        try:
+            numba.cuda.current_context()
+        except Exception:
+            logger.error("Unable to start CUDA Context", exc_info=True)

--- a/dask_cuda/tests/test_initialize.py
+++ b/dask_cuda/tests/test_initialize.py
@@ -27,16 +27,21 @@ def _test_initialize_ucx_tcp():
         threads_per_worker=1,
         processes=True,
     ) as cluster:
-        with Client(cluster):
+        with Client(cluster) as client:
             res = da.from_array(numpy.arange(10000), chunks=(1000,))
             res = res.sum().compute()
             assert res == 49995000
-            conf = ucp.get_config()
-            assert "TLS" in conf
-            assert "tcp" in conf["TLS"]
-            assert "sockcm" in conf["TLS"]
-            assert "cuda_copy" in conf["TLS"]
-            assert "sockcm" in conf["SOCKADDR_TLS_PRIORITY"]
+
+            def check_ucx_options():
+                conf = ucp.get_config()
+                assert "TLS" in conf
+                assert "tcp" in conf["TLS"]
+                assert "sockcm" in conf["TLS"]
+                assert "cuda_copy" in conf["TLS"]
+                assert "sockcm" in conf["SOCKADDR_TLS_PRIORITY"]
+                return True
+
+            assert all(client.run(check_ucx_options).values())
 
 
 def test_initialize_ucx_tcp():
@@ -55,17 +60,22 @@ def _test_initialize_ucx_nvlink():
         threads_per_worker=1,
         processes=True,
     ) as cluster:
-        with Client(cluster):
+        with Client(cluster) as client:
             res = da.from_array(numpy.arange(10000), chunks=(1000,))
             res = res.sum().compute()
             assert res == 49995000
-            conf = ucp.get_config()
-            assert "TLS" in conf
-            assert "cuda_ipc" in conf["TLS"]
-            assert "tcp" in conf["TLS"]
-            assert "sockcm" in conf["TLS"]
-            assert "cuda_copy" in conf["TLS"]
-            assert "sockcm" in conf["SOCKADDR_TLS_PRIORITY"]
+
+            def check_ucx_options():
+                conf = ucp.get_config()
+                assert "TLS" in conf
+                assert "cuda_ipc" in conf["TLS"]
+                assert "tcp" in conf["TLS"]
+                assert "sockcm" in conf["TLS"]
+                assert "cuda_copy" in conf["TLS"]
+                assert "sockcm" in conf["SOCKADDR_TLS_PRIORITY"]
+                return True
+
+            assert all(client.run(check_ucx_options).values())
 
 
 def test_initialize_ucx_nvlink():
@@ -84,18 +94,23 @@ def _test_initialize_ucx_infiniband():
         threads_per_worker=1,
         processes=True,
     ) as cluster:
-        with Client(cluster):
+        with Client(cluster) as client:
             res = da.from_array(numpy.arange(10000), chunks=(1000,))
             res = res.sum().compute()
             assert res == 49995000
-            conf = ucp.get_config()
-            assert "TLS" in conf
-            assert "rc" in conf["TLS"]
-            assert "tcp" in conf["TLS"]
-            assert "sockcm" in conf["TLS"]
-            assert "cuda_copy" in conf["TLS"]
-            assert "sockcm" in conf["SOCKADDR_TLS_PRIORITY"]
-            assert conf["NET_DEVICES"] == "ib0"
+
+            def check_ucx_options():
+                conf = ucp.get_config()
+                assert "TLS" in conf
+                assert "rc" in conf["TLS"]
+                assert "tcp" in conf["TLS"]
+                assert "sockcm" in conf["TLS"]
+                assert "cuda_copy" in conf["TLS"]
+                assert "sockcm" in conf["SOCKADDR_TLS_PRIORITY"]
+                assert conf["NET_DEVICES"] == "ib0"
+                return True
+
+            assert all(client.run(check_ucx_options).values())
 
 
 @pytest.mark.skipif(

--- a/dask_cuda/tests/test_initialize.py
+++ b/dask_cuda/tests/test_initialize.py
@@ -1,107 +1,108 @@
 import os
 import psutil
+import multiprocessing as mp
 import pytest
+import numpy
 import dask.array as da
 
 from dask_cuda.initialize import initialize
 from distributed.deploy.local import LocalCluster
 from distributed import Client
-from multiprocessing import Process
 
+mp = mp.get_context("spawn")
 ucp = pytest.importorskip("ucp")
-cupy = pytest.importorskip("cupy")
+
+# Notice, all of the following tests is executed in a new process such
+# that UCX options of the different tests doesn't conflict.
+# Furthermore, all tests do some computation to trigger initialization
+# of UCX before retrieving the current config.
 
 
-@pytest.mark.xfail(reason="https://github.com/rapidsai/dask-cuda/pull/168")
+def _test_initialize_ucx_tcp():
+    initialize(enable_tcp_over_ucx=True)
+    with LocalCluster(
+        protocol="ucx",
+        dashboard_address=None,
+        n_workers=1,
+        threads_per_worker=1,
+        processes=True,
+    ) as cluster:
+        with Client(cluster):
+            res = da.from_array(numpy.arange(10000), chunks=(1000,))
+            res = res.sum().compute()
+            assert res == 49995000
+            conf = ucp.get_config()
+            assert "TLS" in conf
+            assert "tcp" in conf["TLS"]
+            assert "sockcm" in conf["TLS"]
+            assert "cuda_copy" in conf["TLS"]
+            assert "sockcm" in conf["SOCKADDR_TLS_PRIORITY"]
+
+
 def test_initialize_ucx_tcp():
-    def test():
-        initialize(enable_tcp_over_ucx=True)
-        with LocalCluster(
-            protocol="ucx",
-            dashboard_address=None,
-            n_workers=1,
-            threads_per_worker=1,
-            processes=True,
-        ) as cluster:
-            with Client(cluster):
-                res = da.from_array(cupy.arange(10000), chunks=(1000,), asarray=False)
-                res = res.sum().compute()
-                assert res == 49995000
-
-                conf = ucp.get_config()
-                assert "TLS" in conf
-                assert "tcp" in conf["TLS"]
-                assert "sockcm" in conf["TLS"]
-                assert "cuda_copy" in conf["TLS"]
-                assert "sockcm" in conf["SOCKADDR_TLS_PRIORITY"]
-
-    # We run in process to avoid using the UCX options from the other tests
-    p = Process(target=test)
+    p = mp.Process(target=_test_initialize_ucx_tcp)
     p.start()
     p.join()
     assert not p.exitcode
 
 
-@pytest.mark.xfail(reason="https://github.com/rapidsai/dask-cuda/pull/168")
+def _test_initialize_ucx_nvlink():
+    initialize(enable_nvlink=True)
+    with LocalCluster(
+        protocol="ucx",
+        dashboard_address=None,
+        n_workers=1,
+        threads_per_worker=1,
+        processes=True,
+    ) as cluster:
+        with Client(cluster):
+            res = da.from_array(numpy.arange(10000), chunks=(1000,))
+            res = res.sum().compute()
+            assert res == 49995000
+            conf = ucp.get_config()
+            assert "TLS" in conf
+            assert "cuda_ipc" in conf["TLS"]
+            assert "tcp" in conf["TLS"]
+            assert "sockcm" in conf["TLS"]
+            assert "cuda_copy" in conf["TLS"]
+            assert "sockcm" in conf["SOCKADDR_TLS_PRIORITY"]
+
+
 def test_initialize_ucx_nvlink():
-    def test():
-        initialize(enable_nvlink=True)
-        with LocalCluster(
-            protocol="ucx",
-            dashboard_address=None,
-            n_workers=1,
-            threads_per_worker=1,
-            processes=True,
-        ) as cluster:
-            with Client(cluster):
-                res = da.from_array(cupy.arange(10000), chunks=(1000,), asarray=False)
-                res = res.sum().compute()
-                assert res == 49995000
-                conf = ucp.get_config()
-                assert "TLS" in conf
-                assert "cuda_ipc" in conf["TLS"]
-                assert "tcp" in conf["TLS"]
-                assert "sockcm" in conf["TLS"]
-                assert "cuda_copy" in conf["TLS"]
-                assert "sockcm" in conf["SOCKADDR_TLS_PRIORITY"]
-
-    # We run in process to avoid using the UCX options from the other tests
-    p = Process(target=test)
+    p = mp.Process(target=_test_initialize_ucx_nvlink)
     p.start()
     p.join()
     assert not p.exitcode
 
 
-@pytest.mark.xfail(reason="https://github.com/rapidsai/dask-cuda/pull/168")
+def _test_initialize_ucx_infiniband():
+    initialize(enable_infiniband=True, net_devices="ib0")
+    with LocalCluster(
+        protocol="ucx",
+        dashboard_address=None,
+        n_workers=1,
+        threads_per_worker=1,
+        processes=True,
+    ) as cluster:
+        with Client(cluster):
+            res = da.from_array(numpy.arange(10000), chunks=(1000,))
+            res = res.sum().compute()
+            assert res == 49995000
+            conf = ucp.get_config()
+            assert "TLS" in conf
+            assert "rc" in conf["TLS"]
+            assert "tcp" in conf["TLS"]
+            assert "sockcm" in conf["TLS"]
+            assert "cuda_copy" in conf["TLS"]
+            assert "sockcm" in conf["SOCKADDR_TLS_PRIORITY"]
+            assert conf["NET_DEVICES"] == "ib0"
+
+
 @pytest.mark.skipif(
     "ib0" not in psutil.net_if_addrs(), reason="Infiniband interface ib0 not found"
 )
 def test_initialize_ucx_infiniband():
-    initialize(enable_infiniband=True, net_devices="ib0")
-
-    def test():
-        with LocalCluster(
-            protocol="ucx",
-            dashboard_address=None,
-            n_workers=1,
-            threads_per_worker=1,
-            processes=True,
-        ) as cluster:
-            with Client(cluster):
-                res = da.from_array(cupy.arange(10000), chunks=(1000,), asarray=False)
-                res = res.sum().compute()
-                assert res == 49995000
-                conf = ucp.get_config()
-                assert "TLS" in conf
-                assert "rc" in conf["TLS"]
-                assert "tcp" in conf["TLS"]
-                assert "sockcm" in conf["TLS"]
-                assert "cuda_copy" in conf["TLS"]
-                assert "sockcm" in conf["SOCKADDR_TLS_PRIORITY"]
-                assert conf["NET_DEVICES"] == "ib0"
-
-    # We run in process to avoid using the UCX options from the other tests
-    p = Process(target=test)
+    p = mp.Process(target=_test_initialize_ucx_infiniband)
     p.start()
     p.join()
     assert not p.exitcode

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -71,7 +71,6 @@ async def test_with_subset_of_cuda_visible_devices():
         del os.environ["CUDA_VISIBLE_DEVICES"]
 
 
-@pytest.mark.xfail(reason="https://github.com/rapidsai/dask-cuda/pull/168")
 @gen_test(timeout=20)
 async def test_ucx_protocol():
     pytest.importorskip("distributed.comm.ucx")

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -1,12 +1,10 @@
-from distributed.utils_test import gen_test
-
 import os
-
-from dask.distributed import Client
-from distributed.system import MEMORY_LIMIT
-from dask_cuda import LocalCUDACluster
-from dask_cuda import utils
 import pytest
+from distributed.utils_test import gen_test
+from distributed.system import MEMORY_LIMIT
+from dask.distributed import Client
+from dask_cuda import LocalCUDACluster, utils
+from dask_cuda.initialize import initialize
 
 
 @gen_test(timeout=20)
@@ -74,6 +72,8 @@ async def test_with_subset_of_cuda_visible_devices():
 @gen_test(timeout=20)
 async def test_ucx_protocol():
     pytest.importorskip("distributed.comm.ucx")
+
+    initialize()
     async with LocalCUDACluster(
         protocol="ucx", asynchronous=True, data=dict
     ) as cluster:

--- a/dask_cuda/tests/test_ucx_options.py
+++ b/dask_cuda/tests/test_ucx_options.py
@@ -1,0 +1,38 @@
+import os
+import multiprocessing as mp
+import numpy
+import pytest
+import dask.array as da
+import dask
+from distributed.deploy.local import LocalCluster
+from distributed import Client
+
+mp = mp.get_context("spawn")
+ucp = pytest.importorskip("ucp")
+
+
+def _test_global_option(seg_size):
+    """Test setting UCX options through dask's global config"""
+    dask.config.set({"ucx": {"SEG_SIZE": seg_size}})
+
+    with LocalCluster(
+        protocol="ucx",
+        dashboard_address=None,
+        n_workers=1,
+        threads_per_worker=1,
+        processes=True,
+    ) as cluster:
+        with Client(cluster):
+            res = da.from_array(numpy.arange(10000), chunks=(1000,))
+            res = res.sum().compute()
+            assert res == 49995000
+            conf = ucp.get_config()
+            assert conf["SEG_SIZE"] == seg_size
+
+
+def test_global_option():
+    for seg_size in ["2K", "1M", "2M"]:
+        p = mp.Process(target=_test_global_option, args=(seg_size,))
+        p.start()
+        p.join()
+        assert not p.exitcode

--- a/dask_cuda/tests/test_ucx_options.py
+++ b/dask_cuda/tests/test_ucx_options.py
@@ -10,6 +10,11 @@ from distributed import Client
 mp = mp.get_context("spawn")
 ucp = pytest.importorskip("ucp")
 
+# Notice, all of the following tests is executed in a new process such
+# that UCX options of the different tests doesn't conflict.
+# Furthermore, all tests do some computation to trigger initialization
+# of UCX before retrieving the current config.
+
 
 def _test_global_option(seg_size):
     """Test setting UCX options through dask's global config"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dask>=2.4.0
-distributed>=2.4.0
+distributed>=2.7.0
 pynvml>=8.0.3
 numpy>=1.16.0
 numba>=0.40.1


### PR DESCRIPTION
This PR makes `initialize()` use https://github.com/dask/distributed/pull/3178 and https://github.com/dask/distributed/pull/3192 to initialize UCX with the specified options.

cc @pentschev 