### PR TITLE
DeviceHostFile: get stored value without moving it from host to device memory

### DIFF
--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -186,3 +186,12 @@ class DeviceHostFile(ZictBase):
     def __delitem__(self, key):
         self.device_keys.discard(key)
         del self.device_buffer[key]
+
+    def get_from_dev_or_host_buffer(self, key):
+        """Get stored value without moving it from host to device memory.
+        If the value isn't in device memory, `DeviceSerialized` is returned.
+        """
+        if key not in self.device_keys or key in self.device_func:
+            return self.__getitem__(key)
+        else:
+            return self.host_buffer[key]

--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -163,7 +163,10 @@ class DeviceHostFile(ZictBase):
         self.fast = self.host_buffer.fast
 
     def __setitem__(self, key, value):
-        if is_device_object(value):
+        if isinstance(value, DeviceSerialized):
+            self.device_keys.add(key)
+            self.host_buffer[key] = value
+        elif is_device_object(value):
             self.device_keys.add(key)
             self.device_buffer[key] = value
         else:

--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -195,3 +195,6 @@ class DeviceHostFile(ZictBase):
             return self.__getitem__(key)
         else:
             return self.host_buffer[key]
+
+    def __contains__(self, key):
+        return key in self.device_buffer or key in self.host_buffer


### PR DESCRIPTION
This PR makes it possible to retrieve data from `DeviceHostFile` without moving it from host to device memory.