### PR TITLE
Add NVTX annotations for spilling

### DIFF
--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -19,16 +19,7 @@ from zict import Buffer, File, Func
 from zict.common import ZictBase
 
 from .is_device_object import is_device_object
-
-try:
-    from cudf._lib.nvtx import annotate
-except ImportError:
-    # NVTX annotations functionality currently exists in cuDF, if cuDF isn't
-    # installed, `annotate` yields only.
-    from contextlib import contextmanager
-    @contextmanager
-    def annotate(message=None, color="blue", domain=None):
-        yield
+from .utils import nvtx_annotate
 
 
 class DeviceSerialized:
@@ -75,14 +66,14 @@ def device_deserialize(header, frames):
     return DeviceSerialized(header["main-header"], parts)
 
 
-@annotate("SPILL_D2H", color="red", domain="dask_cuda")
+@nvtx_annotate("SPILL_D2H", color="red", domain="dask_cuda")
 def device_to_host(obj: object) -> DeviceSerialized:
     header, frames = serialize(obj, serializers=["dask", "pickle"])
     frames = [numpy.asarray(f) for f in frames]
     return DeviceSerialized(header, frames)
 
 
-@annotate("SPILL_H2D", color="green", domain="dask_cuda")
+@nvtx_annotate("SPILL_H2D", color="green", domain="dask_cuda")
 def host_to_device(s: DeviceSerialized) -> object:
     return deserialize(s.header, s.parts)
 

--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -20,6 +20,16 @@ from zict.common import ZictBase
 
 from .is_device_object import is_device_object
 
+try:
+    from cudf._lib.nvtx import annotate
+except ImportError:
+    # NVTX annotations functionality currently exists in cuDF, if cuDF isn't
+    # installed, `annotate` yields only.
+    from contextlib import contextmanager
+    @contextmanager
+    def annotate(message=None, color="blue", domain=None):
+        yield
+
 
 class DeviceSerialized:
     """ Store device object on the host
@@ -65,12 +75,14 @@ def device_deserialize(header, frames):
     return DeviceSerialized(header["main-header"], parts)
 
 
+@annotate("SPILL_D2H", color="red", domain="dask_cuda")
 def device_to_host(obj: object) -> DeviceSerialized:
     header, frames = serialize(obj, serializers=["dask", "pickle"])
     frames = [numpy.asarray(f) for f in frames]
     return DeviceSerialized(header, frames)
 
 
+@annotate("SPILL_H2D", color="green", domain="dask_cuda")
 def host_to_device(s: DeviceSerialized) -> object:
     return deserialize(s.header, s.parts)
 

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -8,6 +8,17 @@ import pynvml
 import toolz
 
 
+try:
+    from cudf._lib.nvtx import annotate as nvtx_annotate
+except ImportError:
+    # NVTX annotations functionality currently exists in cuDF, if cuDF isn't
+    # installed, `annotate` yields only.
+    from contextlib import contextmanager
+    @contextmanager
+    def nvtx_annotate(message=None, color="blue", domain=None):
+        yield
+
+
 class CPUAffinity:
     def __init__(self, cores):
         self.cores = cores


### PR DESCRIPTION
NVTX annotations add a new row `dask_cuda` to profiles, identifying when transfers are due to the spilling mechanism. See example below:

![Screenshot 2020-04-14 at 13 52 41](https://user-images.githubusercontent.com/4398246/79223350-734f7e00-7e59-11ea-94bd-49b57ab54f57.png)