### PR TITLE
Raise serialization errors when spilling

### DIFF
--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -1,3 +1,4 @@
+import functools
 import os
 
 import numpy
@@ -108,7 +109,9 @@ class DeviceHostFile(ZictBase):
 
         self.host_func = dict()
         self.disk_func = Func(
-            serialize_bytelist, deserialize_bytes, File(self.disk_func_path)
+            functools.partial(serialize_bytelist, on_error="raise"),
+            deserialize_bytes,
+            File(self.disk_func_path),
         )
         if memory_limit == 0:
             self.host_buffer = self.host_func


### PR DESCRIPTION
The default behavior of `serialize` and thus `serialize_bytes` is to capture any serialization errors as messages. The result is the error gets raises on deserialization. However for spilling, this means that we fail to spill and raise that error after trying to restore that data. Instead go ahead and raise the error when trying to spill to avoid thinking content has spilled successfully (when that is not the case) and thus losing it.