### PR TITLE
[REVIEW] Update CI scripts to remove references to master [skip ci] 

### DIFF
--- a/ci/cpu/upload-pypi.sh
+++ b/ci/cpu/upload-pypi.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 set -e
 
-SOURCE_BRANCH=master
 
-# Restrict uploads to master branch
-if [ ${GIT_BRANCH} != ${SOURCE_BRANCH} ]; then
+if [ ${BUILD_MODE} != "branch" ]; then
   echo "Skipping upload"
   return 0
 fi


### PR DESCRIPTION
This PR removes unecessary references to master or updates references to the new main branch in CI scripts and other OPS-owned files.