### PR TITLE
Fix behavior for `memory_limit=0`

### DIFF
--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -111,7 +111,7 @@ class DeviceHostFile(ZictBase):
             serialize_bytelist, deserialize_bytes, File(self.disk_func_path)
         )
         if memory_limit == 0:
-            self.host_buffer = host_func
+            self.host_buffer = self.host_func
         else:
             self.host_buffer = Buffer(
                 self.host_func, self.disk_func, memory_limit, weight=weight
@@ -125,11 +125,11 @@ class DeviceHostFile(ZictBase):
         )
 
         self.device = self.device_buffer.fast.d
-        self.host = host_buffer if memory_limit == 0 else self.host_buffer.fast.d
+        self.host = self.host_buffer if memory_limit == 0 else self.host_buffer.fast.d
         self.disk = None if memory_limit == 0 else self.host_buffer.slow.d
 
         # For Worker compatibility only, where `fast` is host memory buffer
-        self.fast = self.host_buffer.fast
+        self.fast = self.host_buffer if memory_limit == 0 else self.host_buffer.fast
 
     def __setitem__(self, key, value):
         if is_device_object(value):

--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -90,7 +90,8 @@ class DeviceHostFile(ZictBase):
         spills to host cache once filled.
     memory_limit: int
         Number of bytes of host memory for host LRU cache, spills to
-        disk once filled.
+        disk once filled. Setting this to 0 means unlimited host memory,
+        implies no spilling to disk.
     local_directory: path
         Path where to store serialized objects on disk
     """
@@ -109,9 +110,12 @@ class DeviceHostFile(ZictBase):
         self.disk_func = Func(
             serialize_bytelist, deserialize_bytes, File(self.disk_func_path)
         )
-        self.host_buffer = Buffer(
-            self.host_func, self.disk_func, memory_limit, weight=weight
-        )
+        if memory_limit == 0:
+            self.host_buffer = host_func
+        else:
+            self.host_buffer = Buffer(
+                self.host_func, self.disk_func, memory_limit, weight=weight
+            )
 
         self.device_keys = set()
         self.device_func = dict()
@@ -121,8 +125,8 @@ class DeviceHostFile(ZictBase):
         )
 
         self.device = self.device_buffer.fast.d
-        self.host = self.host_buffer.fast.d
-        self.disk = self.host_buffer.slow.d
+        self.host = host_buffer if memory_limit == 0 else self.host_buffer.fast.d
+        self.disk = None if memory_limit == 0 else self.host_buffer.slow.d
 
         # For Worker compatibility only, where `fast` is host memory buffer
         self.fast = self.host_buffer.fast

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -146,7 +146,7 @@ class LocalCUDACluster(LocalCluster):
         if n_workers is None:
             n_workers = len(CUDA_VISIBLE_DEVICES)
         self.host_memory_limit = parse_memory_limit(
-            MEMORY_LIMIT, threads_per_worker, n_workers
+            memory_limit, threads_per_worker, n_workers
         )
         self.device_memory_limit = device_memory_limit
 
@@ -206,7 +206,7 @@ class LocalCUDACluster(LocalCluster):
         super().__init__(
             n_workers=0,
             threads_per_worker=threads_per_worker,
-            memory_limit=memory_limit,
+            memory_limit=self.host_memory_limit,
             processes=True,
             data=data,
             local_directory=local_directory,

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -5,6 +5,7 @@ import dask
 from dask.distributed import LocalCluster
 from distributed.system import MEMORY_LIMIT
 from distributed.utils import parse_bytes
+from distributed.worker import parse_memory_limit
 
 from .device_host_file import DeviceHostFile
 from .initialize import initialize
@@ -124,7 +125,7 @@ class LocalCUDACluster(LocalCluster):
         n_workers=None,
         threads_per_worker=1,
         processes=True,
-        memory_limit=None,
+        memory_limit="auto",
         device_memory_limit=None,
         CUDA_VISIBLE_DEVICES=None,
         data=None,
@@ -144,9 +145,9 @@ class LocalCUDACluster(LocalCluster):
         CUDA_VISIBLE_DEVICES = list(map(int, CUDA_VISIBLE_DEVICES))
         if n_workers is None:
             n_workers = len(CUDA_VISIBLE_DEVICES)
-        if memory_limit is None:
-            memory_limit = MEMORY_LIMIT / n_workers
-        self.host_memory_limit = memory_limit
+        self.host_memory_limit = parse_memory_limit(
+            MEMORY_LIMIT, n_threads_per_worker, n_workers
+        )
         self.device_memory_limit = device_memory_limit
 
         self.rmm_pool_size = rmm_pool_size

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -146,7 +146,7 @@ class LocalCUDACluster(LocalCluster):
         if n_workers is None:
             n_workers = len(CUDA_VISIBLE_DEVICES)
         self.host_memory_limit = parse_memory_limit(
-            MEMORY_LIMIT, n_threads_per_worker, n_workers
+            MEMORY_LIMIT, threads_per_worker, n_workers
         )
         self.device_memory_limit = device_memory_limit
 


### PR DESCRIPTION
This ensures behavior for `memory_limit=0` matches that of dask/distributed, meaning unlimited host memory, implying no spilling to disk.