### PR TITLE
Respect `temporary-directory` config for spilling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 0.13
 ----
 - Restrict CuPy to <7.2 (#239) `Benjamin Zaitlen`_
+- Respect `temporary-directory` config for spilling (#247) `John Kirkham`_
 
 0.12
 ----

--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -138,8 +138,7 @@ class DeviceHostFile(ZictBase):
     ):
         if local_directory is None:
             local_directory = dask.config.get("temporary-directory") or os.getcwd()
-            if not os.path.exists(local_directory):
-                os.mkdir(local_directory)
+            os.makedirs(local_directory, exist_ok=True)
             local_directory = os.path.join(local_directory, "dask-worker-space")
 
         self.disk_func_path = os.path.join(local_directory, "storage")

--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -145,7 +145,9 @@ class DeviceHostFile(ZictBase):
         self.disk_func_path = os.path.join(local_directory, "storage")
 
         self.host_func = dict()
-        self.disk_func = Func(serialize_bytelist, deserialize_bytes, File(self.disk_func_path))
+        self.disk_func = Func(
+            serialize_bytelist, deserialize_bytes, File(self.disk_func_path)
+        )
         self.host_buffer = Buffer(
             self.host_func, self.disk_func, memory_limit, weight=weight
         )

--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -142,10 +142,10 @@ class DeviceHostFile(ZictBase):
                 os.mkdir(local_directory)
             local_directory = os.path.join(local_directory, "dask-worker-space")
 
-        path = os.path.join(local_directory, "storage")
+        self.disk_func_path = os.path.join(local_directory, "storage")
 
         self.host_func = dict()
-        self.disk_func = Func(serialize_bytelist, deserialize_bytes, File(path))
+        self.disk_func = Func(serialize_bytelist, deserialize_bytes, File(self.disk_func_path))
         self.host_buffer = Buffer(
             self.host_func, self.disk_func, memory_limit, weight=weight
         )

--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -1,5 +1,6 @@
 import os
 
+import dask
 from dask.sizeof import sizeof
 from distributed.protocol import (
     dask_deserialize,
@@ -133,8 +134,14 @@ class DeviceHostFile(ZictBase):
         self,
         device_memory_limit=None,
         memory_limit=None,
-        local_directory="dask-worker-space",
+        local_directory=None,
     ):
+        if local_directory is None:
+            local_directory = dask.config.get("temporary-directory") or os.getcwd()
+            if not os.path.exists(local_directory):
+                os.mkdir(local_directory)
+            local_directory = os.path.join(local_directory, "dask-worker-space")
+
         path = os.path.join(local_directory, "storage")
 
         self.host_func = dict()

--- a/dask_cuda/tests/test_device_host_file.py
+++ b/dask_cuda/tests/test_device_host_file.py
@@ -1,3 +1,4 @@
+import os
 from random import randint
 
 import dask
@@ -19,6 +20,7 @@ def test_device_host_file_config(tmp_path):
     dhf_disk_path = str(tmp_path / "dask-worker-space" / "storage")
     with dask.config.set(temporary_directory=str(tmp_path)):
         dhf = DeviceHostFile()
+        assert os.path.exists(dhf_disk_path)
         assert dhf.disk_func_path == dhf_disk_path
 
 

--- a/dask_cuda/tests/test_device_host_file.py
+++ b/dask_cuda/tests/test_device_host_file.py
@@ -1,5 +1,6 @@
 from random import randint
 
+import dask
 import dask.array as da
 from dask_cuda.device_host_file import (
     DeviceHostFile,
@@ -12,6 +13,13 @@ import numpy as np
 import pytest
 
 cupy = pytest.importorskip("cupy")
+
+
+def test_device_host_file_config(tmp_path):
+    dhf_disk_path = str(tmp_path / "dask-worker-space" / "storage")
+    with dask.config.set(temporary_directory=str(tmp_path)):
+        dhf = DeviceHostFile()
+        assert dhf.disk_func.d.directory == dhf_disk_path
 
 
 @pytest.mark.parametrize("num_host_arrays", [1, 10, 100])

--- a/dask_cuda/tests/test_device_host_file.py
+++ b/dask_cuda/tests/test_device_host_file.py
@@ -19,7 +19,7 @@ def test_device_host_file_config(tmp_path):
     dhf_disk_path = str(tmp_path / "dask-worker-space" / "storage")
     with dask.config.set(temporary_directory=str(tmp_path)):
         dhf = DeviceHostFile()
-        assert dhf.disk_func.d.directory == dhf_disk_path
+        assert dhf.disk_func_path == dhf_disk_path
 
 
 @pytest.mark.parametrize("num_host_arrays", [1, 10, 100])


### PR DESCRIPTION
Make sure to check `dask.config`'s value for `temporary-directory` when creating a `DeviceHostFile` if `local_directory` is not otherwise specified.