### PR TITLE
Use RMM `pool-size` from config (if unspecified)

### DIFF
--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -156,7 +156,7 @@ class LocalCUDACluster(LocalCluster):
         )
         self.device_memory_limit = device_memory_limit
 
-        self.rmm_pool_size = rmm_pool_size
+        self.rmm_pool_size = rmm_pool_size or dask.config.get("rmm.pool-size")
         if rmm_pool_size is not None:
             try:
                 import rmm  # noqa F401


### PR DESCRIPTION
Builds off of PR ( https://github.com/dask/distributed/pull/3515 )

If the user does not specify the RMM `pool-size`, try grabbing it from the `distributed.yaml` config. By default, that is disabled as well.