### PR TITLE
Mark test_cudf_device_spill xfail

### DIFF
--- a/dask_cuda/tests/test_spill.py
+++ b/dask_cuda/tests/test_spill.py
@@ -199,6 +199,7 @@ async def test_cupy_cluster_device_spill(loop, params):
                         assert dc == 0
 
 
+@pytest.mark.xfail(reason="https://github.com/rapidsai/dask-cuda/issues/79")
 @pytest.mark.parametrize(
     "params",
     [


### PR DESCRIPTION
Marking test_cudf_device_spill, see https://github.com/rapidsai/dask-cuda/issues/79.