### PR TITLE
Add `nfinal` argument to shuffle_group, required in Dask >= 2.17

### DIFF
--- a/dask_cuda/explicit_comms/dataframe_merge.py
+++ b/dask_cuda/explicit_comms/dataframe_merge.py
@@ -95,7 +95,11 @@ def partition_by_hash(df, columns, n_chunks, ignore_index=False):
     # Hashing `columns` in `df` and assing it to the "_partitions" column
     df["_partitions"] = partitioning_index(df[columns], n_chunks)
     # Split `df` based on the hash values in the "_partitions" column
-    ret = shuffle_group(df, "_partitions", 0, n_chunks, n_chunks, ignore_index)
+    try:
+        # For Dask < 2.17 compatibility
+        ret = shuffle_group(df, "_partitions", 0, n_chunks, n_chunks, ignore_index)
+    except TypeError:
+        ret = shuffle_group(df, "_partitions", 0, n_chunks, n_chunks, ignore_index, n_chunks)
 
     # Let's remove the partition column and return the partitions
     del df["_partitions"]


### PR DESCRIPTION
This should fix recent CI build failures.

cc @raydouglass 