### PR TITLE
Fix-up versioneer

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,10 +23,10 @@ project = "dask-cuda"
 copyright = "2020, NVIDIA"
 author = "NVIDIA"
 
-# The short X.Y version.
-version = "0.14"
 # The full version, including alpha/beta/rc tags.
 release = "0.14.0"
+# The short X.Y version.
+version = "0.14"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,9 +23,9 @@ project = "dask-cuda"
 copyright = "2020, NVIDIA"
 author = "NVIDIA"
 
-# The short X.Y version
+# The short X.Y version.
 version = "0.14"
-# The full version, including alpha/beta/rc tags
+# The full version, including alpha/beta/rc tags.
 release = "0.14.0"
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,10 +24,10 @@ copyright = "2020, NVIDIA"
 author = "NVIDIA"
 
 # The full version, including alpha/beta/rc tags.
-release = "0.14.0"
+from dask_cuda import __version__ as release
 
 # The short X.Y version.
-version = "0.14"
+version = ".".join(release.split(".")[:2])
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,6 +25,7 @@ author = "NVIDIA"
 
 # The full version, including alpha/beta/rc tags.
 release = "0.14.0"
+
 # The short X.Y version.
 version = "0.14"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ VCS = git
 style = pep440
 versionfile_source = dask_cuda/_version.py
 versionfile_build = dask_cuda/_version.py
-tag_prefix =
+tag_prefix = v
 parentdir_prefix = dask_cuda-
 
 [flake8]


### PR DESCRIPTION
* Make sure the `v` prefix is stripped from the version
* Use `versioneer` to generate the version in the docs

Note: This is similar in nature to PR ( https://github.com/rapidsai/ucx-py/pull/537 ).