### PR TITLE
Fix benchmark output when scheduler address is specified

### DIFF
--- a/dask_cuda/benchmarks/local_cudf_merge.py
+++ b/dask_cuda/benchmarks/local_cudf_merge.py
@@ -274,7 +274,7 @@ def main(args):
         for (d1, d2), bw in sorted(bandwidths.items()):
             fmt = (
                 "(%s,%s)     | %s %s %s (%s)"
-                if args.multi_node
+                if args.multi_node or args.sched_addr
                 else "(%02d,%02d)     | %s %s %s (%s)"
             )
             print(fmt % (d1, d2, bw[0], bw[1], bw[2], total_nbytes[(d1, d2)]))

--- a/dask_cuda/benchmarks/local_cupy_map_overlap.py
+++ b/dask_cuda/benchmarks/local_cupy_map_overlap.py
@@ -129,7 +129,7 @@ async def run(args):
             for (d1, d2), bw in sorted(bandwidths.items()):
                 fmt = (
                     "(%s,%s)     | %s %s %s (%s)"
-                    if args.multi_node
+                    if args.multi_node or args.sched_addr
                     else "(%02d,%02d)     | %s %s %s (%s)"
                 )
                 print(fmt % (d1, d2, bw[0], bw[1], bw[2], total_nbytes[(d1, d2)]))

--- a/dask_cuda/benchmarks/local_cupy_transpose_sum.py
+++ b/dask_cuda/benchmarks/local_cupy_transpose_sum.py
@@ -115,7 +115,7 @@ async def run(args):
             for (d1, d2), bw in sorted(bandwidths.items()):
                 fmt = (
                     "(%s,%s)     | %s %s %s (%s)"
-                    if args.multi_node
+                    if args.multi_node or args.sched_addr
                     else "(%02d,%02d)     | %s %s %s (%s)"
                 )
                 print(fmt % (d1, d2, bw[0], bw[1], bw[2], total_nbytes[(d1, d2)]))


### PR DESCRIPTION
With this PR we fix a failure in the output of the benchmark:

Before:

```bash
(w1,w2)     | 25% 50% 75% (total nbytes)
-------------------------------
Traceback (most recent call last):
  File "local_cudf_merge.py", line 349, in <module>
    main(parse_args())
  File "local_cudf_merge.py", line 280, in main
    print(fmt % (d1, d2, bw[0], bw[1], bw[2], total_nbytes[(d1, d2)]))
TypeError: %d format: a number is required, not str
```

After:

```bash
(20200918) quasiben@DirtyHorseZ:~/Github/dask-cuda/dask_cuda/benchmarks$ python local_cudf_merge.py -c 100000 --scheduler-address 192.168.1.41:8786
Merge benchmark
-------------------------------
backend        | dask
merge type     | gpu
rows-per-chunk | 100000
protocol       | tcp
device(s)      | 0
rmm-pool       | True
frac-match     | 0.3
data-processed | 6.40 MB
===============================
Wall-clock     | Throughput
-------------------------------
79.10 ms       | 80.91 MB/s
76.30 ms       | 83.88 MB/s
75.31 ms       | 84.99 MB/s
===============================
(w1,w2)     | 25% 50% 75% (total nbytes)
-------------------------------
(tcp://192.168.1.41:35669,tcp://192.168.1.41:36401)     | 200.85 MB/s 251.42 MB/s 276.78 MB/s (72.00 MB)
(tcp://192.168.1.41:36401,tcp://192.168.1.41:35669)     | 177.83 MB/s 232.73 MB/s 285.58 MB/s (72.00 MB)
```