### PR TITLE
[gpuCI] Auto-merge branch-0.15 to branch-0.16 [skip ci]

### DIFF
--- a/ci/cpu/upload-anaconda.sh
+++ b/ci/cpu/upload-anaconda.sh
@@ -7,13 +7,12 @@ set -e
 export UPLOADFILE=`conda build conda/recipes/dask-cuda --python=$PYTHON --output`
 CUDA_REL=${CUDA_VERSION%.*}
 
-SOURCE_BRANCH=master
 
 LABEL_OPTION="--label main"
 echo "LABEL_OPTION=${LABEL_OPTION}"
 
 # Restrict uploads to master branch
-if [ ${GIT_BRANCH} != ${SOURCE_BRANCH} ]; then
+if [ ${BUILD_MODE} != "branch" ]; then
   echo "Skipping upload"
   return 0
 fi

--- a/ci/cpu/upload-pypi.sh
+++ b/ci/cpu/upload-pypi.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 set -e
 
-SOURCE_BRANCH=master
 
-# Restrict uploads to master branch
-if [ ${GIT_BRANCH} != ${SOURCE_BRANCH} ]; then
+if [ ${BUILD_MODE} != "branch" ]; then
   echo "Skipping upload"
   return 0
 fi


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.15` that creates a PR to keep `branch-0.16` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.