### PR TITLE
Install dependencies via meta package

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -57,9 +57,12 @@ conda list
 # Fixing Numpy version to avoid RuntimeWarning: numpy.ufunc size changed, may
 # indicate binary incompatibility. Expected 192 from C header, got 216 from PyObject
 conda install "cudatoolkit=$CUDA_REL" \
-              "cupy>=6.5.0" "numpy=1.16.4" \
               "cudf=${MINOR_VERSION}" "dask-cudf=${MINOR_VERSION}" \
-              "dask>=2.8.1" "distributed>=2.8.1"
+              "rapids-build-env=$MINOR_VERSION.*"
+
+# https://docs.rapids.ai/maintainers/depmgmt/ 
+# conda remove -f rapids-build-env
+# conda install "your-pkg=1.0.0"
 
 # needed for async tests
 conda install -c conda-forge "pytest" "pytest-asyncio"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -58,17 +58,13 @@ conda list
 # indicate binary incompatibility. Expected 192 from C header, got 216 from PyObject
 conda install "cudatoolkit=$CUDA_REL" \
               "cudf=${MINOR_VERSION}" "dask-cudf=${MINOR_VERSION}" \
+              "ucx-py=$MINOR_VERSION.*" "ucx-proc=*=gpu" \
               "rapids-build-env=$MINOR_VERSION.*"
 
 # https://docs.rapids.ai/maintainers/depmgmt/ 
 # conda remove -f rapids-build-env
 # conda install "your-pkg=1.0.0"
 
-# needed for async tests
-conda install -c conda-forge "pytest" "pytest-asyncio"
-
-# Use nightly build of ucx-py for now
-conda install -c rapidsai-nightly "ucx-py" "ucx-proc=*=gpu"
 
 conda list
 


### PR DESCRIPTION
Install dependencies via `rapids-build-env` (which is pre-installed in the containers).

This brings the repo in line with https://docs.rapids.ai/maintainers/depmgmt/

Depends on https://github.com/rapidsai/integration/pull/49