### PR TITLE
Use get_n_gpus for RMM test with dask-cuda-worker

### DIFF
--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -9,7 +9,7 @@ from distributed.system import MEMORY_LIMIT
 from distributed.utils_test import loop  # noqa: F401
 from distributed.utils_test import popen
 
-from dask_cuda.utils import get_gpu_count, wait_workers
+from dask_cuda.utils import get_n_gpus, wait_workers
 
 
 def test_cuda_visible_devices_and_memory_limit(loop):  # noqa: F811
@@ -64,7 +64,7 @@ def test_rmm(loop):  # noqa: F811
             ]
         ):
             with Client("127.0.0.1:9369", loop=loop) as client:
-                assert wait_workers(client, n_gpus=get_gpu_count())
+                assert wait_workers(client, n_gpus=get_n_gpus())
 
                 memory_resource_type = client.run(rmm.mr.get_default_resource_type)
                 for v in memory_resource_type.values():


### PR DESCRIPTION
Attempt to fix [CI failures](https://gpuci.gpuopenanalytics.com/view/RAPIDS%20Builds%20-%20Nightly/job/rapidsai/job/gpuci/job/dask-cuda/job/branches/job/dask-cuda-gpu-matrix-branch-0.15/63/CUDA=10.1,LINUX_VERSION=centos7,PYTHON_VERSION=3.8/testReport/junit/dask_cuda.tests/test_dask_cuda_worker/test_rmm/). It's not clear if this will have any effect, the difference of `get_n_gpus` to `get_gpu_count` is that the former takes into account `CUAD_VISIBLE_DEVICES` which may be defined differently than the number of GPUs available in a CI instance.