### PR TITLE
LocalCUDACluster sets closest network device

### DIFF
--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -171,12 +171,13 @@ class LocalCUDACluster(LocalCluster):
             {
                 "env": {
                     "CUDA_VISIBLE_DEVICES": visible_devices,
-                    "UCX_NET_DEVICES": _ucx_net_devices(
-                        visible_devices.split(",")[0], self.ucx_net_devices
-                    ),
                 },
                 "plugins": {CPUAffinity(get_cpu_affinity(worker_count))},
             }
         )
+
+        net_dev = _ucx_net_devices(visible_devices.split(",")[0], self.ucx_net_devices)
+        if net_dev is not None:
+            spec["options"]["env"]["UCX_NET_DEVICES"] = net_dev
 
         return {name: spec}

--- a/dask_cuda/tests/test_ucx_options.py
+++ b/dask_cuda/tests/test_ucx_options.py
@@ -19,7 +19,15 @@ ucp = pytest.importorskip("ucp")
 
 def _test_global_option(seg_size):
     """Test setting UCX options through dask's global config"""
-    dask.config.set({"ucx": {"SEG_SIZE": seg_size, "TLS": "tcp,sockcm,cuda_copy"}})
+    dask.config.set(
+        {
+            "ucx": {
+                "SEG_SIZE": seg_size,
+                "TLS": "tcp,sockcm,cuda_copy",
+                "SOCKADDR_TLS_PRIORITY": "sockcm",
+            }
+        }
+    )
 
     with LocalCluster(
         protocol="ucx",


### PR DESCRIPTION
This PR makes `LocalCUDACluster` sets the closest network device for UCX explicitly 