### PR TITLE
Drop Numba `DeviceNDArray` code for `sizeof`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@
 - Respect `temporary-directory` config for spilling (#247) `John Kirkham`_
 - Relax CuPy pin (#248) `John Kirkham`_
 - Added `ignore_index` argument to `partition_by_hash()` (#253) `Mads R. B. Kristensen`_
+- Drop Numba `DeviceNDArray` code for `sizeof` (#257) `John Kirkham`_
 
 0.12
 ----

--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -1,7 +1,6 @@
 import os
 
 import dask
-from dask.sizeof import sizeof
 from distributed.protocol import (
     dask_deserialize,
     dask_serialize,
@@ -23,18 +22,6 @@ try:
     from rmm import DeviceBuffer as cuda_memory_manager
 except ImportError:
     import numba.cuda as cuda_memory_manager
-
-
-# Register sizeof for Numba DeviceNDArray while Dask doesn't add it
-if not hasattr(sizeof, "register_numba"):
-
-    @sizeof.register_lazy("numba")
-    def register_numba():
-        import numba
-
-        @sizeof.register(numba.cuda.cudadrv.devicearray.DeviceNDArray)
-        def sizeof_numba_devicearray(x):
-            return int(x.nbytes)
 
 
 class DeviceSerialized:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dask>=2.4.0
+dask>=2.9.0
 distributed>=2.7.0
 pynvml>=8.0.3
 numpy>=1.16.0


### PR DESCRIPTION
Fixes https://github.com/rapidsai/dask-cuda/issues/224

As Dask 2.9.0+ has code for determining `sizeof` for Numba `DeviceNDArray`s, there is no need for us to carry around our own code for this. So go ahead and drop it.