### PR TITLE
Initialize dask-cuda-worker parent process' UCX configuration

### DIFF
--- a/dask_cuda/dask_cuda_worker.py
+++ b/dask_cuda/dask_cuda_worker.py
@@ -23,6 +23,7 @@ from tornado import gen
 from tornado.ioloop import IOLoop, TimeoutError
 
 from .device_host_file import DeviceHostFile
+from .initialize import initialize
 from .local_cuda_cluster import cuda_visible_devices
 from .utils import (
     CPUAffinity,
@@ -307,6 +308,18 @@ def main(
                 "https://github.com/rapidsai/rmm"
             )  # pragma: no cover
         rmm_pool_size = parse_bytes(rmm_pool_size)
+
+    # Ensure this parent dask-cuda-worker process uses the same UCX
+    # configuration as child worker processes created by it.
+    initialize(
+        create_cuda_context=False,
+        enable_tcp_over_ucx=enable_tcp_over_ucx,
+        enable_infiniband=enable_infiniband,
+        enable_nvlink=enable_nvlink,
+        enable_rdmacm=enable_rdmacm,
+        net_devices=net_devices,
+        cuda_device_index=0,
+    )
 
     nannies = [
         t(

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -7,6 +7,7 @@ from distributed.utils import parse_bytes
 from distributed.worker import parse_memory_limit
 
 from .device_host_file import DeviceHostFile
+from .initialize import initialize
 from .utils import (
     CPUAffinity,
     RMMPool,

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -209,6 +209,15 @@ class LocalCUDACluster(LocalCluster):
         self.set_ucx_net_devices = enable_infiniband
         self.host = kwargs.get("host", None)
 
+        initialize(
+            enable_tcp_over_ucx=enable_tcp_over_ucx,
+            enable_nvlink=enable_nvlink,
+            enable_infiniband=enable_infiniband,
+            enable_rdmacm=enable_rdmacm,
+            net_devices=ucx_net_devices,
+            cuda_device_index=0,
+        )
+
         super().__init__(
             n_workers=0,
             threads_per_worker=threads_per_worker,


### PR DESCRIPTION
This ensures the main process is also using the correct UCX transports for a homogeneous cluster.