### PR TITLE
Improve CUDAWorker scheduler-address parsing and __init__

### DIFF
--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -47,7 +47,7 @@ def _get_interface(interface, host, cuda_device_index, ucx_net_devices):
 class CUDAWorker:
     def __init__(
         self,
-        scheduler,
+        scheduler=None,
         host=None,
         nthreads=0,
         name=None,

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -9,6 +9,7 @@ import warnings
 from toolz import valmap
 from tornado.ioloop import IOLoop
 
+import dask
 from distributed import Nanny
 from distributed.config import config
 from distributed.proctitle import (
@@ -127,7 +128,11 @@ class CUDAWorker:
         kwargs = {"worker_port": None, "listen_address": None}
         t = Nanny
 
-        if not scheduler and not scheduler_file and "scheduler-address" not in config:
+        if (
+            not scheduler
+            and not scheduler_file
+            and dask.config.get("scheduler-address", None) is None
+        ):
             raise ValueError(
                 "Need to provide scheduler address like\n"
                 "dask-worker SCHEDULER_ADDRESS:8786"

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -11,7 +11,6 @@ from tornado.ioloop import IOLoop
 
 import dask
 from distributed import Nanny
-from distributed.config import config
 from distributed.proctitle import (
     enable_proctitle_on_children,
     enable_proctitle_on_current,


### PR DESCRIPTION
Allows `scheduler` argument to be optional, and uses `dask.config` to check the `scheduler-address` rather than dictionary lookup (this allows e.g. environment variables like `DASK_SCHEDULER_ADDRESS` to be correctly parsed)