### PR TITLE
Follow-up revision of local_cudf_merge benchmark

### DIFF
--- a/dask_cuda/benchmarks/local_cudf_merge.py
+++ b/dask_cuda/benchmarks/local_cudf_merge.py
@@ -217,6 +217,11 @@ def main(args):
     print(f"Ignore-size | {format_bytes(args.ignore_size)}")
     print(f"Protocol    | {args.protocol}")
     print(f"Device(s)   | {args.devs}")
+    print(f"rmm-pool    | {(not args.no_pool_allocator)}")
+    if args.protocol == "ucx":
+        print(f"tcp         | {(not args.no_tcp)}")
+        print(f"ib          | {(not args.no_ib)}")
+        print(f"nvlink      | {(not args.no_nvlink)}")
     print("==========================")
     for took in took_list:
         print(f"Total time  | {format_time(took)}")

--- a/dask_cuda/benchmarks/local_cudf_merge.py
+++ b/dask_cuda/benchmarks/local_cudf_merge.py
@@ -105,7 +105,7 @@ def get_random_ddf(chunk_size, num_chunks, frac_match, chunk_type, args):
     ddf = new_dd_object(graph, name, meta, divisions)
 
     if chunk_type == "build":
-        if args.shuffle:
+        if not args.no_shuffle:
             divisions = [i for i in range(num_chunks)] + [num_chunks]
             return ddf.set_index("shuffle", divisions=tuple(divisions))
         else:
@@ -258,10 +258,9 @@ def parse_args():
         help="Write dask profile report (E.g. dask-report.html)",
     )
     parser.add_argument(
-        "-s",
-        "--shuffle",
+        "--no-shuffle",
         action="store_true",
-        help="Shuffle the key sof the left (base) dataframe.",
+        help="Don't shuffle the keys of the left (base) dataframe.",
     )
     parser.add_argument(
         "--markdown", action="store_true", help="Write output as markdown"

--- a/dask_cuda/benchmarks/local_cudf_merge.py
+++ b/dask_cuda/benchmarks/local_cudf_merge.py
@@ -26,7 +26,9 @@ def generate_chunk(i_chunk, local_size, num_chunks, chunk_type, frac_match):
     if chunk_type == "build":
         # Build dataframe
         #
-        # "key" column is a unique sample within [0, local_size * num_chunks)
+        # "key" column is a unique range
+        #
+        # "shuffle" column is a random selection of partitions (used for shuffle)
         #
         # "payload" column is a random permutation of the chunk_size
 

--- a/dask_cuda/benchmarks/local_cudf_merge.py
+++ b/dask_cuda/benchmarks/local_cudf_merge.py
@@ -152,8 +152,8 @@ def main(args):
         )
     else:
         enable_infiniband = not args.no_ib
-        enable_nvlink = True
-        enable_tcp_over_ucx = False
+        enable_nvlink = not args.no_nvlink
+        enable_tcp_over_ucx = not args.no_tcp
         cluster = LocalCUDACluster(
             protocol=args.protocol,
             n_workers=args.n_workers,
@@ -290,7 +290,11 @@ def parse_args():
     )
     parser.add_argument("--runs", default=3, type=int, help="Number of runs")
     parser.add_argument(
-        "--no-ib", action="store_true", help="Disable infiniband for ucx."
+        "--no-ib", action="store_true", help="Disable infiniband over ucx."
+    )
+    parser.add_argument("--no-tcp", action="store_true", help="Disable tcp over ucx.")
+    parser.add_argument(
+        "--no-nvlink", action="store_true", help="Disable NVLink over ucx."
     )
     args = parser.parse_args()
     args.n_workers = len(args.devs.split(","))

--- a/dask_cuda/benchmarks/local_cudf_merge.py
+++ b/dask_cuda/benchmarks/local_cudf_merge.py
@@ -1,6 +1,7 @@
 import argparse
 import math
 from collections import defaultdict
+from distutils.util import strtobool
 from time import perf_counter as clock
 
 from dask.base import tokenize
@@ -153,9 +154,9 @@ def main(args):
             CUDA_VISIBLE_DEVICES=args.devs,
         )
     else:
-        enable_infiniband = not args.no_ib
-        enable_nvlink = not args.no_nvlink
-        enable_tcp_over_ucx = not args.no_tcp
+        enable_infiniband = bool(strtobool(args.enable_infiniband))
+        enable_nvlink = bool(strtobool(args.enable_nvlink))
+        enable_tcp_over_ucx = bool(strtobool(args.enable_tcp_over_ucx))
         cluster = LocalCUDACluster(
             protocol=args.protocol,
             n_workers=args.n_workers,
@@ -219,9 +220,9 @@ def main(args):
     print(f"Device(s)   | {args.devs}")
     print(f"rmm-pool    | {(not args.no_pool_allocator)}")
     if args.protocol == "ucx":
-        print(f"tcp         | {(not args.no_tcp)}")
-        print(f"ib          | {(not args.no_ib)}")
-        print(f"nvlink      | {(not args.no_nvlink)}")
+        print(f"tcp         | {args.enable_tcp_over_ucx}")
+        print(f"ib          | {args.enable_infiniband}")
+        print(f"nvlink      | {args.enable_nvlink}")
     print("==========================")
     for took in took_list:
         print(f"Total time  | {format_time(took)}")
@@ -303,11 +304,13 @@ def parse_args():
     )
     parser.add_argument("--runs", default=3, type=int, help="Number of runs")
     parser.add_argument(
-        "--no-ib", action="store_true", help="Disable infiniband over ucx."
+        "--enable-tcp-over-ucx", default="True", help="Enable tcp over ucx."
     )
-    parser.add_argument("--no-tcp", action="store_true", help="Disable tcp over ucx.")
     parser.add_argument(
-        "--no-nvlink", action="store_true", help="Disable NVLink over ucx."
+        "--enable-infiniband", default="True", help="Enable infiniband over ucx."
+    )
+    parser.add_argument(
+        "--enable-nvlink", default="True", help="Enable NVLink over ucx."
     )
     args = parser.parse_args()
     args.n_workers = len(args.devs.split(","))

--- a/dask_cuda/benchmarks/local_cudf_merge.py
+++ b/dask_cuda/benchmarks/local_cudf_merge.py
@@ -1,7 +1,6 @@
 import argparse
 import math
 from collections import defaultdict
-from distutils.util import strtobool
 from time import perf_counter as clock
 
 from dask.base import tokenize
@@ -154,9 +153,9 @@ def main(args):
             CUDA_VISIBLE_DEVICES=args.devs,
         )
     else:
-        enable_infiniband = bool(strtobool(args.enable_infiniband))
-        enable_nvlink = bool(strtobool(args.enable_nvlink))
-        enable_tcp_over_ucx = bool(strtobool(args.enable_tcp_over_ucx))
+        enable_infiniband = args.enable_infiniband
+        enable_nvlink = args.enable_nvlink
+        enable_tcp_over_ucx = args.enable_tcp_over_ucx
         cluster = LocalCUDACluster(
             protocol=args.protocol,
             n_workers=args.n_workers,
@@ -304,13 +303,43 @@ def parse_args():
     )
     parser.add_argument("--runs", default=3, type=int, help="Number of runs")
     parser.add_argument(
-        "--enable-tcp-over-ucx", default="True", help="Enable tcp over ucx."
+        "--enable-tcp-over-ucx",
+        action="store_true",
+        dest="enable_tcp_over_ucx",
+        help="Enable tcp over ucx.",
     )
     parser.add_argument(
-        "--enable-infiniband", default="True", help="Enable infiniband over ucx."
+        "--enable-infiniband",
+        action="store_true",
+        dest="enable_infiniband",
+        help="Enable infiniband over ucx.",
     )
     parser.add_argument(
-        "--enable-nvlink", default="True", help="Enable NVLink over ucx."
+        "--enable-nvlink",
+        action="store_true",
+        dest="enable_nvlink",
+        help="Enable NVLink over ucx.",
+    )
+    parser.add_argument(
+        "--disable-tcp-over-ucx",
+        action="store_false",
+        dest="enable_tcp_over_ucx",
+        help="Disable tcp over ucx.",
+    )
+    parser.add_argument(
+        "--disable-infiniband",
+        action="store_false",
+        dest="enable_infiniband",
+        help="Disable infiniband over ucx.",
+    )
+    parser.add_argument(
+        "--disable-nvlink",
+        action="store_false",
+        dest="enable_nvlink",
+        help="Disable NVLink over ucx.",
+    )
+    parser.set_defaults(
+        enable_tcp_over_ucx=True, enable_infiniband=True, enable_nvlink=True
     )
     args = parser.parse_args()
     args.n_workers = len(args.devs.split(","))


### PR DESCRIPTION
This is a revision of the benchmark changes in #201 

Upon a follow-up inspection of `local_cudf_merge.py`,  I realized that the key of the left (base) index needs to be shuffled differently to achieve the intended behavior.  This PR removes the `--set-index` option, and instead uses shuffling by default.  To remove the shuffling behavior, one can add the `--no-shuffle` argument.

**WITH Shuffle**:

```
Merge benchmark
--------------------------
Chunk-size  | 100000000
Frac-match  | 0.3
Ignore-size | 1.05 MB
Protocol    | ucx
Device(s)   | 0,1,2,3
==========================
Total time  | 1.65 s
Total time  | 1.57 s
Total time  | 1.66 s
==========================
(w1,w2)     | 25% 50% 75% (total nbytes)
--------------------------
(00,01)     | 4.31 GB/s 4.40 GB/s 4.80 GB/s (9.60 GB)
(00,02)     | 4.47 GB/s 4.73 GB/s 4.90 GB/s (7.20 GB)
(00,03)     | 5.43 GB/s 5.81 GB/s 8.34 GB/s (12.00 GB)
(01,00)     | 3.87 GB/s 4.85 GB/s 5.69 GB/s (9.60 GB)
(01,02)     | 5.45 GB/s 5.92 GB/s 6.55 GB/s (12.00 GB)
(01,03)     | 4.72 GB/s 4.79 GB/s 5.52 GB/s (7.20 GB)
(02,00)     | 4.03 GB/s 4.45 GB/s 5.05 GB/s (7.20 GB)
(02,01)     | 4.95 GB/s 5.92 GB/s 7.00 GB/s (12.00 GB)
(02,03)     | 4.55 GB/s 4.96 GB/s 5.98 GB/s (9.60 GB)
(03,00)     | 4.88 GB/s 5.25 GB/s 6.58 GB/s (12.00 GB)
(03,01)     | 4.26 GB/s 4.93 GB/s 5.55 GB/s (7.20 GB)
(03,02)     | 4.80 GB/s 5.86 GB/s 6.33 GB/s (9.60 GB)
```

**Without Shuffling**:
```
Merge benchmark
--------------------------
Chunk-size  | 100000000
Frac-match  | 0.3
Ignore-size | 1.05 MB
Protocol    | ucx
Device(s)   | 0,1,2,3
==========================
Total time  | 1.75 s
Total time  | 910.33 ms
Total time  | 901.90 ms
==========================
(w1,w2)     | 25% 50% 75% (total nbytes)
--------------------------
(00,01)     | 4.43 GB/s 4.92 GB/s 5.21 GB/s (4.20 GB)
(00,02)     | 4.32 GB/s 4.77 GB/s 7.80 GB/s (9.00 GB)
(00,03)     | 4.07 GB/s 4.86 GB/s 5.72 GB/s (6.60 GB)
(01,00)     | 3.66 GB/s 4.32 GB/s 5.68 GB/s (6.60 GB)
(01,02)     | 4.89 GB/s 5.11 GB/s 5.22 GB/s (4.20 GB)
(01,03)     | 4.30 GB/s 4.60 GB/s 5.34 GB/s (6.60 GB)
(02,00)     | 4.47 GB/s 5.68 GB/s 11.40 GB/s (9.00 GB)
(02,01)     | 5.39 GB/s 5.44 GB/s 6.22 GB/s (4.20 GB)
(02,03)     | 4.96 GB/s 5.77 GB/s 6.02 GB/s (4.20 GB)
(03,00)     | 4.58 GB/s 4.80 GB/s 5.13 GB/s (4.20 GB)
(03,01)     | 4.41 GB/s 4.98 GB/s 9.85 GB/s (9.00 GB)
(03,02)     | 4.63 GB/s 4.76 GB/s 4.99 GB/s (4.20 GB)
```