### PR TITLE
Make sure `del` clears keys from `host_buffer`

### DIFF
--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -1,3 +1,4 @@
+import contextlib
 import functools
 import os
 
@@ -146,3 +147,5 @@ class DeviceHostFile(ZictBase):
     def __delitem__(self, key):
         self.device_keys.discard(key)
         del self.device_buffer[key]
+        with contextlib.suppress(KeyError):
+            del self.host_buffer[key]

--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -146,6 +146,7 @@ class DeviceHostFile(ZictBase):
 
     def __delitem__(self, key):
         self.device_keys.discard(key)
-        del self.device_buffer[key]
+        with contextlib.suppress(KeyError):
+            del self.device_buffer[key]
         with contextlib.suppress(KeyError):
             del self.host_buffer[key]


### PR DESCRIPTION
As `host_buffer` can still contain the spilled value, make sure to remove that when `del` is called. Since it is possible the value was not spilled to the `host_buffer`, make sure a `KeyError` that could be thrown here is ignored.