### PR TITLE
Fix tests related to latest RMM changes

### DIFF
--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -55,7 +55,6 @@ def test_cuda_visible_devices_and_memory_limit(loop):  # noqa: F811
         del os.environ["CUDA_VISIBLE_DEVICES"]
 
 
-@pytest.mark.xfail(reason="rmm.get_info removed by https://github.com/rapidsai/rmm/pull/363")
 def test_rmm_pool(loop):  # noqa: F811
     rmm = pytest.importorskip("rmm")
     with popen(["dask-scheduler", "--port", "9369", "--no-dashboard"]):
@@ -79,6 +78,6 @@ def test_rmm_pool(loop):  # noqa: F811
                         assert time() - start < 10
                         sleep(0.1)
 
-                memory_info = client.run(rmm.get_info)
-                for v in memory_info.values():
-                    assert v.total == 2000000000
+                memory_resource_type = client.run(rmm.mr.get_default_resource_type)
+                for v in memory_resource_type.values():
+                    assert v is rmm._lib.memory_resource.CNMemMemoryResource

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -55,6 +55,7 @@ def test_cuda_visible_devices_and_memory_limit(loop):  # noqa: F811
         del os.environ["CUDA_VISIBLE_DEVICES"]
 
 
+@pytest.mark.xfail(reason="rmm.get_info removed by https://github.com/rapidsai/rmm/pull/363")
 def test_rmm_pool(loop):  # noqa: F811
     rmm = pytest.importorskip("rmm")
     with popen(["dask-scheduler", "--port", "9369", "--no-dashboard"]):

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -106,6 +106,7 @@ async def test_n_workers():
         assert len(cluster.worker_spec) == 2
 
 
+@pytest.mark.xfail(reason="rmm.get_info removed by https://github.com/rapidsai/rmm/pull/363")
 @gen_test(timeout=20)
 async def test_rmm_pool():
     rmm = pytest.importorskip("rmm")

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -106,13 +106,12 @@ async def test_n_workers():
         assert len(cluster.worker_spec) == 2
 
 
-@pytest.mark.xfail(reason="rmm.get_info removed by https://github.com/rapidsai/rmm/pull/363")
 @gen_test(timeout=20)
 async def test_rmm_pool():
     rmm = pytest.importorskip("rmm")
 
     async with LocalCUDACluster(rmm_pool_size="2GB", asynchronous=True) as cluster:
         async with Client(cluster, asynchronous=True) as client:
-            memory_info = await client.run(rmm.get_info)
-            for v in memory_info.values():
-                assert v.total == 2000000000
+            memory_resource_type = await client.run(rmm.mr.get_default_resource_type)
+            for v in memory_resource_type.values():
+                assert v is rmm._lib.memory_resource.CNMemMemoryResource

--- a/dask_cuda/tests/test_utils.py
+++ b/dask_cuda/tests/test_utils.py
@@ -55,6 +55,7 @@ def test_cpu_affinity():
         assert list(os.sched_getaffinity(0)) == affinity
 
 
+@pytest.mark.xfail(reason="https://github.com/rapidsai/dask-cuda/issues/313")
 def test_get_device_total_memory():
     # Ensure Numba is using its own memory manager, rather than RMM's
     cuda.set_memory_manager(cuda.cudadrv.driver.NumbaCUDAMemoryManager)

--- a/dask_cuda/tests/test_utils.py
+++ b/dask_cuda/tests/test_utils.py
@@ -56,6 +56,9 @@ def test_cpu_affinity():
 
 
 def test_get_device_total_memory():
+    # Ensure Numba is using its own memory manager, rather than RMM's
+    cuda.set_memory_manager(cuda.cudadrv.driver.NumbaCUDAMemoryManager)
+
     for i in range(get_n_gpus()):
         with cuda.gpus[i]:
             assert (


### PR DESCRIPTION
Ensure we use Numba memory manager or xfail tests for which there's not yet a fix, may change with https://github.com/rapidsai/rmm/pull/391 .

cc @jakirkham 