### PR TITLE
Merge benchmark

### DIFF
--- a/dask_cuda/benchmarks/local_cuda.py
+++ b/dask_cuda/benchmarks/local_cuda.py
@@ -46,9 +46,11 @@ async def run(args):
                 (
                     cluster.scheduler.workers[w1].name,
                     cluster.scheduler.workers[w2].name,
-                ): ["%s/s" % format_bytes(x) for x in np.quantile(v, [0.25, 0.50, 0.75])]
+                ): [
+                    "%s/s" % format_bytes(x) for x in np.quantile(v, [0.25, 0.50, 0.75])
+                ]
                 for (w1, w2), v in bandwidths.items()
-            }        
+            }
             total_nbytes = {
                 (
                     cluster.scheduler.workers[w1].name,
@@ -67,11 +69,14 @@ async def run(args):
             print(f"npartitions | {x.npartitions}")
             print("==========================")
             print(f"Total time  | {format_time(took)}")
-            print("==========================")            
+            print("==========================")
             print("(w1,w2)     | 25% 50% 75% (total nbytes)")
             print("--------------------------")
             for (d1, d2), bw in sorted(bandwidths.items()):
-                print("(%02d,%02d)     | %s %s %s (%s)" % (d1, d2, bw[0], bw[1], bw[2], total_nbytes[(d1, d2)]))
+                print(
+                    "(%02d,%02d)     | %s %s %s (%s)"
+                    % (d1, d2, bw[0], bw[1], bw[2], total_nbytes[(d1, d2)])
+                )
 
 
 def parse_args():

--- a/dask_cuda/benchmarks/local_merge.py
+++ b/dask_cuda/benchmarks/local_merge.py
@@ -17,6 +17,9 @@ from dask_cuda import LocalCUDACluster
 
 
 def generate_chunk(i_chunk, local_size, num_chunks, chunk_type, frac_match):
+    # Setting a seed that triggers max amount of comm in the two-GPU case.
+    cupy.random.seed(17561648246761420848)
+
     chunk_type = chunk_type or "build"
     frac_match = frac_match or 1.0
     if chunk_type == "build":
@@ -203,9 +206,7 @@ def parse_args():
         help="Fraction of rows that matches (default 0.3)",
     )
     parser.add_argument(
-        "--no-pool-allocator",
-        action="store_true",
-        help="Disable the RMM memory pool",
+        "--no-pool-allocator", action="store_true", help="Disable the RMM memory pool",
     )
 
     args = parser.parse_args()

--- a/dask_cuda/benchmarks/local_merge.py
+++ b/dask_cuda/benchmarks/local_merge.py
@@ -104,9 +104,9 @@ def main(args):
     client = Client(cluster)
 
     if args.no_pool_allocator:
-        client.run(lambda: cudf.set_allocator("default", pool=False))
+        client.run(cudf.set_allocator, "default", pool=False)
     else:
-        client.run(lambda: cudf.set_allocator("default", pool=True))
+        client.run(cudf.set_allocator, "default", pool=True)
 
     # Generate random Dask dataframes
     ddf_base = get_random_ddf(
@@ -120,7 +120,7 @@ def main(args):
     ddf_join = ddf_base.merge(ddf_other, on=["key"], how="inner")
 
     t1 = clock()
-    wait(ddf_join.compute())
+    wait(ddf_join.persist())
     took = clock() - t1
 
     # Collect, aggregate, and print peer-to-peer bandwidths

--- a/dask_cuda/benchmarks/local_merge.py
+++ b/dask_cuda/benchmarks/local_merge.py
@@ -1,0 +1,216 @@
+import argparse
+from collections import defaultdict
+from time import perf_counter as clock
+import numpy
+import cudf
+import cupy
+import dask_cudf
+from dask.distributed import Client, wait
+from dask.dataframe.core import new_dd_object
+from dask.base import tokenize
+from dask.utils import format_time, format_bytes, parse_bytes
+
+from dask_cuda import LocalCUDACluster
+
+# Benchmarking cuDF merge operation based on
+# <https://gist.github.com/rjzamora/0ffc35c19b5180ab04bbf7c793c45955>
+
+
+def generate_chunk(i_chunk, local_size, num_chunks, chunk_type, frac_match):
+    chunk_type = chunk_type or "build"
+    frac_match = frac_match or 1.0
+    if chunk_type == "build":
+        # Build dataframe
+        #
+        # "key" column is a unique range
+        #
+        # "payload" column is a random permutation of the chunk_size
+
+        start = local_size * i_chunk
+        stop = start + local_size
+        df = cudf.DataFrame(
+            {
+                "key": cupy.arange(start, stop=stop, dtype="int64"),
+                "payload": cupy.random.permutation(
+                    cupy.arange(local_size, dtype="int64")
+                ),
+            }
+        )
+    else:
+        # Other dataframe
+        #
+        # "key" column matches values from the build dataframe
+        # for a fraction (`frac_match`) of the entries. The matching
+        # entries are perfectly balanced across each partition of the
+        # "base" dataframe.
+        #
+        # "payload" column is a random permutation of the chunk_size
+
+        # Step 1. Choose values that DO match
+        sub_local_size = local_size // num_chunks
+        sub_local_size_use = int(sub_local_size * frac_match)
+        arrays = []
+        for i in range(num_chunks):
+            bgn = (local_size * i) + (sub_local_size * i_chunk)
+            end = bgn + sub_local_size
+            ar = cupy.arange(bgn, stop=end, dtype="int64")
+            arrays.append(cupy.random.permutation(ar)[:sub_local_size_use])
+        key_array_match = cupy.concatenate(tuple(arrays), axis=0)
+
+        # Step 2. Add values that DON'T match
+        missing_size = local_size - key_array_match.shape[0]
+        start = local_size * num_chunks + local_size * i_chunk
+        stop = start + missing_size
+        key_array_no_match = cupy.arange(start, stop=stop, dtype="int64")
+
+        # Step 3. Combine and create the fineal dataframe chunk (dask_cudf partition)
+        key_array_combine = cupy.concatenate(
+            (key_array_match, key_array_no_match), axis=0
+        )
+        df = cudf.DataFrame(
+            {
+                "key": cupy.random.permutation(key_array_combine),
+                "payload": cupy.random.permutation(
+                    cupy.arange(local_size, dtype="int64")
+                ),
+            }
+        )
+    return df
+
+
+def get_random_ddf(chunk_size, num_chunks, frac_match, chunk_type):
+
+    parts = [chunk_size for i in range(num_chunks)]
+    meta = generate_chunk(0, 4, None, None, None)
+    divisions = [None] * (len(parts) + 1)
+
+    name = "generate-data-" + tokenize(chunk_size, num_chunks, frac_match, chunk_type)
+
+    graph = {
+        (name, i): (generate_chunk, i, part, len(parts), chunk_type, frac_match)
+        for i, part in enumerate(parts)
+    }
+
+    return new_dd_object(graph, name, meta, divisions)
+
+
+def main(args):
+    n_workers = len(args.devs.split(","))
+
+    # Set up workers on the local machine
+    cluster = LocalCUDACluster(
+        protocol=args.protocol, n_workers=n_workers, CUDA_VISIBLE_DEVICES=args.devs,
+    )
+    client = Client(cluster)
+
+    if args.no_pool_allocator:
+        client.run(lambda: cudf.set_allocator("default", pool=False))
+    else:
+        client.run(lambda: cudf.set_allocator("default", pool=True))
+
+    # Generate random Dask dataframes
+    ddf_base = get_random_ddf(
+        args.chunk_size, n_workers, args.frac_match, "build"
+    ).persist()
+    ddf_other = get_random_ddf(
+        args.chunk_size, n_workers, args.frac_match, "other"
+    ).persist()
+
+    # Lazy merge/join operation
+    ddf_join = ddf_base.merge(ddf_other, on=["key"], how="inner")
+
+    t1 = clock()
+    wait(ddf_join.compute())
+    took = clock() - t1
+
+    # Collect, aggregate, and print peer-to-peer bandwidths
+    incoming_logs = client.run(lambda dask_worker: dask_worker.incoming_transfer_log)
+    bandwidths = defaultdict(list)
+    total_nbytes = defaultdict(list)
+    for k, L in incoming_logs.items():
+        for d in L:
+            if d["total"] >= args.ignore_size:
+                bandwidths[k, d["who"]].append(d["bandwidth"])
+                total_nbytes[k, d["who"]].append(d["total"])
+    bandwidths = {
+        (cluster.scheduler.workers[w1].name, cluster.scheduler.workers[w2].name,): [
+            "%s/s" % format_bytes(x) for x in numpy.quantile(v, [0.25, 0.50, 0.75])
+        ]
+        for (w1, w2), v in bandwidths.items()
+    }
+    total_nbytes = {
+        (
+            cluster.scheduler.workers[w1].name,
+            cluster.scheduler.workers[w2].name,
+        ): format_bytes(sum(nb))
+        for (w1, w2), nb in total_nbytes.items()
+    }
+
+    print("Merge benchmark")
+    print("--------------------------")
+    print(f"Chunk-size  | {args.chunk_size}")
+    print(f"Frac-match  | {args.frac_match}")
+    print(f"Ignore-size | {format_bytes(args.ignore_size)}")
+    print(f"Protocol    | {args.protocol}")
+    print(f"Device(s)   | {args.devs}")
+
+    print("==========================")
+    print(f"Total time  | {format_time(took)}")
+    print("==========================")
+    print("(w1,w2)     | 25% 50% 75% (total nbytes)")
+    print("--------------------------")
+    for (d1, d2), bw in sorted(bandwidths.items()):
+        print(
+            "(%02d,%02d)     | %s %s %s (%s)"
+            % (d1, d2, bw[0], bw[1], bw[2], total_nbytes[(d1, d2)])
+        )
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Merge (dask/cudf) on LocalCUDACluster benchmark"
+    )
+    parser.add_argument(
+        "-d", "--devs", default="0", type=str, help='GPU devices to use (default "0").'
+    )
+    parser.add_argument(
+        "-p",
+        "--protocol",
+        choices=["tcp", "ucx"],
+        default="tcp",
+        type=str,
+        help="The communication protocol to use.",
+    )
+    parser.add_argument(
+        "-c",
+        "--chunk-size",
+        default=1_000_000,
+        metavar="n",
+        type=int,
+        help="Chunk size (default 1_000_000)",
+    )
+    parser.add_argument(
+        "--ignore-size",
+        default="1 MiB",
+        metavar="nbytes",
+        type=parse_bytes,
+        help='Ignore messages smaller than this (default "1 MB")',
+    )
+    parser.add_argument(
+        "--frac-match",
+        default=0.3,
+        type=float,
+        help="Fraction of rows that matches (default 0.3)",
+    )
+    parser.add_argument(
+        "--no-pool-allocator",
+        action="store_true",
+        help="Disable the RMM memory pool",
+    )
+
+    args = parser.parse_args()
+    return args
+
+
+if __name__ == "__main__":
+    main(parse_args())


### PR DESCRIPTION
Added a cuDF merge benchmark based on @rjzamora's notebook: https://gist.github.com/rjzamora/0ffc35c19b5180ab04bbf7c793c45955

```$ local_merge.py --help
usage: local_merge.py [-h] [-d DEVS] [-p {tcp,ucx}] [-c n]
                      [--ignore-size nbytes] [--frac-match FRAC]
                      [--no-pool-allocator]

Merge (dask/cudf) on LocalCUDACluster benchmark

optional arguments:
  -h, --help            show this help message and exit
  -d DEVS, --devs DEVS  GPU devices to use (default "0").
  -p {tcp,ucx}, --protocol {tcp,ucx}
                        The communication protocol to use.
  -c n, --chunk-size n  Chunk size per worker (default 1_000_000)
  --ignore-size nbytes  Ignore messages smaller than this (default "1 MB")
  --frac-match FRAC     Fraction of rows that matches (default 0.3)
  --no-pool-allocator   Disable the RMM memory pool
```

### Two GPUs on a DGX-1
#### UCX
```
Merge benchmark
--------------------------
Chunk-size  | 100000000
Frac-match  | 0.3
Ignore-size | 1.05 MB
Protocol    | ucx
Device(s)   | 1,2
==========================
Total time  | 8.57 s
==========================
(w1,w2)     | 25% 50% 75% (total nbytes)
--------------------------
(01,02)     | 2.48 GB/s 3.21 GB/s 3.32 GB/s (5.20 GB)
(02,01)     | 2.45 GB/s 3.12 GB/s 3.26 GB/s (5.20 GB)
```

#### TCP
```
Merge benchmark
--------------------------
Chunk-size  | 100000000
Frac-match  | 0.3
Ignore-size | 1.05 MB
Protocol    | tcp
Device(s)   | 1,2
==========================
Total time  | 30.10 s
==========================
(w1,w2)     | 25% 50% 75% (total nbytes)
--------------------------
(01,02)     | 136.55 MB/s 143.48 MB/s 150.41 MB/s (2.80 GB)
(02,01)     | 142.75 MB/s 154.91 MB/s 167.08 MB/s (2.80 GB)
```
Going from TCP to UCX we see a **3.5 times** speedup (wall-clock) and more than **20 times** higher bandwidth. 
Notice, that the total amount of data send in TCP is only 2.8 GB (one-way) whereas in UCX it is  5.20 GB. This is not always the case, some very few times UCX also only communicated 2.8 GB. 
I don't know what happens but my guess is that the data distribution by `distributed` is sensitive to network timings. @mrocklin @quasiben? 


### Four GPUs on a DGX-1
#### UCX
```
Merge benchmark
--------------------------
Chunk-size  | 100000000
Frac-match  | 0.3
Ignore-size | 1.05 MB
Protocol    | ucx
Device(s)   | 4,5,6,7
==========================
Total time  | 18.97 s
==========================
(w1,w2)     | 25% 50% 75% (total nbytes)
--------------------------
(04,05)     | 725.28 MB/s 881.78 MB/s 1.04 GB/s (1.40 GB)
(04,06)     | 718.94 MB/s 877.93 MB/s 1.31 GB/s (3.80 GB)
(04,07)     | 968.64 MB/s 1.26 GB/s 1.55 GB/s (1.40 GB)
(05,04)     | 676.29 MB/s 749.17 MB/s 1.66 GB/s (3.80 GB)
(05,06)     | 709.26 MB/s 892.33 MB/s 1.08 GB/s (1.40 GB)
(05,07)     | 935.18 MB/s 1.30 GB/s 1.66 GB/s (1.40 GB)
(06,04)     | 613.71 MB/s 662.51 MB/s 711.31 MB/s (1.40 GB)
(06,05)     | 679.15 MB/s 827.13 MB/s 975.12 MB/s (1.40 GB)
(06,07)     | 1.15 GB/s 1.70 GB/s 2.19 GB/s (3.80 GB)
(07,04)     | 1.03 GB/s 1.40 GB/s 1.78 GB/s (1.40 GB)
(07,05)     | 896.32 MB/s 1.24 GB/s 1.81 GB/s (3.80 GB)
(07,06)     | 638.65 MB/s 723.34 MB/s 808.03 MB/s (1.40 GB)
```
#### TCP
```
Merge benchmark
--------------------------
Chunk-size  | 100000000
Frac-match  | 0.3
Ignore-size | 1.05 MB
Protocol    | tcp
Device(s)   | 4,5,6,7
==========================
Total time  | 63.81 s
==========================
(w1,w2)     | 25% 50% 75% (total nbytes)
--------------------------
(04,05)     | 63.66 MB/s 96.47 MB/s 143.60 MB/s (2.80 GB)
(04,06)     | 31.92 MB/s 36.21 MB/s 40.50 MB/s (1.40 GB)
(04,07)     | 42.46 MB/s 49.54 MB/s 79.11 MB/s (2.10 GB)
(05,04)     | 74.86 MB/s 88.78 MB/s 104.15 MB/s (4.50 GB)
(05,06)     | 87.26 MB/s 100.29 MB/s 117.02 MB/s (2.10 GB)
(05,07)     | 32.12 MB/s 32.12 MB/s 32.12 MB/s (699.95 MB)
(06,04)     | 36.48 MB/s 36.48 MB/s 36.48 MB/s (700.11 MB)
(06,05)     | 75.25 MB/s 89.02 MB/s 102.79 MB/s (1.40 GB)
(06,07)     | 89.11 MB/s 94.32 MB/s 108.84 MB/s (3.80 GB)
(07,04)     | 46.27 MB/s 55.91 MB/s 68.64 MB/s (2.10 GB)
(07,05)     | 36.90 MB/s 36.95 MB/s 37.00 MB/s (1.40 GB)
(07,06)     | 113.82 MB/s 155.57 MB/s 182.52 MB/s (2.80 GB)
```
Again, with four GPUs we see similar results: **3.4 speedup** (wall-clock) and more than **10 times** higher bandwidth in most cases.
Notice, the wall-clock does not goes down compared to the two-gpu case because the chunk-size is *per* worker.


