### PR TITLE
Add missing __init__.py to dask_cuda/cli

### DIFF
--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -107,7 +107,7 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 )
 @click.option("--pid-file", type=str, default="", help="File to write the process PID")
 @click.option(
-    "--local-directory", default="", type=str, help="Directory to place worker files"
+    "--local-directory", default=None, type=str, help="Directory to place worker files"
 )
 @click.option(
     "--resources",

--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -91,8 +91,10 @@ class DeviceHostFile(ZictBase):
     ):
         if local_directory is None:
             local_directory = dask.config.get("temporary-directory") or os.getcwd()
+
+        if not os.path.exists(local_directory):
             os.makedirs(local_directory, exist_ok=True)
-            local_directory = os.path.join(local_directory, "dask-worker-space")
+        local_directory = os.path.join(local_directory, "dask-worker-space")
 
         self.disk_func_path = os.path.join(local_directory, "storage")
 


### PR DESCRIPTION
Fixes `ModuleNotFoundError: No module named 'dask_cuda.cli'` when starting `dask-cuda-worker` .