### PR TITLE
Change pytest's basetemp in CI build script

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -100,7 +100,7 @@ else
     logger "Python py.test for dask-cuda..."
     cd $WORKSPACE
     ls dask_cuda/tests/
-    UCXPY_IFNAME=eth0 UCX_WARN_UNUSED_ENV_VARS=n UCX_MEMTYPE_CACHE=n py.test -vs --cache-clear --junitxml=${WORKSPACE}/junit-dask-cuda.xml --cov-config=.coveragerc --cov=dask_cuda --cov-report=xml:${WORKSPACE}/dask-cuda-coverage.xml --cov-report term dask_cuda/tests/
+    UCXPY_IFNAME=eth0 UCX_WARN_UNUSED_ENV_VARS=n UCX_MEMTYPE_CACHE=n py.test -vs --cache-clear --basetemp=${WORKSPACE}/dask-cuda-tmp --junitxml=${WORKSPACE}/junit-dask-cuda.xml --cov-config=.coveragerc --cov=dask_cuda --cov-report=xml:${WORKSPACE}/dask-cuda-coverage.xml --cov-report term dask_cuda/tests/
 
     logger "Running dask.distributed GPU tests"
     # Test downstream packages, which requires Python v3.7


### PR DESCRIPTION
This fixes A100 builds that are failing with errors like:

```python
E           OSError: could not create numbered dir with prefix pytest- in /tmp/pytest-of-jenkins after 10 tries
```