### PR TITLE
Multi-node benchmarks

### DIFF
--- a/dask_cuda/benchmarks/local_cudf_merge.py
+++ b/dask_cuda/benchmarks/local_cudf_merge.py
@@ -178,6 +178,12 @@ def main(args):
     scheduler_addr = cluster_options["scheduler_addr"]
 
     cluster = Cluster(*cluster_args, **cluster_kwargs)
+    if args.multi_node:
+        import time
+        # Allow some time for workers to start and connect to scheduler
+        # TODO: make this a command-line argument?
+        time.sleep(15)
+
     client = Client(scheduler_addr if args.multi_node else cluster)
 
     client.run(setup_memory_pool, disable_pool=args.no_rmm_pool)

--- a/dask_cuda/benchmarks/local_cudf_merge.py
+++ b/dask_cuda/benchmarks/local_cudf_merge.py
@@ -1,4 +1,3 @@
-import argparse
 import math
 from collections import defaultdict
 from time import perf_counter as clock
@@ -7,19 +6,17 @@ from dask.base import tokenize
 from dask.dataframe.core import new_dd_object
 from dask.distributed import Client, performance_report, wait
 from dask.utils import format_bytes, format_time, parse_bytes
-from dask_cuda.initialize import initialize
 from dask_cuda import explicit_comms
-
-import cudf
-import cupy
-import numpy
-
 from dask_cuda.benchmarks.utils import (
     get_cluster_options,
     get_scheduler_workers,
     parse_benchmark_args,
     setup_memory_pool,
 )
+
+import cudf
+import cupy
+import numpy
 
 # Benchmarking cuDF merge operation based on
 # <https://gist.github.com/rjzamora/0ffc35c19b5180ab04bbf7c793c45955>

--- a/dask_cuda/benchmarks/local_cupy_transpose_sum.py
+++ b/dask_cuda/benchmarks/local_cupy_transpose_sum.py
@@ -26,7 +26,7 @@ async def run(args):
     cluster_kwargs = cluster_options["kwargs"]
     scheduler_addr = cluster_options["scheduler_addr"]
 
-    async with Cluster(*cluster_args, **cluster_kwargs) as cluster:
+    async with Cluster(*cluster_args, **cluster_kwargs, asynchronous=True) as cluster:
         # Use the scheduler address with an SSHCluster rather than the cluster
         # object, otherwise we can't shut it down.
         async with Client(

--- a/dask_cuda/benchmarks/local_cupy_transpose_sum.py
+++ b/dask_cuda/benchmarks/local_cupy_transpose_sum.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from time import perf_counter as clock
 
 import dask.array as da
-from dask.distributed import Client, performance_report, wait
+from dask.distributed import Client, SSHCluster, performance_report, wait
 from dask.utils import format_bytes, format_time, parse_bytes
 from dask_cuda.local_cuda_cluster import LocalCUDACluster
 
@@ -12,20 +12,67 @@ import cupy
 import numpy as np
 
 
-async def run(args):
+def get_scheduler_workers(dask_scheduler=None):
+    return dask_scheduler.workers
 
-    # Set up workers on the local machine
-    async with LocalCUDACluster(
-        protocol=args.protocol,
-        n_workers=len(args.devs.split(",")),
-        CUDA_VISIBLE_DEVICES=args.devs,
-        ucx_net_devices=args.ucx_net_devices,
-        enable_tcp_over_ucx=args.enable_tcp_over_ucx,
-        enable_infiniband=args.enable_infiniband,
-        enable_nvlink=args.enable_nvlink,
-        asynchronous=True,
-    ) as cluster:
-        async with Client(cluster, asynchronous=True) as client:
+
+async def run(args):
+    if args.multi_node is True:
+        Cluster = SSHCluster
+        cluster_args = [args.hosts.split(",")]
+        scheduler_addr = args.protocol + "://" + cluster_args[0][0] + ":8786"
+
+        worker_options = {}
+
+        # This looks counterintuitive but adding the variable name with
+        # an empty string is how we can enable CLI booleans currently,
+        # note that SSHCluster uses the dask-cuda-worker CLI.
+        if args.enable_tcp_over_ucx:
+            worker_options["enable_tcp_over_ucx"] = ""
+        if args.enable_nvlink:
+            worker_options["enable_nvlink"] = ""
+        if args.enable_infiniband:
+            worker_options["enable_infiniband"] = ""
+
+        if args.ucx_net_devices:
+            worker_options["ucx_net_devices"] = args.ucx_net_devices
+
+        cluster_kwargs = {
+            "connect_options": {"known_hosts": None},
+            "scheduler_options": {"protocol": args.protocol},
+            "worker_module": "dask_cuda.dask_cuda_worker",
+            "worker_options": worker_options,
+            "asynchronous": True,
+            # "n_workers": len(args.devs.split(",")),
+            # "CUDA_VISIBLE_DEVICES": args.devs,
+        }
+    else:
+        Cluster = LocalCUDACluster
+        cluster_args = []
+        cluster_kwargs = {
+            "protocol": args.protocol,
+            "n_workers": len(args.devs.split(",")),
+            "CUDA_VISIBLE_DEVICES": args.devs,
+            "ucx_net_devices": args.ucx_net_devices,
+            "enable_tcp_over_ucx": args.enable_tcp_over_ucx,
+            "enable_infiniband": args.enable_infiniband,
+            "enable_nvlink": args.enable_nvlink,
+            "asynchronous": True,
+        }
+
+    async with Cluster(*cluster_args, **cluster_kwargs) as cluster:
+        # Use the scheduler address with an SSHCluster rather than the cluster
+        # object, otherwise we can't shut it down.
+        async with Client(
+            scheduler_addr if args.multi_node else cluster, asynchronous=True
+        ) as client:
+            print("Client connected", client)
+
+            import time
+
+            time.sleep(5)
+            scheduler_workers = await client.run_on_scheduler(get_scheduler_workers)
+            print("Client connected", client)
 
             def _worker_setup(size=None):
                 import rmm
@@ -69,20 +116,17 @@ async def run(args):
                     if d["total"] >= args.ignore_size:
                         bandwidths[k, d["who"]].append(d["bandwidth"])
                         total_nbytes[k, d["who"]].append(d["total"])
+
             bandwidths = {
-                (
-                    cluster.scheduler.workers[w1].name,
-                    cluster.scheduler.workers[w2].name,
-                ): [
+                (scheduler_workers[w1].name, scheduler_workers[w2].name,): [
                     "%s/s" % format_bytes(x) for x in np.quantile(v, [0.25, 0.50, 0.75])
                 ]
                 for (w1, w2), v in bandwidths.items()
             }
             total_nbytes = {
-                (
-                    cluster.scheduler.workers[w1].name,
-                    cluster.scheduler.workers[w2].name,
-                ): format_bytes(sum(nb))
+                (scheduler_workers[w1].name, scheduler_workers[w2].name,): format_bytes(
+                    sum(nb)
+                )
                 for (w1, w2), nb in total_nbytes.items()
             }
 
@@ -100,10 +144,17 @@ async def run(args):
             print("(w1,w2)     | 25% 50% 75% (total nbytes)")
             print("--------------------------")
             for (d1, d2), bw in sorted(bandwidths.items()):
-                print(
-                    "(%02d,%02d)     | %s %s %s (%s)"
-                    % (d1, d2, bw[0], bw[1], bw[2], total_nbytes[(d1, d2)])
+                fmt = (
+                    "(%s,%s)     | %s %s %s (%s)"
+                    if args.multi_node
+                    else "(%02d,%02d)     | %s %s %s (%s)"
                 )
+                print(fmt % (d1, d2, bw[0], bw[1], bw[2], total_nbytes[(d1, d2)]))
+
+            # An SSHCluster will not automatically shut down, we have to
+            # ensure it does.
+            if args.multi_node:
+                await client.shutdown()
 
 
 def parse_args():
@@ -197,14 +248,40 @@ def parse_args():
         help="The device to be used for UCX communication, or 'auto'. "
         "Ignored if protocol is 'tcp'",
     )
+    parser.add_argument(
+        "--single-node",
+        action="store_true",
+        dest="multi_node",
+        help="Runs a single-node cluster on the current host.",
+    )
+    parser.add_argument(
+        "--multi-node",
+        action="store_true",
+        dest="multi_node",
+        help="Runs a multi-node cluster on the hosts specified by --hosts.",
+    )
+    parser.add_argument(
+        "--hosts",
+        default=None,
+        type=str,
+        help="Specifies a comma-separated list of IP addresses or hostnames. "
+        "The list begins with the host where the scheduler will be launched "
+        "followed by any number of workers, with a minimum of 1 worker. "
+        "Requires --multi-node, ignored otherwise.",
+    )
     parser.set_defaults(
         enable_tcp_over_ucx=True, enable_infiniband=True, enable_nvlink=True
     )
     args = parser.parse_args()
+
     if args.protocol == "tcp":
         args.enable_tcp_over_ucx = False
-        args.enable_infinibank = False
+        args.enable_infiniband = False
         args.enable_nvlink = False
+
+    if args.multi_node and len(args.hosts.split(",")) < 2:
+        raise ValueError("--multi-node requires at least 2 hosts")
+
     return args
 
 

--- a/dask_cuda/benchmarks/local_cupy_transpose_sum.py
+++ b/dask_cuda/benchmarks/local_cupy_transpose_sum.py
@@ -11,54 +11,20 @@ from dask_cuda.local_cuda_cluster import LocalCUDACluster
 import cupy
 import numpy as np
 
-
-def get_scheduler_workers(dask_scheduler=None):
-    return dask_scheduler.workers
+from dask_cuda.benchmarks.utils import (
+    get_cluster_options,
+    get_scheduler_workers,
+    parse_benchmark_args,
+    setup_memory_pool,
+)
 
 
 async def run(args):
-    if args.multi_node is True:
-        Cluster = SSHCluster
-        cluster_args = [args.hosts.split(",")]
-        scheduler_addr = args.protocol + "://" + cluster_args[0][0] + ":8786"
-
-        worker_options = {}
-
-        # This looks counterintuitive but adding the variable name with
-        # an empty string is how we can enable CLI booleans currently,
-        # note that SSHCluster uses the dask-cuda-worker CLI.
-        if args.enable_tcp_over_ucx:
-            worker_options["enable_tcp_over_ucx"] = ""
-        if args.enable_nvlink:
-            worker_options["enable_nvlink"] = ""
-        if args.enable_infiniband:
-            worker_options["enable_infiniband"] = ""
-
-        if args.ucx_net_devices:
-            worker_options["ucx_net_devices"] = args.ucx_net_devices
-
-        cluster_kwargs = {
-            "connect_options": {"known_hosts": None},
-            "scheduler_options": {"protocol": args.protocol},
-            "worker_module": "dask_cuda.dask_cuda_worker",
-            "worker_options": worker_options,
-            "asynchronous": True,
-            # "n_workers": len(args.devs.split(",")),
-            # "CUDA_VISIBLE_DEVICES": args.devs,
-        }
-    else:
-        Cluster = LocalCUDACluster
-        cluster_args = []
-        cluster_kwargs = {
-            "protocol": args.protocol,
-            "n_workers": len(args.devs.split(",")),
-            "CUDA_VISIBLE_DEVICES": args.devs,
-            "ucx_net_devices": args.ucx_net_devices,
-            "enable_tcp_over_ucx": args.enable_tcp_over_ucx,
-            "enable_infiniband": args.enable_infiniband,
-            "enable_nvlink": args.enable_nvlink,
-            "asynchronous": True,
-        }
+    cluster_options = get_cluster_options(args)
+    Cluster = cluster_options["class"]
+    cluster_args = cluster_options["args"]
+    cluster_kwargs = cluster_options["kwargs"]
+    scheduler_addr = cluster_options["scheduler_addr"]
 
     async with Cluster(*cluster_args, **cluster_kwargs) as cluster:
         # Use the scheduler address with an SSHCluster rather than the cluster
@@ -66,28 +32,14 @@ async def run(args):
         async with Client(
             scheduler_addr if args.multi_node else cluster, asynchronous=True
         ) as client:
-            print("Client connected", client)
-
-            import time
-
-            time.sleep(5)
             scheduler_workers = await client.run_on_scheduler(get_scheduler_workers)
-            print("Client connected", client)
 
-            def _worker_setup(size=None):
-                import rmm
-
-                rmm.reinitialize(
-                    pool_allocator=not args.no_rmm_pool,
-                    devices=0,
-                    initial_pool_size=size,
-                )
-                cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)
-
-            await client.run(_worker_setup)
+            await client.run(setup_memory_pool, disable_pool=args.no_rmm_pool)
             # Create an RMM pool on the scheduler due to occasional deserialization
             # of CUDA objects. May cause issues with InfiniBand otherwise.
-            await client.run_on_scheduler(_worker_setup, 1e9)
+            await client.run_on_scheduler(
+                setup_memory_pool, 1e9, disable_pool=args.no_rmm_pool
+            )
 
             # Create a simple random array
             rs = da.random.RandomState(RandomState=cupy.random.RandomState)
@@ -158,131 +110,33 @@ async def run(args):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(
-        description="Transpose on LocalCUDACluster benchmark"
-    )
-    parser.add_argument(
-        "-d", "--devs", default="0", type=str, help='GPU devices to use (default "0").'
-    )
-    parser.add_argument(
-        "-p",
-        "--protocol",
-        choices=["tcp", "ucx"],
-        default="tcp",
-        type=str,
-        help="The communication protocol to use.",
-    )
-    parser.add_argument(
-        "-s",
-        "--size",
-        default="10000",
-        metavar="n",
-        type=int,
-        help="The size n in n^2 (default 10000)",
-    )
-    parser.add_argument(
-        "-c",
-        "--chunk-size",
-        default="128 MiB",
-        metavar="nbytes",
-        type=str,
-        help='Chunk size (default "128 MiB")',
-    )
-    parser.add_argument(
-        "--ignore-size",
-        default="1 MiB",
-        metavar="nbytes",
-        type=parse_bytes,
-        help='Ignore messages smaller than this (default "1 MB")',
-    )
-    parser.add_argument(
-        "--profile",
-        metavar="PATH",
-        default=None,
-        type=str,
-        help="Write dask profile report (E.g. dask-report.html)",
-    )
-    parser.add_argument(
-        "--no-rmm-pool", action="store_true", help="Disable the RMM memory pool"
-    )
-    parser.add_argument(
-        "--enable-tcp-over-ucx",
-        action="store_true",
-        dest="enable_tcp_over_ucx",
-        help="Enable tcp over ucx.",
-    )
-    parser.add_argument(
-        "--enable-infiniband",
-        action="store_true",
-        dest="enable_infiniband",
-        help="Enable infiniband over ucx.",
-    )
-    parser.add_argument(
-        "--enable-nvlink",
-        action="store_true",
-        dest="enable_nvlink",
-        help="Enable NVLink over ucx.",
-    )
-    parser.add_argument(
-        "--disable-tcp-over-ucx",
-        action="store_false",
-        dest="enable_tcp_over_ucx",
-        help="Disable tcp over ucx.",
-    )
-    parser.add_argument(
-        "--disable-infiniband",
-        action="store_false",
-        dest="enable_infiniband",
-        help="Disable infiniband over ucx.",
-    )
-    parser.add_argument(
-        "--disable-nvlink",
-        action="store_false",
-        dest="enable_nvlink",
-        help="Disable NVLink over ucx.",
-    )
-    parser.add_argument(
-        "--ucx-net-devices",
-        default=None,
-        type=str,
-        help="The device to be used for UCX communication, or 'auto'. "
-        "Ignored if protocol is 'tcp'",
-    )
-    parser.add_argument(
-        "--single-node",
-        action="store_true",
-        dest="multi_node",
-        help="Runs a single-node cluster on the current host.",
-    )
-    parser.add_argument(
-        "--multi-node",
-        action="store_true",
-        dest="multi_node",
-        help="Runs a multi-node cluster on the hosts specified by --hosts.",
-    )
-    parser.add_argument(
-        "--hosts",
-        default=None,
-        type=str,
-        help="Specifies a comma-separated list of IP addresses or hostnames. "
-        "The list begins with the host where the scheduler will be launched "
-        "followed by any number of workers, with a minimum of 1 worker. "
-        "Requires --multi-node, ignored otherwise.",
-    )
-    parser.set_defaults(
-        enable_tcp_over_ucx=True, enable_infiniband=True, enable_nvlink=True
-    )
-    args = parser.parse_args()
+    special_args = [
+        {
+            "name": ["-s", "--size",],
+            "default": "10000",
+            "metavar": "n",
+            "type": int,
+            "help": "The size n in n^2 (default 10000)",
+        },
+        {
+            "name": ["-c", "--chunk-size",],
+            "default": "128 MiB",
+            "metavar": "nbytes",
+            "type": str,
+            "help": "Chunk size (default '128 MiB')",
+        },
+        {
+            "name": "--ignore-size",
+            "default": "1 MiB",
+            "metavar": "nbytes",
+            "type": parse_bytes,
+            "help": "Ignore messages smaller than this (default '1 MB')",
+        },
+    ]
 
-    if args.protocol == "tcp":
-        args.enable_tcp_over_ucx = False
-        args.enable_infiniband = False
-        args.enable_nvlink = False
-
-    if args.multi_node and len(args.hosts.split(",")) < 2:
-        raise ValueError("--multi-node requires at least 2 hosts")
-
-    return args
+    return parse_benchmark_args(
+        description="Transpose on LocalCUDACluster benchmark", args_list=special_args
+    )
 
 
 def main():

--- a/dask_cuda/benchmarks/local_cupy_transpose_sum.py
+++ b/dask_cuda/benchmarks/local_cupy_transpose_sum.py
@@ -25,6 +25,12 @@ async def run(args):
     scheduler_addr = cluster_options["scheduler_addr"]
 
     async with Cluster(*cluster_args, **cluster_kwargs, asynchronous=True) as cluster:
+        if args.multi_node:
+            import time
+            # Allow some time for workers to start and connect to scheduler
+            # TODO: make this a command-line argument?
+            time.sleep(15)
+
         # Use the scheduler address with an SSHCluster rather than the cluster
         # object, otherwise we can't shut it down.
         async with Client(

--- a/dask_cuda/benchmarks/local_cupy_transpose_sum.py
+++ b/dask_cuda/benchmarks/local_cupy_transpose_sum.py
@@ -6,17 +6,15 @@ from time import perf_counter as clock
 import dask.array as da
 from dask.distributed import Client, SSHCluster, performance_report, wait
 from dask.utils import format_bytes, format_time, parse_bytes
-from dask_cuda.local_cuda_cluster import LocalCUDACluster
-
-import cupy
-import numpy as np
-
 from dask_cuda.benchmarks.utils import (
     get_cluster_options,
     get_scheduler_workers,
     parse_benchmark_args,
     setup_memory_pool,
 )
+
+import cupy
+import numpy as np
 
 
 async def run(args):

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -5,9 +5,7 @@ from dask_cuda.local_cuda_cluster import LocalCUDACluster
 
 
 def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]):
-    parser = argparse.ArgumentParser(
-        description=description
-    )
+    parser = argparse.ArgumentParser(description=description)
     parser.add_argument(
         "-d", "--devs", default="0", type=str, help='GPU devices to use (default "0").'
     )
@@ -176,8 +174,6 @@ def setup_memory_pool(pool_size=None, disable_pool=False):
     import cupy
 
     rmm.reinitialize(
-        pool_allocator=not disable_pool,
-        devices=0,
-        initial_pool_size=pool_size,
+        pool_allocator=not disable_pool, devices=0, initial_pool_size=pool_size,
     )
     cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -142,7 +142,6 @@ def get_cluster_options(args):
             "scheduler_options": {"protocol": args.protocol},
             "worker_module": "dask_cuda.dask_cuda_worker",
             "worker_options": worker_options,
-            "asynchronous": True,
             # "n_workers": len(args.devs.split(",")),
             # "CUDA_VISIBLE_DEVICES": args.devs,
         }
@@ -158,7 +157,6 @@ def get_cluster_options(args):
             "enable_tcp_over_ucx": args.enable_tcp_over_ucx,
             "enable_infiniband": args.enable_infiniband,
             "enable_nvlink": args.enable_nvlink,
-            "asynchronous": True,
         }
 
     return {

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -1,0 +1,185 @@
+import argparse
+
+from dask.distributed import SSHCluster
+from dask_cuda.local_cuda_cluster import LocalCUDACluster
+
+
+def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]):
+    parser = argparse.ArgumentParser(
+        description=description
+    )
+    parser.add_argument(
+        "-d", "--devs", default="0", type=str, help='GPU devices to use (default "0").'
+    )
+    parser.add_argument(
+        "-p",
+        "--protocol",
+        choices=["tcp", "ucx"],
+        default="tcp",
+        type=str,
+        help="The communication protocol to use.",
+    )
+    parser.add_argument(
+        "--profile",
+        metavar="PATH",
+        default=None,
+        type=str,
+        help="Write dask profile report (E.g. dask-report.html)",
+    )
+    parser.add_argument(
+        "--no-rmm-pool", action="store_true", help="Disable the RMM memory pool"
+    )
+    parser.add_argument(
+        "--enable-tcp-over-ucx",
+        action="store_true",
+        dest="enable_tcp_over_ucx",
+        help="Enable tcp over ucx.",
+    )
+    parser.add_argument(
+        "--enable-infiniband",
+        action="store_true",
+        dest="enable_infiniband",
+        help="Enable infiniband over ucx.",
+    )
+    parser.add_argument(
+        "--enable-nvlink",
+        action="store_true",
+        dest="enable_nvlink",
+        help="Enable NVLink over ucx.",
+    )
+    parser.add_argument(
+        "--disable-tcp-over-ucx",
+        action="store_false",
+        dest="enable_tcp_over_ucx",
+        help="Disable tcp over ucx.",
+    )
+    parser.add_argument(
+        "--disable-infiniband",
+        action="store_false",
+        dest="enable_infiniband",
+        help="Disable infiniband over ucx.",
+    )
+    parser.add_argument(
+        "--disable-nvlink",
+        action="store_false",
+        dest="enable_nvlink",
+        help="Disable NVLink over ucx.",
+    )
+    parser.add_argument(
+        "--ucx-net-devices",
+        default=None,
+        type=str,
+        help="The device to be used for UCX communication, or 'auto'. "
+        "Ignored if protocol is 'tcp'",
+    )
+    parser.add_argument(
+        "--single-node",
+        action="store_true",
+        dest="multi_node",
+        help="Runs a single-node cluster on the current host.",
+    )
+    parser.add_argument(
+        "--multi-node",
+        action="store_true",
+        dest="multi_node",
+        help="Runs a multi-node cluster on the hosts specified by --hosts.",
+    )
+    parser.add_argument(
+        "--hosts",
+        default=None,
+        type=str,
+        help="Specifies a comma-separated list of IP addresses or hostnames. "
+        "The list begins with the host where the scheduler will be launched "
+        "followed by any number of workers, with a minimum of 1 worker. "
+        "Requires --multi-node, ignored otherwise.",
+    )
+
+    for args in args_list:
+        name = args.pop("name")
+        if not isinstance(name, list):
+            name = [name]
+        parser.add_argument(*name, **args)
+
+    parser.set_defaults(
+        enable_tcp_over_ucx=True, enable_infiniband=True, enable_nvlink=True
+    )
+    args = parser.parse_args()
+
+    if args.protocol == "tcp":
+        args.enable_tcp_over_ucx = False
+        args.enable_infiniband = False
+        args.enable_nvlink = False
+
+    if args.multi_node and len(args.hosts.split(",")) < 2:
+        raise ValueError("--multi-node requires at least 2 hosts")
+
+    return args
+
+
+def get_cluster_options(args):
+    if args.multi_node is True:
+        Cluster = SSHCluster
+        cluster_args = [args.hosts.split(",")]
+        scheduler_addr = args.protocol + "://" + cluster_args[0][0] + ":8786"
+
+        worker_options = {}
+
+        # This looks counterintuitive but adding the variable name with
+        # an empty string is how we can enable CLI booleans currently,
+        # note that SSHCluster uses the dask-cuda-worker CLI.
+        if args.enable_tcp_over_ucx:
+            worker_options["enable_tcp_over_ucx"] = ""
+        if args.enable_nvlink:
+            worker_options["enable_nvlink"] = ""
+        if args.enable_infiniband:
+            worker_options["enable_infiniband"] = ""
+
+        if args.ucx_net_devices:
+            worker_options["ucx_net_devices"] = args.ucx_net_devices
+
+        cluster_kwargs = {
+            "connect_options": {"known_hosts": None},
+            "scheduler_options": {"protocol": args.protocol},
+            "worker_module": "dask_cuda.dask_cuda_worker",
+            "worker_options": worker_options,
+            "asynchronous": True,
+            # "n_workers": len(args.devs.split(",")),
+            # "CUDA_VISIBLE_DEVICES": args.devs,
+        }
+    else:
+        Cluster = LocalCUDACluster
+        scheduler_addr = None
+        cluster_args = []
+        cluster_kwargs = {
+            "protocol": args.protocol,
+            "n_workers": len(args.devs.split(",")),
+            "CUDA_VISIBLE_DEVICES": args.devs,
+            "ucx_net_devices": args.ucx_net_devices,
+            "enable_tcp_over_ucx": args.enable_tcp_over_ucx,
+            "enable_infiniband": args.enable_infiniband,
+            "enable_nvlink": args.enable_nvlink,
+            "asynchronous": True,
+        }
+
+    return {
+        "class": Cluster,
+        "args": cluster_args,
+        "kwargs": cluster_kwargs,
+        "scheduler_addr": scheduler_addr,
+    }
+
+
+def get_scheduler_workers(dask_scheduler=None):
+    return dask_scheduler.workers
+
+
+def setup_memory_pool(pool_size=None, disable_pool=False):
+    import rmm
+    import cupy
+
+    rmm.reinitialize(
+        pool_allocator=not disable_pool,
+        devices=0,
+        initial_pool_size=pool_size,
+    )
+    cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -89,7 +89,13 @@ def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]
         help="Specifies a comma-separated list of IP addresses or hostnames. "
         "The list begins with the host where the scheduler will be launched "
         "followed by any number of workers, with a minimum of 1 worker. "
-        "Requires --multi-node, ignored otherwise.",
+        "Requires --multi-node, ignored otherwise. "
+        "Usage example: --multi-node --hosts 'dgx12,dgx12,10.10.10.10,dgx13' . "
+        "In the example, the benchmark is launched with scheduler on host "
+        "'dgx12' (first in the list), and workers on three hosts being 'dgx12', "
+        "'10.10.10.10', and 'dgx13'. "
+        "Note: --devs is currently ignored in multi-node mode and for each host "
+        "one worker per GPU will be launched.",
     )
 
     for args in args_list:


### PR DESCRIPTION
This PR adds the capability to run the existing benchmarks in multi-node mode, using `SSHCluster`.

There are still a few issues that probably can't be resolved in dask-cuda:

1. We have to sleep for some time to allow workers to spin and connect to the scheduler;
1. We have to manually call `client.shutdown()`/`client.close()` to force the cluster to terminate;
1. We see some errors when the cluster is being terminated using the method from the previous item.

I haven't spent any time trying to fix the issues above yet, but this should give us at least some room to benchmarks things more easily.