### PR TITLE
update numba pinning

### DIFF
--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - distributed >=2.18.0
     - pynvml >=8.0.3
     - numpy >=1.16.0
-    - numba >=0.40.1
+    - numba >=0.50.0,!=0.51.0
 
 test:
   imports:


### PR DESCRIPTION
PR updates the numba pinning for dask-cuda.  We exclude `0.51.0` due to a small bug related to cuda context creation.  PR https://github.com/numba/numba/pull/6147 address the problem and `0.51.1` will be released in the future

cc @jakirkham @kkraus14 @pentschev 