### PR TITLE
Use `"dask"` serialization to move to/from host

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@
 - Respect `temporary-directory` config for spilling (#247) `John Kirkham`_
 - Relax CuPy pin (#248) `John Kirkham`_
 - Added `ignore_index` argument to `partition_by_hash()` (#253) `Mads R. B. Kristensen`_
+- Use `"dask"` serialization to move to/from host (#256) `John Kirkham`_
 - Drop Numba `DeviceNDArray` code for `sizeof` (#257) `John Kirkham`_
 - Support spilling of device objects in dictionaries (#260) `Mads R. B. Kristensen`_
 

--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -45,7 +45,7 @@ class DeviceSerialized:
 
 
 @dask_serialize.register(DeviceSerialized)
-def _(obj):
+def device_serialize(obj):
     headers = []
     all_frames = []
     for part in obj.parts:
@@ -60,7 +60,7 @@ def _(obj):
 
 
 @dask_deserialize.register(DeviceSerialized)
-def _(header, frames):
+def device_deserialize(header, frames):
     parts = []
     for sub_header in header["sub-headers"]:
         start, stop = sub_header.pop("frame-start-stop")

--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -26,9 +26,8 @@ class DeviceSerialized:
     This stores a device-side object as
 
     1.  A msgpack encodable header
-    2.  A list of objects that are returned by calling
-        `numba.cuda.as_cuda_array(f).copy_to_host()`
-        which are typically NumPy arrays
+    2.  A list of `bytes`-like objects (like NumPy arrays)
+        that are in host memory
     """
 
     def __init__(self, header, parts):

--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -115,10 +115,7 @@ class DeviceHostFile(ZictBase):
     """
 
     def __init__(
-        self,
-        device_memory_limit=None,
-        memory_limit=None,
-        local_directory=None,
+        self, device_memory_limit=None, memory_limit=None, local_directory=None,
     ):
         if local_directory is None:
             local_directory = dask.config.get("temporary-directory") or os.getcwd()

--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -1,5 +1,7 @@
 import os
 
+import numpy
+
 import dask
 from distributed.protocol import (
     dask_deserialize,
@@ -65,6 +67,7 @@ def device_deserialize(header, frames):
 
 def device_to_host(obj: object) -> DeviceSerialized:
     header, frames = serialize(obj, serializers=["dask", "pickle"])
+    frames = [numpy.asarray(f) for f in frames]
     return DeviceSerialized(header, frames)
 
 

--- a/dask_cuda/tests/test_device_host_file.py
+++ b/dask_cuda/tests/test_device_host_file.py
@@ -157,9 +157,9 @@ def test_serialize_cupy_collection(collection, length, value):
     if length > 5:
         assert obj.header["serializer"] == "pickle"
     elif length > 0:
-        assert all([h["serializer"] == "cuda" for h in obj.header["sub-headers"]])
+        assert all([h["serializer"] == "dask" for h in obj.header["sub-headers"]])
     else:
-        assert obj.header["serializer"] == "cuda"
+        assert obj.header["serializer"] == "dask"
 
     btslst = serialize_bytelist(obj)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dask>=2.9.0
-distributed>=2.7.0
+distributed>=2.11.0
 pynvml>=8.0.3
 numpy>=1.16.0
 numba>=0.40.1


### PR DESCRIPTION
Fixes https://github.com/rapidsai/dask-cuda/issues/242

As all `"cuda"` serializable objects are now also `"dask"` serializable, switch to just using `"dask"` serialization to perform device-to-host transfers to spill to host memory. Though continue falling back to `"pickle"` if nothing better can be found (after all that will be on host too). Similarly "unspilling" from host-to-device will happen naturally as part of the deserialization step. Should simplify what Dask-CUDA needs to keep track of/do.