### PR TITLE
Fix isort and black line length

### DIFF
--- a/ci/checks/style.sh
+++ b/ci/checks/style.sh
@@ -12,7 +12,7 @@ PATH=/conda/bin:$PATH
 source activate gdf
 
 # Run isort and get results/return code
-ISORT=`isort --recursive --check-only .`
+ISORT=`isort --check-only .`
 ISORT_RETVAL=$?
 
 # Run black and get results/return code

--- a/dask_cuda/explicit_comms/comms.py
+++ b/dask_cuda/explicit_comms/comms.py
@@ -5,11 +5,7 @@ import uuid
 
 import distributed.comm
 from distributed import default_client, get_worker
-from distributed.comm.addressing import (
-    parse_address,
-    parse_host_port,
-    unparse_address,
-)
+from distributed.comm.addressing import parse_address, parse_host_port, unparse_address
 
 from . import utils
 

--- a/dask_cuda/tests/test_device_host_file.py
+++ b/dask_cuda/tests/test_device_host_file.py
@@ -8,11 +8,7 @@ import dask
 from dask import array as da
 from distributed.protocol import deserialize_bytes, serialize_bytelist
 
-from dask_cuda.device_host_file import (
-    DeviceHostFile,
-    device_to_host,
-    host_to_device,
-)
+from dask_cuda.device_host_file import DeviceHostFile, device_to_host, host_to_device
 
 cupy = pytest.importorskip("cupy")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ parentdir_prefix = dask_cuda-
 
 [flake8]
 exclude = docs, __init__.py, versioneer.py
-max-line-length = 88
+max_line_length = 88
 ignore =
     # Assigning lambda expression
     E731
@@ -22,7 +22,7 @@ ignore =
     E231
 
 [isort]
-line_length=79
+line_length=88
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0


### PR DESCRIPTION
Appears that isort and black (via flake8) had different line lengths, which clashed with each other resulting in the lint always failing. This makes sure isort uses the same line length that black (and flake8) use. Also reruns isort, black, and flake8 to make sure everything is copacetic.