### PR TITLE
Require Distributed 2.15.0+

### DIFF
--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -25,7 +25,7 @@ requirements:
   run:
     - python x.x
     - dask-core >=2.4.0
-    - distributed >=2.7.0
+    - distributed >=2.15.0
     - pynvml >=8.0.3
     - numpy >=1.16.0
     - numba >=0.40.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dask>=2.9.0
-distributed>=2.11.0
+distributed>=2.15.0
 pynvml>=8.0.3
 numpy>=1.16.0
 numba>=0.40.1


### PR DESCRIPTION
This is needed for serialization fixes when working with collections of objects (particularly when they contain 5+ elements).

xref: https://github.com/dask/distributed/pull/3689
xref: https://github.com/rapidsai/dask-cuda/pull/286