### PR TITLE
Revert RMM init change

### DIFF
--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -1,5 +1,4 @@
 import argparse
-import os
 
 from dask.distributed import SSHCluster
 
@@ -187,7 +186,6 @@ def get_scheduler_workers(dask_scheduler=None):
 def setup_memory_pool(pool_size=None, disable_pool=False):
     import cupy
 
-    os.environ['RMM_NO_INITIALIZE'] = 'True'
     import rmm
 
     rmm.reinitialize(

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -133,7 +133,6 @@ class CUDAWorker:
 
         if rmm_pool_size is not None or rmm_managed_memory:
             try:
-                os.environ['RMM_NO_INITIALIZE'] = 'True'
                 import rmm  # noqa F401
             except ImportError:
                 raise ValueError(

--- a/dask_cuda/initialize.py
+++ b/dask_cuda/initialize.py
@@ -24,7 +24,6 @@ See https://docs.dask.org/en/latest/configuration.html for more information
 about Dask configuration.
 """
 import logging
-import os
 
 import click
 import numba.cuda
@@ -47,7 +46,6 @@ def initialize(
 ):
     if create_cuda_context:
         try:
-            os.environ['RMM_NO_INITIALIZE'] = 'True'
             numba.cuda.current_context()
         except Exception:
             logger.error("Unable to start CUDA Context", exc_info=True)
@@ -107,7 +105,6 @@ def dask_setup(
 ):
     if create_cuda_context:
         try:
-            os.environ['RMM_NO_INITIALIZE'] = 'True'
             numba.cuda.current_context()
         except Exception:
             logger.error("Unable to start CUDA Context", exc_info=True)

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -168,7 +168,6 @@ class LocalCUDACluster(LocalCluster):
         self.rmm_managed_memory = rmm_managed_memory
         if rmm_pool_size is not None or rmm_managed_memory:
             try:
-                os.environ['RMM_NO_INITIALIZE'] = 'True'
                 import rmm  # noqa F401
             except ImportError:
                 raise ValueError(

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -35,7 +35,6 @@ class RMMSetup:
 
     def setup(self, worker=None):
         if self.nbytes is not None or self.managed_memory is True:
-            os.environ['RMM_NO_INITIALIZE'] = 'True'
             import rmm
 
             pool_allocator = False if self.nbytes is None else True


### PR DESCRIPTION
As RMM now delays CUDA initialization (and doesn't include this environment variable) ( https://github.com/rapidsai/rmm/pull/493 ), we are able to revert this change.

cc @quasiben @pentschev @kkraus14 @harrism