### PR TITLE
Fix typo in benchmark utils

### DIFF
--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -73,7 +73,7 @@ def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]
     )
     parser.add_argument(
         "--single-node",
-        action="store_true",
+        action="store_false",
         dest="multi_node",
         help="Runs a single-node cluster on the current host.",
     )

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -72,12 +72,6 @@ def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]
         "Ignored if protocol is 'tcp'",
     )
     parser.add_argument(
-        "--single-node",
-        action="store_false",
-        dest="multi_node",
-        help="Runs a single-node cluster on the current host.",
-    )
-    parser.add_argument(
         "--multi-node",
         action="store_true",
         dest="multi_node",


### PR DESCRIPTION
@manopapad  it looked you branched from `main`.  I cherry picked the commit and applied it to branch-0.17 for a clean commit history 

Supersedes https://github.com/rapidsai/dask-cuda/pull/415/commits/