### PR TITLE
Update RMM tests based on deprecated CNMeM

### DIFF
--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -67,7 +67,7 @@ def test_rmm(loop):  # noqa: F811
                 assert wait_workers(client, n_gpus=get_gpu_count())
 
                 memory_resource_type = client.run(
-                    lambda: type(rmm.mr.get_per_device_resource(0))
+                    rmm.mr.get_current_device_resource_type
                 )
                 for v in memory_resource_type.values():
                     assert v is rmm.mr.PoolMemoryResource

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -68,4 +68,4 @@ def test_rmm(loop):  # noqa: F811
 
                 memory_resource_type = client.run(rmm.mr.get_default_resource_type)
                 for v in memory_resource_type.values():
-                    assert v is rmm._lib.memory_resource.CNMemManagedMemoryResource
+                    assert v is rmm.mr.CNMemManagedMemoryResource

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -70,4 +70,4 @@ def test_rmm(loop):  # noqa: F811
                     lambda: type(rmm.mr.get_per_device_resource(0))
                 )
                 for v in memory_resource_type.values():
-                    assert v is rmm.mr.CNMemManagedMemoryResource
+                    assert v is rmm.mr.PoolMemoryResource

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -66,6 +66,8 @@ def test_rmm(loop):  # noqa: F811
             with Client("127.0.0.1:9369", loop=loop) as client:
                 assert wait_workers(client, n_gpus=get_gpu_count())
 
-                memory_resource_type = client.run(rmm.mr.get_default_resource_type)
+                memory_resource_type = client.run(
+                    lambda: type(rmm.mr.get_per_device_resource(0))
+                )
                 for v in memory_resource_type.values():
                     assert v is rmm.mr.CNMemManagedMemoryResource

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -116,7 +116,7 @@ async def test_rmm():
     ) as cluster:
         async with Client(cluster, asynchronous=True) as client:
             memory_resource_type = await client.run(
-                lambda: type(rmm.mr.get_per_device_resource(0))
+                rmm.mr.get_current_device_resource_type
             )
             for v in memory_resource_type.values():
                 assert v is rmm.mr.PoolMemoryResource

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -119,4 +119,4 @@ async def test_rmm():
                 lambda: type(rmm.mr.get_per_device_resource(0))
             )
             for v in memory_resource_type.values():
-                assert v is rmm.mr.CNMemManagedMemoryResource
+                assert v is rmm.mr.PoolMemoryResource

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -115,6 +115,8 @@ async def test_rmm():
         rmm_pool_size="2GB", rmm_managed_memory=True, asynchronous=True
     ) as cluster:
         async with Client(cluster, asynchronous=True) as client:
-            memory_resource_type = await client.run(rmm.mr.get_default_resource_type)
+            memory_resource_type = await client.run(
+                lambda: type(rmm.mr.get_per_device_resource(0))
+            )
             for v in memory_resource_type.values():
                 assert v is rmm.mr.CNMemManagedMemoryResource

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -117,4 +117,4 @@ async def test_rmm():
         async with Client(cluster, asynchronous=True) as client:
             memory_resource_type = await client.run(rmm.mr.get_default_resource_type)
             for v in memory_resource_type.values():
-                assert v is rmm._lib.memory_resource.CNMemManagedMemoryResource
+                assert v is rmm.mr.CNMemManagedMemoryResource


### PR DESCRIPTION
The recent RMM PR ( https://github.com/rapidsai/rmm/pull/466 ) deprecated CNMeM and made some changes for handling memory resources for multiple devices (needed by XGBoost). As a result, we are seeing a few test failures in Dask-CUDA. This makes the necessary changes to update these tests.