### PR TITLE
Relax CuPy pin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 0.13
 ----
 - Restrict CuPy to <7.2 (#239) `Benjamin Zaitlen`_
+- Relax CuPy pin (#248) `John Kirkham`_
 
 0.12
 ----

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -57,7 +57,7 @@ conda list
 # Fixing Numpy version to avoid RuntimeWarning: numpy.ufunc size changed, may
 # indicate binary incompatibility. Expected 192 from C header, got 216 from PyObject
 conda install "cudatoolkit=$CUDA_REL" \
-              "cupy>=6.5.0,<7.2.0a0,!=7.1.0" "numpy=1.16.4" \
+              "cupy>=6.5.0" "numpy=1.16.4" \
               "cudf=${MINOR_VERSION}" "dask-cudf=${MINOR_VERSION}" \
               "dask>=2.8.1" "distributed>=2.8.1"
 


### PR DESCRIPTION
Closes https://github.com/rapidsai/dask-cuda/issues/241

Try relaxing the CuPy pin since we have made some changes to the package.