### PR TITLE
Just-in-time deserialization

### DIFF
--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -29,7 +29,6 @@ requirements:
     - pynvml >=8.0.3
     - numpy >=1.16.0
     - numba >=0.50.0,!=0.51.0
-    - pandas >=1.0,<1.2.0dev0
 
 test:
   imports:

--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - setuptools
   run:
     - python x.x
-    - dask-core >=2.4.0
+    - dask >=2.4.0
     - distributed >=2.18.0
     - pynvml >=8.0.3
     - numpy >=1.16.0

--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - pynvml >=8.0.3
     - numpy >=1.16.0
     - numba >=0.50.0,!=0.51.0
+    - pandas >=1.0,<1.2.0dev0
 
 test:
   imports:

--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -190,6 +190,11 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     "InfiniBand only and will still cause unpredictable errors if not _ALL_ "
     "interfaces are connected and properly configured.",
 )
+@click.option(
+    "--enable-jit-unspill/--disable-jit-unspill",
+    default=None,  # If not specified, use Dask config
+    help="Enable just-in-time unspilling",
+)
 def main(
     scheduler,
     host,
@@ -217,6 +222,7 @@ def main(
     enable_nvlink,
     enable_rdmacm,
     net_devices,
+    enable_jit_unspill,
     **kwargs,
 ):
     if tls_ca_file and tls_cert and tls_key:
@@ -251,6 +257,7 @@ def main(
         enable_nvlink,
         enable_rdmacm,
         net_devices,
+        enable_jit_unspill,
         **kwargs,
     )
 

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -71,6 +71,7 @@ class CUDAWorker:
         enable_nvlink=False,
         enable_rdmacm=False,
         net_devices=None,
+        jit_unspill=None,
         **kwargs,
     ):
         # Required by RAPIDS libraries (e.g., cuDF) to ensure no context
@@ -177,6 +178,11 @@ class CUDAWorker:
             cuda_device_index=0,
         )
 
+        if jit_unspill is None:
+            self.jit_unspill = dask.config.get("jit-unspill", default=False)
+        else:
+            self.jit_unspill = jit_unspill
+
         self.nannies = [
             t(
                 scheduler,
@@ -219,6 +225,7 @@ class CUDAWorker:
                         else parse_bytes(device_memory_limit),
                         "memory_limit": memory_limit,
                         "local_directory": local_directory,
+                        "jit_unspill": self.jit_unspill,
                     },
                 ),
                 **kwargs,

--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -6,6 +6,8 @@ from zict.common import ZictBase
 
 import dask
 from distributed.protocol import (
+    dask_deserialize,
+    dask_serialize,
     deserialize,
     deserialize_bytes,
     serialize,
@@ -38,6 +40,18 @@ class DeviceSerialized:
         header, frames = device_serialize(self)
         frames = [f.obj for f in frames]
         return device_deserialize, (header, frames)
+
+
+@dask_serialize.register(DeviceSerialized)
+def device_serialize(obj):
+    header = {"obj-header": obj.header}
+    frames = obj.frames
+    return header, frames
+
+
+@dask_deserialize.register(DeviceSerialized)
+def device_deserialize(header, frames):
+    return DeviceSerialized(header["obj-header"], frames)
 
 
 @nvtx_annotate("SPILL_D2H", color="red", domain="dask_cuda")

--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -97,6 +97,8 @@ class DeviceHostFile(ZictBase):
         implies no spilling to disk.
     local_directory: path
         Path where to store serialized objects on disk
+    jit_unspill: bool
+        If True, enable just-in-time unspilling (see proxy_object.ObjectProxy).
     """
 
     def __init__(
@@ -104,7 +106,7 @@ class DeviceHostFile(ZictBase):
         device_memory_limit=None,
         memory_limit=None,
         local_directory=None,
-        spill_proxy=False,
+        jit_unspill=False,
     ):
         if local_directory is None:
             local_directory = dask.config.get("temporary-directory") or os.getcwd()
@@ -130,7 +132,7 @@ class DeviceHostFile(ZictBase):
 
         self.device_keys = set()
         self.device_func = dict()
-        if spill_proxy:
+        if jit_unspill:
             self.device_host_func = Func(
                 pxy_obj_device_to_host, pxy_obj_host_to_device, self.host_buffer
             )

--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -66,14 +66,14 @@ def host_to_device(s: DeviceSerialized) -> object:
 
 
 @nvtx_annotate("SPILL_D2H", color="red", domain="dask_cuda")
-def pxy_obj_device_to_host(obj: object) -> proxy_object.ObjectProxy:
+def pxy_obj_device_to_host(obj: object) -> proxy_object.ProxyObject:
     # Notice, both the "dask" and the "pickle" serializer will
     # spill `obj` to main memory.
     return proxy_object.asproxy(obj, serializers=["dask", "pickle"])
 
 
 @nvtx_annotate("SPILL_H2D", color="green", domain="dask_cuda")
-def pxy_obj_host_to_device(s: proxy_object.ObjectProxy) -> object:
+def pxy_obj_host_to_device(s: proxy_object.ProxyObject) -> object:
     # Notice, we do _not_ deserialize at this point. The proxy
     # object automatically deserialize just-in-time.
     return s
@@ -100,7 +100,7 @@ class DeviceHostFile(ZictBase):
     local_directory: path
         Path where to store serialized objects on disk
     jit_unspill: bool
-        If True, enable just-in-time unspilling (see proxy_object.ObjectProxy).
+        If True, enable just-in-time unspilling (see proxy_object.ProxyObject).
     """
 
     def __init__(

--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -67,7 +67,9 @@ def host_to_device(s: DeviceSerialized) -> object:
 
 @nvtx_annotate("SPILL_D2H", color="red", domain="dask_cuda")
 def pxy_obj_device_to_host(obj: object) -> proxy_object.ObjectProxy:
-    return proxy_object.asproxy(obj, serialize_obj=True)
+    # Notice, both the "dask" and the "pickle" serializer will
+    # spill `obj` to main memory.
+    return proxy_object.asproxy(obj, serializers=["dask", "pickle"])
 
 
 @nvtx_annotate("SPILL_H2D", color="green", domain="dask_cuda")

--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -67,6 +67,13 @@ def host_to_device(s: DeviceSerialized) -> object:
 
 @nvtx_annotate("SPILL_D2H", color="red", domain="dask_cuda")
 def pxy_obj_device_to_host(obj: object) -> proxy_object.ProxyObject:
+    try:
+        # Never re-serialize proxy objects.
+        if obj._obj_pxy["serializers"] is None:
+            return obj
+    except (KeyError, AttributeError):
+        pass
+
     # Notice, both the "dask" and the "pickle" serializer will
     # spill `obj` to main memory.
     return proxy_object.asproxy(obj, serializers=["dask", "pickle"])

--- a/dask_cuda/explicit_comms/dataframe_merge.py
+++ b/dask_cuda/explicit_comms/dataframe_merge.py
@@ -63,9 +63,10 @@ def concat(df_list):
         return None
     else:
         typ = str(type(df_list[0]))
-        if 'cudf' in typ:
+        if "cudf" in typ:
             # delay import of cudf to handle CPU only tests
             import cudf
+
             return cudf.concat(df_list)
         else:
             return pandas.concat(df_list)

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -108,6 +108,8 @@ class LocalCUDACluster(LocalCluster):
         but in that case with default (non-managed) memory type.
         WARNING: managed memory is currently incompatible with NVLink, trying
         to enable both will result in an exception.
+    jit_unspill: bool
+        If True, enable just-in-time unspilling (see proxy_object.ObjectProxy).
 
     Examples
     --------
@@ -149,7 +151,7 @@ class LocalCUDACluster(LocalCluster):
         ucx_net_devices=None,
         rmm_pool_size=None,
         rmm_managed_memory=False,
-        spill_proxy=None,
+        jit_unspill=None,
         **kwargs,
     ):
         # Required by RAPIDS libraries (e.g., cuDF) to ensure no context
@@ -200,10 +202,10 @@ class LocalCUDACluster(LocalCluster):
         elif isinstance(self.device_memory_limit, str):
             self.device_memory_limit = parse_bytes(self.device_memory_limit)
 
-        if spill_proxy is None:
-            self.spill_proxy = dask.config.get("spill-proxy", default=False)
+        if jit_unspill is None:
+            self.jit_unspill = dask.config.get("jit-unspill", default=False)
         else:
-            self.spill_proxy = spill_proxy
+            self.jit_unspill = jit_unspill
 
         if data is None:
             data = (
@@ -214,7 +216,7 @@ class LocalCUDACluster(LocalCluster):
                     "local_directory": local_directory
                     or dask.config.get("temporary-directory")
                     or os.getcwd(),
-                    "spill_proxy": self.spill_proxy,
+                    "jit_unspill": self.jit_unspill,
                 },
             )
 

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -150,6 +150,7 @@ class LocalCUDACluster(LocalCluster):
         ucx_net_devices=None,
         rmm_pool_size=None,
         rmm_managed_memory=False,
+        spill_proxy=None,
         **kwargs,
     ):
         if CUDA_VISIBLE_DEVICES is None:
@@ -188,6 +189,11 @@ class LocalCUDACluster(LocalCluster):
         elif isinstance(self.device_memory_limit, str):
             self.device_memory_limit = parse_bytes(self.device_memory_limit)
 
+        if spill_proxy is None:
+            self.spill_proxy = dask.config.get("spill-proxy", default=False)
+        else:
+            self.spill_proxy = spill_proxy
+
         if data is None:
             data = (
                 DeviceHostFile,
@@ -197,6 +203,7 @@ class LocalCUDACluster(LocalCluster):
                     "local_directory": local_directory
                     or dask.config.get("temporary-directory")
                     or os.getcwd(),
+                    "spill_proxy": self.spill_proxy,
                 },
             )
 

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -109,7 +109,7 @@ class LocalCUDACluster(LocalCluster):
         WARNING: managed memory is currently incompatible with NVLink, trying
         to enable both will result in an exception.
     jit_unspill: bool
-        If True, enable just-in-time unspilling (see proxy_object.ObjectProxy).
+        If True, enable just-in-time unspilling (see proxy_object.ProxyObject).
 
     Examples
     --------

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -1,6 +1,5 @@
 import operator
 import pickle
-import sys
 import threading
 
 import dask
@@ -8,6 +7,7 @@ import dask.dataframe.methods
 import dask.dataframe.utils
 import distributed.protocol
 import distributed.utils
+from dask.sizeof import sizeof
 
 from .is_device_object import is_device_object
 
@@ -202,7 +202,7 @@ class ProxyObject:
                 frames = self._obj_pxy["obj"][1]
                 return sum(map(distributed.utils.nbytes, frames))
             else:
-                return sys.getsizeof(self._obj_pxy_deserialize())
+                return sizeof(self._obj_pxy_deserialize())
 
     def __len__(self):
         return len(self._obj_pxy_deserialize())

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -185,7 +185,7 @@ class ProxyObject:
         with self._obj_pxy_lock:
             if (
                 self._obj_pxy["serializers"] is not None
-                and self._obj_pxy["serializers"] != serializers
+                and tuple(self._obj_pxy["serializers"]) != tuple(serializers)
             ):
                 # The proxied object is serialized with other serializers
                 self._obj_pxy_deserialize()

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -27,22 +27,22 @@ def asproxy(obj, serializers=None):
         The proxy object proxing `obj`
     """
 
-    if hasattr(obj, "_obj_pxy"):
-        return obj  # Already a proxy object
+    if hasattr(obj, "_obj_pxy"):  # Already a proxy object
+        ret = obj
+    else:
+        fixed_attr = {}
+        for attr in _FIXED_ATTRS:
+            try:
+                fixed_attr[attr] = getattr(obj, attr)
+            except AttributeError:
+                pass
 
-    fixed_attr = {}
-    for attr in _FIXED_ATTRS:
-        try:
-            fixed_attr[attr] = getattr(obj, attr)
-        except AttributeError:
-            pass
-
-    ret = ObjectProxy(
-        obj=obj,
-        fixed_attr=fixed_attr,
-        type_serialized=pickle.dumps(type(obj)),
-        typename=dask.utils.typename(type(obj)),
-    )
+        ret = ObjectProxy(
+            obj=obj,
+            fixed_attr=fixed_attr,
+            type_serialized=pickle.dumps(type(obj)),
+            typename=dask.utils.typename(type(obj)),
+        )
     if serializers is not None:
         ret._obj_pxy_serialize(serializers=serializers)
     return ret
@@ -89,6 +89,7 @@ class ObjectProxy:
         frames: List[Bytes]
             List of frames that makes up the serialized object
         """
+        assert serializers is not None
         if (
             self._obj_pxy["serializers"] is not None
             and self._obj_pxy["serializers"] != serializers

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -121,6 +121,10 @@ class ObjectProxy:
     def __iter__(self):
         return iter(self._obj_pxy_deserialize())
 
+    def __array__(self):
+        ret = getattr(self._obj_pxy_deserialize(), "__array__")()
+        return ret
+
     @property
     def __class__(self):
         try:

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -170,3 +170,8 @@ def obj_pxy_group_split(obj: ObjectProxy, *args, **kwargs):
     return dask.dataframe.utils.hash_object_dispatch(
         obj._obj_pxy_deserialize(), *args, **kwargs
     )
+
+
+@dask.dataframe.utils.make_scalar.register(ObjectProxy)
+def obj_pxy_make_scalar(obj: ObjectProxy, *args, **kwargs):
+    return dask.dataframe.utils.make_scalar(obj._obj_pxy_deserialize(), *args, **kwargs)

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -1,0 +1,117 @@
+import pickle
+
+import dask
+import distributed.protocol
+
+# List of attributes that should be copied to the proxy at creation, which makes
+# them accessible without deserialization of the proxied object
+_FIXED_ATTRS = ["name"]
+
+
+def asproxy(obj, serialize_obj=True, serializers=["dask", "pickle"]):
+    if hasattr(obj, "_obj_pxy"):
+        return obj  # Already a proxy object
+
+    fixed_attr = {}
+    for attr in _FIXED_ATTRS:
+        try:
+            fixed_attr[attr] = getattr(obj, attr)
+        except AttributeError:
+            pass
+
+    orig_obj = obj
+    if serialize_obj:
+        obj = distributed.protocol.serialize(obj, serializers=serializers)
+
+    return ObjectProxy(
+        obj=obj,
+        is_serialized=serialize_obj,
+        fixed_attr=fixed_attr,
+        type_serialized=pickle.dumps(type(orig_obj)),
+        typename=dask.utils.typename(type(orig_obj)),
+        serializers=serializers,
+    )
+
+
+class ObjectProxy:
+    __slots__ = [
+        "_obj_pxy",  # A dict that holds the state of the proxy object
+        "__obj_pxy_cache",  # A dict used for caching attributes
+    ]
+
+    def __init__(
+        self, obj, is_serialized, fixed_attr, type_serialized, typename, serializers
+    ):
+        self._obj_pxy = {
+            "obj": obj,
+            "is_serialized": is_serialized,
+            "fixed_attr": fixed_attr,
+            "type_serialized": type_serialized,
+            "typename": typename,
+            "serializers": serializers,
+        }
+        self.__obj_pxy_cache = {}
+
+    def _obj_pxy_get_meta(self):
+        return {k: self._obj_pxy[k] for k in self._obj_pxy.keys() if k != "obj"}
+
+    def _obj_pxy_serialize(self):
+        if not self._obj_pxy["is_serialized"]:
+            self._obj_pxy["obj"] = distributed.protocol.serialize(
+                self._obj_pxy["obj"], self._obj_pxy["serializers"]
+            )
+            self._obj_pxy["is_serialized"] = True
+        return self._obj_pxy["obj"]
+
+    def _obj_pxy_deserialize(self):
+        if self._obj_pxy["is_serialized"]:
+            header, frames = self._obj_pxy["obj"]
+            self._obj_pxy["obj"] = distributed.protocol.deserialize(header, frames)
+            self._obj_pxy["is_serialized"] = False
+        return self._obj_pxy["obj"]
+
+    def __getattr__(self, name):
+        typename = self._obj_pxy["typename"]
+        if name in _FIXED_ATTRS:
+            try:
+                return self._obj_pxy["fixed_attr"][name]
+            except KeyError:
+                raise AttributeError(
+                    f"type object '{typename}' has no attribute '{name}'"
+                )
+
+        return getattr(self._obj_pxy_deserialize(), name)
+
+    def __str__(self):
+        return str(self._obj_pxy_deserialize())
+
+    def __repr__(self):
+        typename = self._obj_pxy["typename"]
+        ret = f"<{dask.utils.typename(type(self))} at {hex(id(self))} for {typename}"
+        if self._obj_pxy["is_serialized"]:
+            ret += " (serialized)>"
+        else:
+            ret += f" at {hex(id(self._obj_pxy['obj']))}>"
+        return ret
+
+    @property
+    def __class__(self):
+        try:
+            return self.__obj_pxy_cache["type_serialized"]
+        except KeyError:
+            ret = pickle.loads(self._obj_pxy["type_serialized"])
+            self.__obj_pxy_cache["type_serialized"] = ret
+            return ret
+
+
+@distributed.protocol.dask_serialize.register(ObjectProxy)
+def obj_pxy_dask_serialize(obj: ObjectProxy):
+    header, frames = obj._obj_pxy_serialize()
+    return {"proxied-header": header, "obj-pxy-meta": obj._obj_pxy_get_meta()}, frames
+
+
+@distributed.protocol.dask_deserialize.register(ObjectProxy)
+def obj_pxy_dask_deserialize(header, frames):
+    return ObjectProxy(
+        obj=(header["proxied-header"], frames), **header["obj-pxy-meta"],
+    )

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -155,27 +155,26 @@ def obj_pxy_dask_serialize(obj: ObjectProxy):
 @distributed.protocol.dask_deserialize.register(ObjectProxy)
 def obj_pxy_dask_deserialize(header, frames):
     return ObjectProxy(
-        obj=(header["proxied-header"], frames), **header["obj-pxy-meta"],
+        obj=(header["proxied-header"], frames),
+        **header["obj-pxy-meta"],
     )
 
 
 @dask.dataframe.utils.hash_object_dispatch.register(ObjectProxy)
-def obj_pxy_hash_object(obj: ObjectProxy, *args, **kwargs):
-    return dask.dataframe.utils.hash_object_dispatch(
-        obj._obj_pxy_deserialize(), *args, **kwargs
-    )
+def obj_pxy_hash_object(obj: ObjectProxy, index=True):
+    return dask.dataframe.utils.hash_object_dispatch(obj._obj_pxy_deserialize(), index)
 
 
 @dask.dataframe.utils.group_split_dispatch.register(ObjectProxy)
-def obj_pxy_group_split(obj: ObjectProxy, *args, **kwargs):
+def obj_pxy_group_split(obj: ObjectProxy, c, k, ignore_index=False):
     return dask.dataframe.utils.hash_object_dispatch(
-        obj._obj_pxy_deserialize(), *args, **kwargs
+        obj._obj_pxy_deserialize(), c, k, ignore_index
     )
 
 
 @dask.dataframe.utils.make_scalar.register(ObjectProxy)
-def obj_pxy_make_scalar(obj: ObjectProxy, *args, **kwargs):
-    return dask.dataframe.utils.make_scalar(obj._obj_pxy_deserialize(), *args, **kwargs)
+def obj_pxy_make_scalar(obj: ObjectProxy):
+    return dask.dataframe.utils.make_scalar(obj._obj_pxy_deserialize())
 
 
 @dask.dataframe.methods.concat_dispatch.register(ObjectProxy)

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -160,9 +160,13 @@ def obj_pxy_dask_deserialize(header, frames):
 
 @dask.dataframe.utils.hash_object_dispatch.register(ObjectProxy)
 def obj_pxy_hash_object(obj: ObjectProxy, *args, **kwargs):
-    return dask.dataframe.utils.hash_object_dispatch(obj._obj_pxy_deserialize())
+    return dask.dataframe.utils.hash_object_dispatch(
+        obj._obj_pxy_deserialize(), *args, **kwargs
+    )
 
 
 @dask.dataframe.utils.group_split_dispatch.register(ObjectProxy)
 def obj_pxy_group_split(obj: ObjectProxy, *args, **kwargs):
-    return dask.dataframe.utils.hash_object_dispatch(obj._obj_pxy_deserialize())
+    return dask.dataframe.utils.hash_object_dispatch(
+        obj._obj_pxy_deserialize(), *args, **kwargs
+    )

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -148,12 +148,12 @@ class ProxyObject:
             return self._obj_pxy["obj"]
 
     def _obj_pxy_is_cuda_object(self):
-        """Inplace deserialization of the proxied object
+        """Return whether the proxied object is a CUDA or not
 
         Returns
         -------
-        ret : object
-            The proxied object (deserialized)
+        ret : boolean
+            Is the proxied object a CUDA object?
         """
         with self._obj_pxy_lock:
             return self._obj_pxy["is_cuda_object"]

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -86,7 +86,8 @@ class ProxyObject:
     """Object wrapper/proxy for serializable objects
 
     This is used by DeviceHostFile to delay deserialization of returned objects.
-   Objects proxied by an instance of this class will be JIT-deserialized when
+
+    Objects proxied by an instance of this class will be JIT-deserialized when
     accessed. The instance behaves as the proxied object and can be accessed/used
     just like the proxied object.
 
@@ -183,10 +184,9 @@ class ProxyObject:
             raise ValueError("Please specify a list of serializers")
 
         with self._obj_pxy_lock:
-            if (
-                self._obj_pxy["serializers"] is not None
-                and tuple(self._obj_pxy["serializers"]) != tuple(serializers)
-            ):
+            if self._obj_pxy["serializers"] is not None and tuple(
+                self._obj_pxy["serializers"]
+            ) != tuple(serializers):
                 # The proxied object is serialized with other serializers
                 self._obj_pxy_deserialize()
 

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -167,7 +167,7 @@ def obj_pxy_hash_object(obj: ObjectProxy, index=True):
 
 @dask.dataframe.utils.group_split_dispatch.register(ObjectProxy)
 def obj_pxy_group_split(obj: ObjectProxy, c, k, ignore_index=False):
-    return dask.dataframe.utils.hash_object_dispatch(
+    return dask.dataframe.utils.group_split_dispatch(
         obj._obj_pxy_deserialize(), c, k, ignore_index
     )
 

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -12,7 +12,20 @@ import distributed.utils
 _FIXED_ATTRS = ["name"]
 
 
-def asproxy(obj, serialize_obj=True, serializers=["dask", "pickle"]):
+def asproxy(obj, serializers=None):
+    """Wrap `obj` in a ObjectProxy object if it isn't already.
+
+    Parameters
+    ----------
+    obj: object
+        Object to wrap in a ObjectProxy object.
+    serializers: List[Str], optional
+        List of serializers to use to serialize `obj`. If None,
+        no serialization is done.
+    ret: ObjectProxy
+        The proxy object proxing `obj`
+    """
+
     if hasattr(obj, "_obj_pxy"):
         return obj  # Already a proxy object
 
@@ -23,18 +36,15 @@ def asproxy(obj, serialize_obj=True, serializers=["dask", "pickle"]):
         except AttributeError:
             pass
 
-    orig_obj = obj
-    if serialize_obj:
-        obj = distributed.protocol.serialize(obj, serializers=serializers)
-
-    return ObjectProxy(
+    ret = ObjectProxy(
         obj=obj,
-        is_serialized=serialize_obj,
         fixed_attr=fixed_attr,
-        type_serialized=pickle.dumps(type(orig_obj)),
-        typename=dask.utils.typename(type(orig_obj)),
-        serializers=serializers,
+        type_serialized=pickle.dumps(type(obj)),
+        typename=dask.utils.typename(type(obj)),
     )
+    if serializers is not None:
+        ret._obj_pxy_serialize(serializers=serializers)
+    return ret
 
 
 class ObjectProxy:
@@ -43,12 +53,9 @@ class ObjectProxy:
         "__obj_pxy_cache",  # A dict used for caching attributes
     ]
 
-    def __init__(
-        self, obj, is_serialized, fixed_attr, type_serialized, typename, serializers
-    ):
+    def __init__(self, obj, fixed_attr, type_serialized, typename, serializers=None):
         self._obj_pxy = {
             "obj": obj,
-            "is_serialized": is_serialized,
             "fixed_attr": fixed_attr,
             "type_serialized": type_serialized,
             "typename": typename,
@@ -57,22 +64,58 @@ class ObjectProxy:
         self.__obj_pxy_cache = {}
 
     def _obj_pxy_get_meta(self):
+        """Return the metadata of the proxy object.
+
+        Returns
+        -------
+        ret: dict
+            Dictionary of metadata
+        """
         return {k: self._obj_pxy[k] for k in self._obj_pxy.keys() if k != "obj"}
 
     def _obj_pxy_serialize(self, serializers):
-        if not self._obj_pxy["is_serialized"]:
+        """Inplace serialization of the proxied object using the `serializers`
+
+        Parameters
+        ----------
+        serializers: List[Str]
+            List of serializers to use to serialize the proxied object.
+
+        Returns
+        -------
+        header: dict
+            The header of the serialized frames
+        frames: List[Bytes]
+            List of frames that makes up the serialized object
+        """
+        if (
+            self._obj_pxy["serializers"] is not None
+            and self._obj_pxy["serializers"] != serializers
+        ):
+            # The proxied object is serialized with other serializers
+            self._obj_pxy_deserialize()
+
+        if self._obj_pxy["serializers"] is None:
             self._obj_pxy["obj"] = distributed.protocol.serialize(
                 self._obj_pxy["obj"], serializers
             )
             self._obj_pxy["serializers"] = serializers
-            self._obj_pxy["is_serialized"] = True
+
+        assert serializers == self._obj_pxy["serializers"]
         return self._obj_pxy["obj"]
 
     def _obj_pxy_deserialize(self):
-        if self._obj_pxy["is_serialized"]:
+        """Inplace deserialization of the proxied object
+
+        Returns
+        -------
+        ret : object
+            The proxied object (deserialized)
+        """
+        if self._obj_pxy["serializers"] is not None:
             header, frames = self._obj_pxy["obj"]
             self._obj_pxy["obj"] = distributed.protocol.deserialize(header, frames)
-            self._obj_pxy["is_serialized"] = False
+            self._obj_pxy["serializers"] = None
         return self._obj_pxy["obj"]
 
     def __getattr__(self, name):
@@ -93,8 +136,8 @@ class ObjectProxy:
     def __repr__(self):
         typename = self._obj_pxy["typename"]
         ret = f"<{dask.utils.typename(type(self))} at {hex(id(self))} for {typename}"
-        if self._obj_pxy["is_serialized"]:
-            ret += " (serialized)>"
+        if self._obj_pxy["serializers"] is not None:
+            ret += f" (serialized={repr(self._obj_pxy['serializers'])})>"
         else:
             ret += f" at {hex(id(self._obj_pxy['obj']))}>"
         return ret
@@ -140,7 +183,7 @@ class ObjectProxy:
             return ret
 
     def __sizeof__(self):
-        if self._obj_pxy["is_serialized"]:
+        if self._obj_pxy["serializers"] is not None:
             frames = self._obj_pxy["obj"][1]
             return sum(map(distributed.utils.nbytes, frames))
         else:

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -2,6 +2,7 @@ import pickle
 import sys
 
 import dask
+import dask.dataframe.utils
 import distributed.protocol
 import distributed.utils
 
@@ -155,3 +156,13 @@ def obj_pxy_dask_deserialize(header, frames):
     return ObjectProxy(
         obj=(header["proxied-header"], frames), **header["obj-pxy-meta"],
     )
+
+
+@dask.dataframe.utils.hash_object_dispatch.register(ObjectProxy)
+def obj_pxy_hash_object(obj: ObjectProxy, *args, **kwargs):
+    return dask.dataframe.utils.hash_object_dispatch(obj._obj_pxy_deserialize())
+
+
+@dask.dataframe.utils.group_split_dispatch.register(ObjectProxy)
+def obj_pxy_group_split(obj: ObjectProxy, *args, **kwargs):
+    return dask.dataframe.utils.hash_object_dispatch(obj._obj_pxy_deserialize())

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -378,10 +378,10 @@ def obj_pxy_dask_serialize(obj: ObjectProxy):
 @distributed.protocol.cuda.cuda_serialize.register(ObjectProxy)
 def obj_pxy_cuda_serialize(obj: ObjectProxy):
     """
-    The CUDA serialization of ObjectProxy used by Dask when communicating
-    ObjectProxy. As serializers, it uses "cuda", "dask" or "pickle", which means
-    that proxied CUDA objects are _not_ spilled to main memory if communicating
-    using UCX or another CUDA friendly communicantion library.
+    The CUDA serialization of ObjectProxy used by Dask when communicating using UCX
+    or another CUDA friendly communicantion library. As serializers, it uses "cuda",
+    "dask" or "pickle", which means that proxied CUDA objects are _not_ spilled to
+    main memory.
     """
     if obj._obj_pxy["serializers"] is not None:  # Already serialized
         header, frames = obj._obj_pxy["obj"]
@@ -395,7 +395,7 @@ def obj_pxy_cuda_serialize(obj: ObjectProxy):
 def obj_pxy_dask_deserialize(header, frames):
     """
     The generic deserialization of ObjectProxy. Notice, it doesn't deserialize
-    thr proxied object at this time. When accessed, the proxied object are
+    the proxied object at this time. When accessed, the proxied object are
     deserialized using the same serializers that were used when the object was
     serialized.
     """

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -1,7 +1,9 @@
 import pickle
+import sys
 
 import dask
 import distributed.protocol
+import distributed.utils
 
 # List of attributes that should be copied to the proxy at creation, which makes
 # them accessible without deserialization of the proxied object
@@ -133,6 +135,13 @@ class ObjectProxy:
             ret = pickle.loads(self._obj_pxy["type_serialized"])
             self.__obj_pxy_cache["type_serialized"] = ret
             return ret
+
+    def __sizeof__(self):
+        if self._obj_pxy["is_serialized"]:
+            frames = self._obj_pxy["obj"][1]
+            return sum(map(distributed.utils.nbytes, frames))
+        else:
+            return sys.getsizeof(self._obj_pxy_deserialize())
 
 
 @distributed.protocol.dask_serialize.register(ObjectProxy)

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -94,6 +94,33 @@ class ObjectProxy:
             ret += f" at {hex(id(self._obj_pxy['obj']))}>"
         return ret
 
+    def __len__(self):
+        return len(self._obj_pxy_deserialize())
+
+    def __contains__(self, value):
+        return value in self._obj_pxy_deserialize()
+
+    def __getitem__(self, key):
+        return self._obj_pxy_deserialize()[key]
+
+    def __setitem__(self, key, value):
+        self._obj_pxy_deserialize()[key] = value
+
+    def __delitem__(self, key):
+        del self._obj_pxy_deserialize()[key]
+
+    def __getslice__(self, i, j):
+        return self._obj_pxy_deserialize()[i:j]
+
+    def __setslice__(self, i, j, value):
+        self._obj_pxy_deserialize()[i:j] = value
+
+    def __delslice__(self, i, j):
+        del self._obj_pxy_deserialize()[i:j]
+
+    def __iter__(self):
+        return iter(self._obj_pxy_deserialize())
+
     @property
     def __class__(self):
         try:

--- a/dask_cuda/tests/test_device_host_file.py
+++ b/dask_cuda/tests/test_device_host_file.py
@@ -39,9 +39,9 @@ def test_device_host_file_config(tmp_path):
 @pytest.mark.parametrize("num_host_arrays", [1, 10, 100])
 @pytest.mark.parametrize("num_device_arrays", [1, 10, 100])
 @pytest.mark.parametrize("array_size_range", [(1, 1000), (100, 100), (1000, 1000)])
-@pytest.mark.parametrize("spill_proxy", [True, False])
+@pytest.mark.parametrize("jit_unspill", [True, False])
 def test_device_host_file_short(
-    tmp_path, num_device_arrays, num_host_arrays, array_size_range, spill_proxy
+    tmp_path, num_device_arrays, num_host_arrays, array_size_range, jit_unspill
 ):
     tmpdir = tmp_path / "storage"
     tmpdir.mkdir()
@@ -49,7 +49,7 @@ def test_device_host_file_short(
         device_memory_limit=1024 * 16,
         memory_limit=1024 * 16,
         local_directory=tmpdir,
-        spill_proxy=spill_proxy,
+        jit_unspill=jit_unspill,
     )
 
     host = [
@@ -81,15 +81,15 @@ def test_device_host_file_short(
     assert set(dhf.disk.keys()) == set()
 
 
-@pytest.mark.parametrize("spill_proxy", [True, False])
-def test_device_host_file_step_by_step(tmp_path, spill_proxy):
+@pytest.mark.parametrize("jit_unspill", [True, False])
+def test_device_host_file_step_by_step(tmp_path, jit_unspill):
     tmpdir = tmp_path / "storage"
     tmpdir.mkdir()
     dhf = DeviceHostFile(
         device_memory_limit=1024 * 16,
         memory_limit=1024 * 16,
         local_directory=tmpdir,
-        spill_proxy=spill_proxy,
+        jit_unspill=jit_unspill,
     )
 
     a = np.random.random(1000)

--- a/dask_cuda/tests/test_device_host_file.py
+++ b/dask_cuda/tests/test_device_host_file.py
@@ -23,7 +23,7 @@ cupy = pytest.importorskip("cupy")
 
 
 def assert_eq(x, y):
-    # Explicitly calling "cupy.asnumpy" to support `ObjectProxy` because
+    # Explicitly calling "cupy.asnumpy" to support `ProxyObject` because
     # "cupy" is hardcoded in `dask.array.normalize_to_array()`
     return dask.array.assert_eq(cupy.asnumpy(x), cupy.asnumpy(y))
 

--- a/dask_cuda/tests/test_device_host_file.py
+++ b/dask_cuda/tests/test_device_host_file.py
@@ -4,12 +4,11 @@ from random import randint
 import numpy as np
 import pytest
 
-import dask
-from dask import array as da
+import dask.array
 from distributed.protocol import (
     deserialize,
-    serialize,
     deserialize_bytes,
+    serialize,
     serialize_bytelist,
 )
 from distributed.protocol.pickle import HIGHEST_PROTOCOL
@@ -23,6 +22,12 @@ from dask_cuda.device_host_file import (
 cupy = pytest.importorskip("cupy")
 
 
+def assert_eq(x, y):
+    # Explicitly calling "cupy.asnumpy" to support `ObjectProxy` because
+    # "cupy" is hardcoded in `dask.array.normalize_to_array()`
+    return dask.array.assert_eq(cupy.asnumpy(x), cupy.asnumpy(y))
+
+
 def test_device_host_file_config(tmp_path):
     dhf_disk_path = str(tmp_path / "dask-worker-space" / "storage")
     with dask.config.set(temporary_directory=str(tmp_path)):
@@ -34,13 +39,17 @@ def test_device_host_file_config(tmp_path):
 @pytest.mark.parametrize("num_host_arrays", [1, 10, 100])
 @pytest.mark.parametrize("num_device_arrays", [1, 10, 100])
 @pytest.mark.parametrize("array_size_range", [(1, 1000), (100, 100), (1000, 1000)])
+@pytest.mark.parametrize("spill_proxy", [True, False])
 def test_device_host_file_short(
-    tmp_path, num_device_arrays, num_host_arrays, array_size_range
+    tmp_path, num_device_arrays, num_host_arrays, array_size_range, spill_proxy
 ):
     tmpdir = tmp_path / "storage"
     tmpdir.mkdir()
     dhf = DeviceHostFile(
-        device_memory_limit=1024 * 16, memory_limit=1024 * 16, local_directory=tmpdir
+        device_memory_limit=1024 * 16,
+        memory_limit=1024 * 16,
+        local_directory=tmpdir,
+        spill_proxy=spill_proxy,
     )
 
     host = [
@@ -64,7 +73,7 @@ def test_device_host_file_short(
 
     for k, original in full:
         acquired = dhf[k]
-        da.assert_eq(original, acquired)
+        assert_eq(original, acquired)
         del dhf[k]
 
     assert set(dhf.device.keys()) == set()
@@ -72,11 +81,15 @@ def test_device_host_file_short(
     assert set(dhf.disk.keys()) == set()
 
 
-def test_device_host_file_step_by_step(tmp_path):
+@pytest.mark.parametrize("spill_proxy", [True, False])
+def test_device_host_file_step_by_step(tmp_path, spill_proxy):
     tmpdir = tmp_path / "storage"
     tmpdir.mkdir()
     dhf = DeviceHostFile(
-        device_memory_limit=1024 * 16, memory_limit=1024 * 16, local_directory=tmpdir
+        device_memory_limit=1024 * 16,
+        memory_limit=1024 * 16,
+        local_directory=tmpdir,
+        spill_proxy=spill_proxy,
     )
 
     a = np.random.random(1000)
@@ -119,17 +132,17 @@ def test_device_host_file_step_by_step(tmp_path):
     assert set(dhf.host.keys()) == set(["a2", "b2"])
     assert set(dhf.disk.keys()) == set(["a1", "b1"])
 
-    da.assert_eq(dhf["a1"], a)
+    assert_eq(dhf["a1"], a)
     del dhf["a1"]
-    da.assert_eq(dhf["a2"], a)
+    assert_eq(dhf["a2"], a)
     del dhf["a2"]
-    da.assert_eq(dhf["b1"], b)
+    assert_eq(dhf["b1"], b)
     del dhf["b1"]
-    da.assert_eq(dhf["b2"], b)
+    assert_eq(dhf["b2"], b)
     del dhf["b2"]
-    da.assert_eq(dhf["b3"], b)
+    assert_eq(dhf["b3"], b)
     del dhf["b3"]
-    da.assert_eq(dhf["b4"], b)
+    assert_eq(dhf["b4"], b)
     del dhf["b4"]
 
     assert set(dhf.device.keys()) == set()
@@ -152,7 +165,7 @@ def test_serialize_cupy_collection(collection, length, value):
         assert_func = dd.assert_eq
     else:
         x = cupy.arange(10)
-        assert_func = da.assert_eq
+        assert_func = assert_eq
 
     if length == 0:
         obj = device_to_host(x)

--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -54,8 +54,8 @@ def test_serialize_of_proxied_cudf(serialize_obj, serializers):
     assert_frame_equal(df.to_pandas(), pxy.to_pandas())
 
 
-@pytest.mark.parametrize("spill_proxy", [True, False])
-def test_spilling_local_cuda_cluster(spill_proxy):
+@pytest.mark.parametrize("jit_unspill", [True, False])
+def test_spilling_local_cuda_cluster(jit_unspill):
     """Testing spelling of a proxied cudf dataframe in a local cuda cluster"""
     cudf = pytest.importorskip("cudf")
 
@@ -66,7 +66,7 @@ def test_spilling_local_cuda_cluster(spill_proxy):
 
     # Notice, setting `device_memory_limit=1` to trigger spilling
     with dask_cuda.LocalCUDACluster(
-        n_workers=1, device_memory_limit=1, spill_proxy=spill_proxy
+        n_workers=1, device_memory_limit=1, jit_unspill=jit_unspill
     ) as cluster:
         with Client(cluster):
             df = cudf.DataFrame({"a": range(10)})

--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -238,3 +238,4 @@ def test_communicating_proxy_objects(protocol, send_serializers):
                 df.assert_on_deserializing = True
             df = client.scatter(df)
             client.submit(task, df).result()
+            client.shutdown()  # Avoids a UCX shutdown error

--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -54,7 +54,8 @@ def test_serialize_of_proxied_cudf(serialize_obj, serializers):
     assert_frame_equal(df.to_pandas(), pxy.to_pandas())
 
 
-def test_spilling_local_cuda_cluster():
+@pytest.mark.parametrize("spill_proxy", [True, False])
+def test_spilling_local_cuda_cluster(spill_proxy):
     """Testing spelling of a proxied cudf dataframe in a local cuda cluster"""
     cudf = pytest.importorskip("cudf")
 
@@ -64,7 +65,9 @@ def test_spilling_local_cuda_cluster():
         return x
 
     # Notice, setting `device_memory_limit=1` to trigger spilling
-    with dask_cuda.LocalCUDACluster(n_workers=1, device_memory_limit=1) as cluster:
+    with dask_cuda.LocalCUDACluster(
+        n_workers=1, device_memory_limit=1, spill_proxy=spill_proxy
+    ) as cluster:
         with Client(cluster):
             df = cudf.DataFrame({"a": range(10)})
             ddf = dask_cudf.from_cudf(df, npartitions=1)

--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -11,6 +11,21 @@ from dask_cuda import proxy_object
 
 
 @pytest.mark.parametrize("serialize_obj", [True, False])
+def test_proxy_object(serialize_obj):
+    """Check "transparency" of the proxy object"""
+
+    org = list(range(10))
+    pxy = proxy_object.asproxy(org, serialize_obj=serialize_obj)
+
+    assert len(org) == len(pxy)
+    assert org[0] == pxy[0]
+    assert 1 in pxy
+    assert -1 not in pxy
+
+    # TODO: check operators (when implemented)
+
+
+@pytest.mark.parametrize("serialize_obj", [True, False])
 def test_proxy_object_of_cudf(serialize_obj):
     """Check that a proxied cudf dataframe is behaviors as a regular dataframe"""
     cudf = pytest.importorskip("cudf")

--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -35,9 +35,7 @@ def test_proxy_object_of_cudf(serialize_obj):
 
 
 @pytest.mark.parametrize("serialize_obj", [True, False])
-@pytest.mark.parametrize(
-    "serializers", [["dask", "pickle"], ["cuda", "dask", "pickle"]]
-)
+@pytest.mark.parametrize("serializers", [["dask"], ["cuda"]])
 def test_serialize_of_proxied_cudf(serialize_obj, serializers):
     """Check that we can serialize a proxied cudf dataframe, which might
     be serialized already.

--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -164,16 +164,16 @@ def test_spilling_local_cuda_cluster(jit_unspill):
         assert isinstance(x, cudf.DataFrame)
         if jit_unspill:
             # Check that `x` is a proxy object and the proxied DataFrame is serialized
-            assert type(x) == proxy_object.ProxyObject
+            assert type(x) is proxy_object.ProxyObject
             assert x._obj_pxy_get_meta()["serializers"] == ["dask", "pickle"]
         else:
             assert type(x) == cudf.DataFrame
         assert len(x) == 10  # Trigger deserialization
         return x
 
-    # Notice, setting `device_memory_limit=1` to trigger spilling
+    # Notice, setting `device_memory_limit=1B` to trigger spilling
     with dask_cuda.LocalCUDACluster(
-        n_workers=1, device_memory_limit=1, jit_unspill=jit_unspill
+        n_workers=1, device_memory_limit="1B", jit_unspill=jit_unspill
     ) as cluster:
         with Client(cluster):
             df = cudf.DataFrame({"a": range(10)})

--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -25,6 +25,22 @@ def test_proxy_object(serializers):
     assert -1 not in pxy
 
 
+@pytest.mark.parametrize("serializers_first", [None, ["dask", "pickle"]])
+@pytest.mark.parametrize("serializers_second", [None, ["dask", "pickle"]])
+def test_double_proxy_object(serializers_first, serializers_second):
+    """Check asproxy() when creating a proxy object of a proxy object"""
+    org = list(range(10))
+    pxy1 = proxy_object.asproxy(org, serializers=serializers_first)
+    assert pxy1._obj_pxy["serializers"] == serializers_first
+    pxy2 = proxy_object.asproxy(pxy1, serializers=serializers_second)
+    if serializers_second is None:
+        # Check that `serializers=None` doesn't change the initial serializers
+        assert pxy2._obj_pxy["serializers"] == serializers_first
+    else:
+        assert pxy2._obj_pxy["serializers"] == serializers_second
+    assert pxy1 is pxy2
+
+
 @pytest.mark.parametrize("serializers", [None, ["dask", "pickle"]])
 def test_proxy_object_of_numpy(serializers):
     """Check that a proxied numpy array behaves as a regular dataframe"""

--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -164,7 +164,7 @@ def test_spilling_local_cuda_cluster(jit_unspill):
         assert isinstance(x, cudf.DataFrame)
         if jit_unspill:
             # Check that `x` is a proxy object and the proxied DataFrame is serialized
-            assert type(x) == proxy_object.ObjectProxy
+            assert type(x) == proxy_object.ProxyObject
             assert x._obj_pxy_get_meta()["serializers"] == ["dask", "pickle"]
         else:
             assert type(x) == cudf.DataFrame
@@ -183,7 +183,7 @@ def test_spilling_local_cuda_cluster(jit_unspill):
             assert_frame_equal(got.to_pandas(), df.to_pandas())
 
 
-class _PxyObjTest(proxy_object.ObjectProxy):
+class _PxyObjTest(proxy_object.ProxyObject):
     """
     A class that:
         - defines `__dask_tokenize__` in order to avoid deserialization when

--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -162,6 +162,12 @@ def test_spilling_local_cuda_cluster(jit_unspill):
 
     def task(x):
         assert isinstance(x, cudf.DataFrame)
+        if jit_unspill:
+            # Check that `x` is a proxy object and the proxied DataFrame is serialized
+            assert type(x) == proxy_object.ObjectProxy
+            assert x._obj_pxy_get_meta()["serializers"] == "['dask', 'pickle']"
+        else:
+            assert type(x) == cudf.DataFrame
         assert len(x) == 10  # Trigger deserialization
         return x
 

--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -34,16 +34,13 @@ def test_proxy_object_of_cudf(serializers):
     assert_frame_equal(df.to_pandas(), pxy.to_pandas())
 
 
-@pytest.mark.parametrize("proxy_serializers", [None, ["dask"]])
+@pytest.mark.parametrize("proxy_serializers", [None, ["dask"], ["cuda"]])
 @pytest.mark.parametrize("dask_serializers", [["dask"], ["cuda"]])
 def test_serialize_of_proxied_cudf(proxy_serializers, dask_serializers):
     """Check that we can serialize a proxied cudf dataframe, which might
     be serialized already.
     """
     cudf = pytest.importorskip("cudf")
-
-    if "cuda" in dask_serializers:
-        pytest.skip("cuda serializer support not implemented")
 
     df = cudf.DataFrame({"a": range(10)})
     pxy = proxy_object.asproxy(df, serializers=proxy_serializers)

--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -1,0 +1,58 @@
+import pytest
+from pandas.testing import assert_frame_equal
+
+from distributed import Client
+from distributed.protocol.serialize import deserialize, serialize
+
+import dask_cudf
+
+import dask_cuda
+from dask_cuda import proxy_object
+
+
+@pytest.mark.parametrize("serialize_obj", [True, False])
+def test_proxy_object_of_cudf(serialize_obj):
+    """Check that a proxied cudf dataframe is behaviors as a regular dataframe"""
+    cudf = pytest.importorskip("cudf")
+    df = cudf.DataFrame({"a": range(10)})
+    pxy = proxy_object.asproxy(df, serialize_obj=serialize_obj)
+    assert_frame_equal(df.to_pandas(), pxy.to_pandas())
+
+
+@pytest.mark.parametrize("serialize_obj", [True, False])
+@pytest.mark.parametrize(
+    "serializers", [["dask", "pickle"], ["cuda", "dask", "pickle"]]
+)
+def test_serialize_of_proxied_cudf(serialize_obj, serializers):
+    """Check that we can serialize a proxied cudf dataframe, which might
+    be serialized already.
+    """
+    cudf = pytest.importorskip("cudf")
+
+    if "cuda" in serializers:
+        pytest.skip("cuda serializer support not implemented")
+
+    df = cudf.DataFrame({"a": range(10)})
+    pxy = proxy_object.asproxy(df, serialize_obj=serialize_obj)
+    header, frames = serialize(pxy, serializers=serializers)
+    pxy = deserialize(header, frames)
+    assert_frame_equal(df.to_pandas(), pxy.to_pandas())
+
+
+def test_spilling_local_cuda_cluster():
+    """Testing spelling of a proxied cudf dataframe in a local cuda cluster"""
+    cudf = pytest.importorskip("cudf")
+
+    def task(x):
+        assert isinstance(x, cudf.DataFrame)
+        assert x.size == 10  # Trigger deserialization
+        return x
+
+    # Notice, setting `device_memory_limit=1` to trigger spilling
+    with dask_cuda.LocalCUDACluster(n_workers=1, device_memory_limit=1) as cluster:
+        with Client(cluster):
+            df = cudf.DataFrame({"a": range(10)})
+            ddf = dask_cudf.from_cudf(df, npartitions=1)
+            ddf = ddf.map_partitions(task, meta=df.head())
+            got = ddf.compute()
+            assert_frame_equal(got.to_pandas(), df.to_pandas())

--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -165,7 +165,7 @@ def test_spilling_local_cuda_cluster(jit_unspill):
         if jit_unspill:
             # Check that `x` is a proxy object and the proxied DataFrame is serialized
             assert type(x) == proxy_object.ObjectProxy
-            assert x._obj_pxy_get_meta()["serializers"] == "['dask', 'pickle']"
+            assert x._obj_pxy_get_meta()["serializers"] == ['dask', 'pickle']
         else:
             assert type(x) == cudf.DataFrame
         assert len(x) == 10  # Trigger deserialization

--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -61,7 +61,7 @@ def test_spilling_local_cuda_cluster(spill_proxy):
 
     def task(x):
         assert isinstance(x, cudf.DataFrame)
-        assert x.size == 10  # Trigger deserialization
+        assert len(x) == 10  # Trigger deserialization
         return x
 
     # Notice, setting `device_memory_limit=1` to trigger spilling


### PR DESCRIPTION
This PR implements Just-in-time deserialization of device memory by wrapping [`DeviceHostFile`](https://github.com/madsbk/dask-cuda/blob/7c528d06cecd9c3d58bc30a5e61702d066859fb7/dask_cuda/device_host_file.py#L61) items in a proxy class: [`ProxyObject`](https://github.com/madsbk/dask-cuda/blob/7c528d06cecd9c3d58bc30a5e61702d066859fb7/dask_cuda/proxy_object.py#L36). The deserializaion of the items are then delayed until the items are accessed.

Fixes https://github.com/rapidsai/dask-cuda/issues/342

Ref. https://github.com/rapidsai/dask-cuda/issues/57

### Use 
In order to enable JIT deserializaion, use the new `jit_unspill` argument when creating `LocalCUDACluster`, set `--enable-jit-unspill` when starting a CUDAWorker, or set the environment variable `DASK_JIT_UNSPILL=True`

### TODO

- [x] Implement `ProxyObject`  (should come up with a better name)
- [x] Add some basic tests
- [x] Support Dask serialization of `ProxyObject` in order to allow the communication spilled data
- [x] Support CUDA serialization of `ProxyObject` in order to avoid re-spilling of data in the case where `ProxyObject` wraps un-spilled device data. 
- [x] Improve the _transparency_ of `ProxyObject` 
- [x] Write documentation



