### PR TITLE
Add support for RMM managed memory

### DIFF
--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -100,6 +100,14 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     "an integer (bytes) or string (like 5GB or 5000M).",
 )
 @click.option(
+    "--rmm-managed-memory/--no-rmm-managed-memory",
+    default=False,
+    help="If enabled, initialize each worker with RMM and set it to "
+    "use managed memory. If disabled, RMM may still be used if "
+    "--rmm-pool-size is specified, but in that case with default "
+    "(non-managed) memory type.",
+)
+@click.option(
     "--reconnect/--no-reconnect",
     default=True,
     help="Reconnect to scheduler if disconnected",
@@ -188,6 +196,7 @@ def main(
     memory_limit,
     device_memory_limit,
     rmm_pool_size,
+    rmm_managed_memory,
     pid_file,
     resources,
     dashboard,
@@ -223,6 +232,7 @@ def main(
         memory_limit,
         device_memory_limit,
         rmm_pool_size,
+        rmm_managed_memory,
         pid_file,
         resources,
         dashboard,

--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -105,7 +105,9 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     help="If enabled, initialize each worker with RMM and set it to "
     "use managed memory. If disabled, RMM may still be used if "
     "--rmm-pool-size is specified, but in that case with default "
-    "(non-managed) memory type.",
+    "(non-managed) memory type."
+    "WARNING: managed memory is currently incompatible with NVLink, "
+    "trying to enable both will result in an exception.",
 )
 @click.option(
     "--reconnect/--no-reconnect",

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -143,6 +143,11 @@ class CUDAWorker:
             if rmm_pool_size is not None:
                 rmm_pool_size = parse_bytes(rmm_pool_size)
 
+        if enable_nvlink and rmm_managed_memory:
+            raise ValueError(
+                "RMM managed memory and NVLink are currently incompatible."
+            )
+
         # Ensure this parent dask-cuda-worker process uses the same UCX
         # configuration as child worker processes created by it.
         initialize(

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -103,10 +103,12 @@ class LocalCUDACluster(LocalCluster):
     rmm_pool_size: None, int or str
         When None (default), no RMM pool is initialized. If a different value
         is given, it can be an integer (bytes) or string (like 5GB or 5000M).
-    rmm_pool_size: bool
+    rmm_managed_memory: bool
         If True, initialize each worker with RMM and set it to use managed
         memory. If False, RMM may still be used if `rmm_pool_size` is specified,
         but in that case with default (non-managed) memory type.
+        WARNING: managed memory is currently incompatible with NVLink, trying
+        to enable both will result in an exception.
 
     Examples
     --------
@@ -122,7 +124,8 @@ class LocalCUDACluster(LocalCluster):
     ValueError
         If ucx_net_devices is an empty string, or if it is "auto" and UCX-Py is
         not installed, or if it is "auto" and enable_infiniband=False, or UCX-Py
-        wasn't compiled with hwloc support.
+        wasn't compiled with hwloc support, or both RMM managed memory and
+        NVLink are enabled.
 
     See Also
     --------

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -10,7 +10,7 @@ from .device_host_file import DeviceHostFile
 from .initialize import initialize
 from .utils import (
     CPUAffinity,
-    RMMPool,
+    RMMSetup,
     get_cpu_affinity,
     get_device_total_memory,
     get_n_gpus,
@@ -102,7 +102,11 @@ class LocalCUDACluster(LocalCluster):
         interfaces are connected and properly configured.
     rmm_pool_size: None, int or str
         When None (default), no RMM pool is initialized. If a different value
-        is given, it can be an integer (bytes) or string (like 5GB or 5000M)."
+        is given, it can be an integer (bytes) or string (like 5GB or 5000M).
+    rmm_pool_size: bool
+        If True, initialize each worker with RMM and set it to use managed
+        memory. If False, RMM may still be used if `rmm_pool_size` is specified,
+        but in that case with default (non-managed) memory type.
 
     Examples
     --------
@@ -142,6 +146,7 @@ class LocalCUDACluster(LocalCluster):
         enable_rdmacm=False,
         ucx_net_devices=None,
         rmm_pool_size=None,
+        rmm_managed_memory=False,
         **kwargs,
     ):
         if CUDA_VISIBLE_DEVICES is None:
@@ -157,16 +162,18 @@ class LocalCUDACluster(LocalCluster):
         self.device_memory_limit = device_memory_limit
 
         self.rmm_pool_size = rmm_pool_size
-        if rmm_pool_size is not None:
+        self.rmm_managed_memory = rmm_managed_memory
+        if rmm_pool_size is not None or rmm_managed_memory:
             try:
                 import rmm  # noqa F401
             except ImportError:
                 raise ValueError(
-                    "RMM pool requested but module 'rmm' is not available. "
-                    "For installation instructions, please see "
-                    "https://github.com/rapidsai/rmm"
+                    "RMM pool or managed memory requested but module 'rmm' "
+                    "is not available. For installation instructions, please "
+                    "see https://github.com/rapidsai/rmm"
                 )  # pragma: no cover
-            self.rmm_pool_size = parse_bytes(self.rmm_pool_size)
+            if self.rmm_pool_size is not None:
+                self.rmm_pool_size = parse_bytes(self.rmm_pool_size)
 
         if not processes:
             raise ValueError(
@@ -265,7 +272,7 @@ class LocalCUDACluster(LocalCluster):
                 "env": {"CUDA_VISIBLE_DEVICES": visible_devices,},
                 "plugins": {
                     CPUAffinity(get_cpu_affinity(worker_count)),
-                    RMMPool(self.rmm_pool_size),
+                    RMMSetup(self.rmm_pool_size, self.rmm_managed_memory),
                 },
             }
         )

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -48,7 +48,7 @@ def test_cuda_visible_devices_and_memory_limit(loop):  # noqa: F811
         del os.environ["CUDA_VISIBLE_DEVICES"]
 
 
-def test_rmm_pool(loop):  # noqa: F811
+def test_rmm(loop):  # noqa: F811
     rmm = pytest.importorskip("rmm")
     with popen(["dask-scheduler", "--port", "9369", "--no-dashboard"]):
         with popen(
@@ -59,6 +59,7 @@ def test_rmm_pool(loop):  # noqa: F811
                 "127.0.0.1",
                 "--rmm-pool-size",
                 "2 GB",
+                "--rmm-managed-memory",
                 "--no-dashboard",
             ]
         ):
@@ -67,4 +68,4 @@ def test_rmm_pool(loop):  # noqa: F811
 
                 memory_resource_type = client.run(rmm.mr.get_default_resource_type)
                 for v in memory_resource_type.values():
-                    assert v is rmm._lib.memory_resource.CNMemMemoryResource
+                    assert v is rmm._lib.memory_resource.CNMemManagedMemoryResource

--- a/dask_cuda/tests/test_explicit_comms.py
+++ b/dask_cuda/tests/test_explicit_comms.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+import dask
 from dask import dataframe as dd
 from distributed import Client
 from distributed.deploy.local import LocalCluster
@@ -45,6 +46,12 @@ def test_local_cluster(protocol):
 
 
 def _test_dataframe_merge(backend, protocol, n_workers):
+    dask.config.update(
+        dask.config.global_config,
+        {"ucx": {"TLS": "tcp,sockcm,cuda_copy",},},
+        priority="new",
+    )
+
     with LocalCluster(
         protocol=protocol,
         dashboard_address=None,

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -108,11 +108,13 @@ async def test_n_workers():
 
 
 @gen_test(timeout=20)
-async def test_rmm_pool():
+async def test_rmm():
     rmm = pytest.importorskip("rmm")
 
-    async with LocalCUDACluster(rmm_pool_size="2GB", asynchronous=True) as cluster:
+    async with LocalCUDACluster(
+        rmm_pool_size="2GB", rmm_managed_memory=True, asynchronous=True
+    ) as cluster:
         async with Client(cluster, asynchronous=True) as client:
             memory_resource_type = await client.run(rmm.mr.get_default_resource_type)
             for v in memory_resource_type.values():
-                assert v is rmm._lib.memory_resource.CNMemMemoryResource
+                assert v is rmm._lib.memory_resource.CNMemManagedMemoryResource

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -219,6 +219,7 @@ def get_ucx_config(
         "rdmacm": None,
         "net-devices": None,
         "cuda_copy": None,
+        "reuse-endpoints": True,
     }
     if enable_tcp_over_ucx or enable_infiniband or enable_nvlink:
         ucx_config["cuda_copy"] = True

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -28,16 +28,21 @@ class CPUAffinity:
         os.sched_setaffinity(0, self.cores)
 
 
-class RMMPool:
-    def __init__(self, nbytes):
+class RMMSetup:
+    def __init__(self, nbytes, managed_memory):
         self.nbytes = nbytes
+        self.managed_memory = managed_memory
 
     def setup(self, worker=None):
-        if self.nbytes is not None:
+        if self.nbytes is not None or self.managed_memory is True:
             import rmm
 
+            pool_allocator = False if self.nbytes is None else True
+
             rmm.reinitialize(
-                pool_allocator=True, managed_memory=False, initial_pool_size=self.nbytes
+                pool_allocator=pool_allocator,
+                managed_memory=self.managed_memory,
+                initial_pool_size=self.nbytes,
             )
 
 


### PR DESCRIPTION
Add support for RMM managed memory via `dask-cuda-worker`/`LocalCUDACluster` parameters.

Fixes #341 .