### PR TITLE
Skip 2nd serialization pass of `DeviceSerialized`

### DIFF
--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -25,7 +25,7 @@ requirements:
   run:
     - python x.x
     - dask-core >=2.4.0
-    - distributed >=2.15.0
+    - distributed >=2.18.0
     - pynvml >=8.0.3
     - numpy >=1.16.0
     - numba >=0.40.1

--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -40,8 +40,8 @@ class DeviceSerialized:
 
 @dask_serialize.register(DeviceSerialized)
 def device_serialize(obj):
-    header = {"obj-header": dict(obj.header)}
-    frames = list(obj.frames)
+    header = {"obj-header": obj.header}
+    frames = obj.frames
     return header, frames
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dask>=2.9.0
-distributed>=2.15.0
+distributed>=2.18.0
 pynvml>=8.0.3
 numpy>=1.16.0
 numba>=0.40.1


### PR DESCRIPTION
Requires PR ( https://github.com/dask/distributed/pull/3639 ) (so latest Dask release)
Finishes the work in PR ( https://github.com/rapidsai/dask-cuda/pull/268 )

As `"dask"` serialization already converts a CUDA object into headers and frames that Dask is able to work with, drop code that tries to serialize frames on host further (as they are already as simple as they can be). Cuts a fair bit of boilerplate from the spilling path, which should simplify things a bit.