### PR TITLE
Fix and improve DGX tests

### DIFF
--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import os
 
-from dask_cuda.utils import wait_workers
+from dask_cuda.utils import get_gpu_count, wait_workers
 from distributed import Client
 from distributed.system import MEMORY_LIMIT
 from distributed.utils_test import loop  # noqa: F401
@@ -27,7 +27,7 @@ def test_cuda_visible_devices_and_memory_limit(loop):  # noqa: F811
                 ]
             ):
                 with Client("127.0.0.1:9359", loop=loop) as client:
-                    assert wait_workers(client)
+                    assert wait_workers(client, n_gpus=4)
 
                     def get_visible_devices():
                         return os.environ["CUDA_VISIBLE_DEVICES"]
@@ -62,7 +62,7 @@ def test_rmm_pool(loop):  # noqa: F811
             ]
         ):
             with Client("127.0.0.1:9369", loop=loop) as client:
-                assert wait_workers(client)
+                assert wait_workers(client, n_gpus=get_gpu_count())
 
                 memory_resource_type = client.run(rmm.mr.get_default_resource_type)
                 for v in memory_resource_type.values():

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -1,11 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
 import os
-from time import sleep
 
 from dask_cuda.utils import wait_workers
 from distributed import Client
-from distributed.metrics import time
 from distributed.system import MEMORY_LIMIT
 from distributed.utils_test import loop  # noqa: F401
 from distributed.utils_test import popen

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -1,11 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
 import os
-from time import sleep
 
-from dask_cuda.utils import get_gpu_count
+from dask_cuda.utils import get_gpu_count, wait_workers
 from distributed import Client
-from distributed.metrics import time
 from distributed.system import MEMORY_LIMIT
 from distributed.utils_test import loop  # noqa: F401
 from distributed.utils_test import popen
@@ -29,13 +27,7 @@ def test_cuda_visible_devices_and_memory_limit(loop):  # noqa: F811
                 ]
             ):
                 with Client("127.0.0.1:9359", loop=loop) as client:
-                    start = time()
-                    while True:
-                        if len(client.scheduler_info()["workers"]) == 4:
-                            break
-                        else:
-                            assert time() - start < 10
-                            sleep(0.1)
+                    assert wait_workers(client, n_gpus=4)
 
                     def get_visible_devices():
                         return os.environ["CUDA_VISIBLE_DEVICES"]
@@ -70,13 +62,7 @@ def test_rmm_pool(loop):  # noqa: F811
             ]
         ):
             with Client("127.0.0.1:9369", loop=loop) as client:
-                start = time()
-                while True:
-                    if len(client.scheduler_info()["workers"]) == get_gpu_count():
-                        break
-                    else:
-                        assert time() - start < 10
-                        sleep(0.1)
+                assert wait_workers(client, n_gpus=get_gpu_count())
 
                 memory_resource_type = client.run(rmm.mr.get_default_resource_type)
                 for v in memory_resource_type.values():

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+from time import sleep
 
-from dask_cuda.utils import get_gpu_count, wait_workers
+from dask_cuda.utils import get_gpu_count
 from distributed import Client
+from distributed.metrics import time
 from distributed.system import MEMORY_LIMIT
 from distributed.utils_test import loop  # noqa: F401
 from distributed.utils_test import popen
@@ -27,7 +29,13 @@ def test_cuda_visible_devices_and_memory_limit(loop):  # noqa: F811
                 ]
             ):
                 with Client("127.0.0.1:9359", loop=loop) as client:
-                    assert wait_workers(client, n_gpus=4)
+                    start = time()
+                    while True:
+                        if len(client.scheduler_info()["workers"]) == 4:
+                            break
+                        else:
+                            assert time() - start < 10
+                            sleep(0.1)
 
                     def get_visible_devices():
                         return os.environ["CUDA_VISIBLE_DEVICES"]
@@ -62,7 +70,13 @@ def test_rmm_pool(loop):  # noqa: F811
             ]
         ):
             with Client("127.0.0.1:9369", loop=loop) as client:
-                assert wait_workers(client, n_gpus=get_gpu_count())
+                start = time()
+                while True:
+                    if len(client.scheduler_info()["workers"]) == get_gpu_count():
+                        break
+                    else:
+                        assert time() - start < 10
+                        sleep(0.1)
 
                 memory_resource_type = client.run(rmm.mr.get_default_resource_type)
                 for v in memory_resource_type.values():

--- a/dask_cuda/tests/test_dgx.py
+++ b/dask_cuda/tests/test_dgx.py
@@ -228,6 +228,8 @@ def _test_dask_cuda_worker_ucx_net_devices(enable_rdmacm):
     sched_env = os.environ.copy()
     sched_env["DASK_UCX__INFINIBAND"] = "True"
     sched_env["DASK_UCX__TCP"] = "True"
+    sched_env["DASK_UCX__CUDA_COPY"] = "True"
+    sched_env["DASK_UCX__NET_DEVICES"] = openfabrics_devices[0]
 
     if enable_rdmacm:
         sched_env["DASK_UCX__RDMACM"] = "True"
@@ -246,7 +248,10 @@ def _test_dask_cuda_worker_ucx_net_devices(enable_rdmacm):
 
     # Enable proper variables for client
     initialize(
-        enable_tcp_over_ucx=True, enable_infiniband=True, enable_rdmacm=enable_rdmacm
+        enable_tcp_over_ucx=True,
+        enable_infiniband=True,
+        enable_rdmacm=enable_rdmacm,
+        net_devices=openfabrics_devices[0],
     )
 
     with subprocess.Popen(

--- a/dask_cuda/tests/test_dgx.py
+++ b/dask_cuda/tests/test_dgx.py
@@ -8,7 +8,6 @@ from dask_cuda import LocalCUDACluster
 from dask_cuda.initialize import initialize
 from dask_cuda.utils import wait_workers
 from distributed import Client
-from distributed.metrics import time
 from distributed.utils import get_ip_interface
 
 import numpy

--- a/dask_cuda/tests/test_dgx.py
+++ b/dask_cuda/tests/test_dgx.py
@@ -51,7 +51,7 @@ def _get_dgx_version():
 
 
 def _get_dgx_net_devices():
-    if _get_dgx_version() == DGXVersion.DGX_A100:
+    if _get_dgx_version() == DGXVersion.DGX_1:
         return [
             "mlx5_0:1,ib0",
             "mlx5_0:1,ib0",

--- a/dask_cuda/tests/test_dgx.py
+++ b/dask_cuda/tests/test_dgx.py
@@ -1,6 +1,7 @@
 import multiprocessing as mp
 import os
 import subprocess
+from enum import Enum, auto
 from time import sleep
 
 import dask.array as da
@@ -19,25 +20,38 @@ ucp = pytest.importorskip("ucp")
 psutil = pytest.importorskip("psutil")
 
 
-def _check_dgx_version():
+class DGXVersion(Enum):
+    DGX_1 = auto()
+    DGX_2 = auto()
+    DGX_A100 = auto()
+
+
+def _get_dgx_name():
+    product_name_file = "/sys/class/dmi/id/product_name"
+
+    if not os.path.isfile(product_name_file):
+        return None
+
+    for line in open(product_name_file):
+        return line
+
+
+def _get_dgx_version():
     dgx_server = None
+    dgx_name = _get_dgx_name()
 
-    if not os.path.isfile("/etc/dgx-release"):
-        return dgx_server
-
-    for line in open("/etc/dgx-release"):
-        if line.startswith("DGX_PLATFORM"):
-            if "DGX Server for DGX-1" in line:
-                dgx_server = 1
-            elif "DGX Server for DGX-2" in line:
-                dgx_server = 2
-            break
+    if "DGX-1" in dgx_name:
+        dgx_server = DGXVersion.DGX_1
+    elif "DGX-2" in dgx_name:
+        dgx_server = DGXVersion.DGX_2
+    elif "DGXA100" in dgx_name:
+        dgx_server = DGXVersion.DGX_A100
 
     return dgx_server
 
 
 def _get_dgx_net_devices():
-    if _check_dgx_version() == 1:
+    if _get_dgx_version() == DGXVersion.DGX_A100:
         return [
             "mlx5_0:1,ib0",
             "mlx5_0:1,ib0",
@@ -48,7 +62,7 @@ def _get_dgx_net_devices():
             "mlx5_3:1,ib3",
             "mlx5_3:1,ib3",
         ]
-    elif _check_dgx_version() == 2:
+    elif _get_dgx_version() == DGXVersion.DGX_2:
         return [
             "mlx5_0:1,ib0",
             "mlx5_0:1,ib0",
@@ -71,7 +85,7 @@ def _get_dgx_net_devices():
         return None
 
 
-if _check_dgx_version() is None:
+if _get_dgx_version() is None:
     pytest.skip("Not a DGX server", allow_module_level=True)
 
 
@@ -200,6 +214,10 @@ def _test_ucx_infiniband_nvlink(enable_infiniband, enable_nvlink, enable_rdmacm)
         {"enable_infiniband": True, "enable_nvlink": True, "enable_rdmacm": True},
     ],
 )
+@pytest.mark.skipif(
+    _get_dgx_version() == DGXVersion.DGX_A100,
+    reason="Automatic InfiniBand device detection Unsupported for %s" % _get_dgx_name(),
+)
 def test_ucx_infiniband_nvlink(params):
     p = mp.Process(
         target=_test_ucx_infiniband_nvlink,
@@ -311,6 +329,10 @@ def _test_dask_cuda_worker_ucx_net_devices(enable_rdmacm):
 
 
 @pytest.mark.parametrize("enable_rdmacm", [False, True])
+@pytest.mark.skipif(
+    _get_dgx_version() == DGXVersion.DGX_A100,
+    reason="Automatic InfiniBand device detection Unsupported for %s" % _get_dgx_name(),
+)
 def test_dask_cuda_worker_ucx_net_devices(enable_rdmacm):
     p = mp.Process(
         target=_test_dask_cuda_worker_ucx_net_devices, args=(enable_rdmacm,),

--- a/dask_cuda/tests/test_dgx.py
+++ b/dask_cuda/tests/test_dgx.py
@@ -6,7 +6,7 @@ from time import sleep
 import dask.array as da
 from dask_cuda import LocalCUDACluster
 from dask_cuda.initialize import initialize
-from dask_cuda.utils import get_gpu_count
+from dask_cuda.utils import get_n_gpus
 from distributed import Client
 from distributed.metrics import time
 from distributed.utils import get_ip_interface
@@ -277,11 +277,16 @@ def _test_dask_cuda_worker_ucx_net_devices(enable_rdmacm):
 
                 start = time()
                 while True:
-                    if len(client.scheduler_info()["workers"]) == get_gpu_count():
+                    n_gpus = get_n_gpus()
+                    if len(client.scheduler_info()["workers"]) == n_gpus:
                         break
-                    else:
-                        assert time() - start < 10
-                        sleep(0.1)
+                    elif time() - start > 2 * n_gpus:
+                        # We need to ensure processes are terminated to avoid hangs
+                        # if a timeout occurs, and then raise an assertion error
+                        worker_proc.kill()
+                        sched_proc.kill()
+                        assert time() - start < 2 * n_gpus
+                    sleep(0.1)
 
                 workers_tls = client.run(lambda: ucp.get_config()["TLS"])
                 workers_tls_priority = client.run(

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -34,7 +34,7 @@ async def test_local_cuda_cluster():
             assert full_mem >= MEMORY_LIMIT - 1024 and full_mem < MEMORY_LIMIT + 1024
 
             for w, devices in result.items():
-                ident = devices[0]
+                ident = devices.split(",")[0]
                 assert int(ident) == cluster.scheduler.workers[w].name
 
             with pytest.raises(ValueError):

--- a/dask_cuda/tests/test_utils.py
+++ b/dask_cuda/tests/test_utils.py
@@ -52,7 +52,7 @@ def test_cpu_affinity():
     for i in range(get_n_gpus()):
         affinity = get_cpu_affinity(i)
         os.sched_setaffinity(0, affinity)
-        assert list(os.sched_getaffinity(0)) == affinity
+        assert os.sched_getaffinity(0) == set(affinity)
 
 
 def test_get_device_total_memory():

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -334,15 +334,16 @@ def wait_workers(client, min_timeout=10, seconds_per_gpu=2, timeout_callback=Non
     -------
     True if all workers were started, False if a timeout occurs.
     """
-    start = time.time()
     n_gpus = get_n_gpus()
-    timeout = max(10, seconds_per_gpu * n_gpus)
+    timeout = max(min_timeout, seconds_per_gpu * n_gpus)
+
+    start = time.time()
     while True:
         if len(client.scheduler_info()["workers"]) == n_gpus:
-            break
+            return True
         elif time.time() - start > timeout:
             if callable(timeout_callback):
                 timeout_callback()
             return False
-        time.sleep(0.1)
-    return True
+        else:
+            time.sleep(0.1)

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -310,7 +310,9 @@ def get_preload_options(
     return preload_options
 
 
-def wait_workers(client, min_timeout=10, seconds_per_gpu=2, timeout_callback=None):
+def wait_workers(
+    client, min_timeout=10, seconds_per_gpu=2, n_gpus=None, timeout_callback=None
+):
     """
     Wait for workers to be available. When a timeout occurs, a callback
     is executed if specified. Generally used for tests.
@@ -326,6 +328,9 @@ def wait_workers(client, min_timeout=10, seconds_per_gpu=2, timeout_callback=Non
         value is 2 and there is a total of 8 GPUs (workers) being started,
         a timeout will occur after 16 seconds. Note that this value is only
         used as timeout when larger than min_timeout.
+    n_gpus: None or int
+        If specified, will wait for a that amount of GPUs (i.e., Dask workers)
+        to come online, else waits for a total of `get_n_gpus` workers.
     timeout_callback: None or callable
         A callback function to be executed if a timeout occurs, ignored if
         None.
@@ -334,7 +339,7 @@ def wait_workers(client, min_timeout=10, seconds_per_gpu=2, timeout_callback=Non
     -------
     True if all workers were started, False if a timeout occurs.
     """
-    n_gpus = get_n_gpus()
+    n_gpus = n_gpus or get_n_gpus()
     timeout = max(min_timeout, seconds_per_gpu * n_gpus)
 
     start = time.time()

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -310,7 +310,7 @@ def get_preload_options(
     return preload_options
 
 
-def wait_workers(client, seconds_per_gpu=2, timeout_callback=None):
+def wait_workers(client, min_timeout=10, seconds_per_gpu=2, timeout_callback=None):
     """
     Wait for workers to be available. When a timeout occurs, a callback
     is executed if specified. Generally used for tests.
@@ -319,10 +319,13 @@ def wait_workers(client, seconds_per_gpu=2, timeout_callback=None):
     ----------
     client: distributed.Client
         Instance of client, used to query for number of workers connected.
+    min_timeout: float
+        Minimum number of seconds to wait before timeout.
     seconds_per_gpu: float
         Seconds to wait for each GPU on the system. For example, if its
         value is 2 and there is a total of 8 GPUs (workers) being started,
-        a timeout will occur after 16 seconds.
+        a timeout will occur after 16 seconds. Note that this value is only
+        used as timeout when larger than min_timeout.
     timeout_callback: None or callable
         A callback function to be executed if a timeout occurs, ignored if
         None.
@@ -332,11 +335,12 @@ def wait_workers(client, seconds_per_gpu=2, timeout_callback=None):
     True if all workers were started, False if a timeout occurs.
     """
     start = time.time()
+    n_gpus = get_n_gpus()
+    timeout = max(10, seconds_per_gpu * n_gpus)
     while True:
-        n_gpus = get_n_gpus()
         if len(client.scheduler_info()["workers"]) == n_gpus:
             break
-        elif time.time() - start > seconds_per_gpu * n_gpus:
+        elif time.time() - start > timeout:
             if callable(timeout_callback):
                 timeout_callback()
             return False


### PR DESCRIPTION
Pass `UCX_NET_DEVICES` to scheduler and client processes, as RDMACM requires an IB device to work. Ensures that `UCX_NET_DEVICES` test also works for systems with many GPUs, such as a DGX-2. Add support for DGX A100 where already possible.