### PR TITLE
Expand cudf-merge benchmark

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@
 - Allow test_cupy_device_spill to xfail (#195) `Peter Andreas Entschev`_
 - Use ucx-py from rapidsai-nightly in CI (#196) `Peter Andreas Entschev`_
 - LocalCUDACluster sets closest network device (#200) `Mads R. B. Kristensen`_
+- Expand cudf-merge benchmark (#201) `Richard (Rick) Zamora`_
 - Added --runs to merge benchmark (#202) `Mads R. B. Kristensen`_
 
 0.10
@@ -86,3 +87,4 @@
 .. _`Sangeeth Keeriyadath`: https://github.com/ksangeek
 .. _`Mike Wendt`: https://github.com/mike-wendt
 .. _`Mads R. B. Kristensen`: https://github.com/madsbk
+.. _`Richard (Rick) Zamora`: https://github.com/rjzamora


### PR DESCRIPTION
It seems that the C++/UCX code that motivated this benchmark actually requires both the left and right dataframes to be dissordered such that there will be all-to-all communication between the partitions for **both** dataframes.  The current version of `local_cudf_merge.py` uses a simple `arange` operation to define the key column for the left (base) dataframe.  Therefore, the left dataframe does **not** need to be shuffled during the merge operation.

This PR modifies the data-generation stage for the left (base) dataframe, so that sorting the column will require all-to-all communication between partitions.  With that said, the data-generation alone does **not** cause the left dataframe to be sorted during the merge.  To do that, we must explicitly reset the index.  I added the `--set-index` option here to accomplish this.

Some execution examples...

[**EDIT:** Results updated to align with recent benchmark and dask changes]

**WITHOUT Index Reset** (Same as before this PR):
```
Merge benchmark
--------------------------
Chunk-size  | 100000000
Frac-match  | 0.3
Ignore-size | 1.05 MB
Protocol    | ucx
Device(s)   | 0,1,2,3
==========================
Total time  | 1.32 s
Total time  | 913.19 ms
Total time  | 789.18 ms
==========================
(w1,w2)     | 25% 50% 75% (total nbytes)
--------------------------
(00,01)     | 4.50 GB/s 5.02 GB/s 5.43 GB/s (6.60 GB)
(00,02)     | 4.65 GB/s 5.09 GB/s 5.64 GB/s (6.60 GB)
(00,03)     | 4.66 GB/s 5.21 GB/s 5.96 GB/s (6.60 GB)
(01,00)     | 4.29 GB/s 4.54 GB/s 5.89 GB/s (6.60 GB)
(01,02)     | 4.85 GB/s 5.12 GB/s 8.38 GB/s (6.60 GB)
(01,03)     | 4.37 GB/s 4.76 GB/s 5.14 GB/s (6.60 GB)
(02,00)     | 4.46 GB/s 5.24 GB/s 5.64 GB/s (4.20 GB)
(02,01)     | 4.30 GB/s 5.71 GB/s 12.88 GB/s (9.00 GB)
(02,03)     | 4.78 GB/s 4.97 GB/s 5.70 GB/s (6.60 GB)
(03,00)     | 4.59 GB/s 5.23 GB/s 14.43 GB/s (9.00 GB)
(03,01)     | 3.95 GB/s 4.70 GB/s 5.10 GB/s (4.20 GB)
(03,02)     | 4.43 GB/s 4.91 GB/s 6.37 GB/s (6.60 GB)
```

**WITH Index Reset**:
```
Merge benchmark
--------------------------
Chunk-size  | 100000000
Frac-match  | 0.3
Ignore-size | 1.05 MB
Protocol    | ucx
Device(s)   | 0,1,2,3
==========================
Total time  | 1.67 s
Total time  | 1.63 s
Total time  | 1.65 s
==========================
(w1,w2)     | 25% 50% 75% (total nbytes)
--------------------------
(00,01)     | 3.99 GB/s 4.98 GB/s 6.46 GB/s (16.48 GB)
(00,02)     | 4.27 GB/s 4.61 GB/s 6.18 GB/s (14.08 GB)
(00,03)     | 4.28 GB/s 5.10 GB/s 7.18 GB/s (11.68 GB)
(01,00)     | 3.67 GB/s 4.66 GB/s 5.46 GB/s (14.15 GB)
(01,02)     | 4.06 GB/s 4.86 GB/s 5.79 GB/s (11.75 GB)
(01,03)     | 3.79 GB/s 5.00 GB/s 6.92 GB/s (16.55 GB)
(02,00)     | 3.61 GB/s 4.38 GB/s 6.69 GB/s (16.48 GB)
(02,01)     | 3.96 GB/s 5.31 GB/s 5.92 GB/s (11.68 GB)
(02,03)     | 4.44 GB/s 5.20 GB/s 5.73 GB/s (14.08 GB)
(03,00)     | 4.00 GB/s 5.35 GB/s 6.67 GB/s (11.70 GB)
(03,01)     | 4.19 GB/s 5.09 GB/s 7.02 GB/s (14.10 GB)
(03,02)     | 4.01 GB/s 5.43 GB/s 10.06 GB/s (16.50 GB)
```

~Note that I am using some cudf and dask optimizations here that are not yet in master branches.~