### PR TITLE
More RMM options in benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ dist/
 dask_cuda.egg-info/
 python/build
 python/cudf/bindings/*.cpp
+dask-worker-space/
 
 ## Patching
 *.diff

--- a/dask_cuda/benchmarks/local_cudf_merge.py
+++ b/dask_cuda/benchmarks/local_cudf_merge.py
@@ -331,10 +331,10 @@ def parse_args():
                 "-c",
                 "--chunk-size",
             ],
-            "default": 40_000_000,
+            "default": 1_000_000,
             "metavar": "n",
             "type": int,
-            "help": "Chunk size (default 40_000_000)",
+            "help": "Chunk size (default 1_000_000)",
         },
         {
             "name": "--ignore-size",

--- a/dask_cuda/benchmarks/local_cudf_merge.py
+++ b/dask_cuda/benchmarks/local_cudf_merge.py
@@ -207,8 +207,9 @@ def main(args):
             client.run(setup_memory_pool, disable_pool=args.disable_rmm_pool)
             # Create an RMM pool on the scheduler due to occasional deserialization
             # of CUDA objects. May cause issues with InfiniBand otherwise.
-            client.run_on_scheduler(setup_memory_pool, 1e9,
-                    disable_pool=args.disable_rmm_pool)
+            client.run_on_scheduler(
+                setup_memory_pool, 1e9, disable_pool=args.disable_rmm_pool
+            )
 
     scheduler_workers = client.run_on_scheduler(get_scheduler_workers)
     n_workers = len(scheduler_workers)
@@ -236,7 +237,10 @@ def main(args):
         for (w1, w2), v in bandwidths.items()
     }
     total_nbytes = {
-        (scheduler_workers[w1].name, scheduler_workers[w2].name,): format_bytes(sum(nb))
+        (
+            scheduler_workers[w1].name,
+            scheduler_workers[w2].name,
+        ): format_bytes(sum(nb))
         for (w1, w2), nb in total_nbytes.items()
     }
 
@@ -291,21 +295,30 @@ def main(args):
 def parse_args():
     special_args = [
         {
-            "name": ["-b", "--backend",],
+            "name": [
+                "-b",
+                "--backend",
+            ],
             "choices": ["dask", "explicit-comms"],
             "default": "dask",
             "type": str,
             "help": "The backend to use.",
         },
         {
-            "name": ["-t", "--type",],
+            "name": [
+                "-t",
+                "--type",
+            ],
             "choices": ["cpu", "gpu"],
             "default": "gpu",
             "type": str,
             "help": "Do merge with GPU or CPU dataframes",
         },
         {
-            "name": ["-c", "--chunk-size",],
+            "name": [
+                "-c",
+                "--chunk-size",
+            ],
             "default": 1_000_000,
             "metavar": "n",
             "type": int,
@@ -334,9 +347,17 @@ def parse_args():
             "action": "store_true",
             "help": "Write output as markdown",
         },
-        {"name": "--runs", "default": 3, "type": int, "help": "Number of runs",},
         {
-            "name": ["-s", "--set-index",],
+            "name": "--runs",
+            "default": 3,
+            "type": int,
+            "help": "Number of runs",
+        },
+        {
+            "name": [
+                "-s",
+                "--set-index",
+            ],
             "action": "store_true",
             "help": "Call set_index on the key column to sort the joined dataframe.",
         },

--- a/dask_cuda/benchmarks/local_cudf_merge.py
+++ b/dask_cuda/benchmarks/local_cudf_merge.py
@@ -203,13 +203,16 @@ def main(args):
         client = Client(scheduler_addr if args.multi_node else cluster)
 
     if args.type == "gpu":
-        if not args.no_rmm_pool:
-            client.run(setup_memory_pool, disable_pool=args.disable_rmm_pool)
-            # Create an RMM pool on the scheduler due to occasional deserialization
-            # of CUDA objects. May cause issues with InfiniBand otherwise.
-            client.run_on_scheduler(
-                setup_memory_pool, 1e9, disable_pool=args.disable_rmm_pool
-            )
+        client.run(
+            setup_memory_pool,
+            pool_size=args.rmm_pool_size,
+            disable_pool=args.disable_rmm_pool,
+        )
+        # Create an RMM pool on the scheduler due to occasional deserialization
+        # of CUDA objects. May cause issues with InfiniBand otherwise.
+        client.run_on_scheduler(
+            setup_memory_pool, 1e9, disable_pool=args.disable_rmm_pool
+        )
 
     scheduler_workers = client.run_on_scheduler(get_scheduler_workers)
     n_workers = len(scheduler_workers)

--- a/dask_cuda/benchmarks/local_cudf_merge.py
+++ b/dask_cuda/benchmarks/local_cudf_merge.py
@@ -265,7 +265,7 @@ def main(args):
     print(f"rows-per-chunk | {args.chunk_size}")
     print(f"protocol       | {args.protocol}")
     print(f"device(s)      | {args.devs}")
-    print(f"rmm-pool       | {(not args.no_rmm_pool)}")
+    print(f"rmm-pool       | {(not args.disable_rmm_pool)}")
     print(f"frac-match     | {args.frac_match}")
     if args.protocol == "ucx":
         print(f"tcp            | {args.enable_tcp_over_ucx}")

--- a/dask_cuda/benchmarks/local_cudf_merge.py
+++ b/dask_cuda/benchmarks/local_cudf_merge.py
@@ -192,7 +192,7 @@ def main(args):
     if args.sched_addr:
         client = Client(args.sched_addr)
     else:
-        cluster = Cluster(*cluster_args, **cluster_kwargs, rmm_pool_size="20GB")
+        cluster = Cluster(*cluster_args, **cluster_kwargs)
         if args.multi_node:
             import time
 

--- a/dask_cuda/benchmarks/local_cudf_merge.py
+++ b/dask_cuda/benchmarks/local_cudf_merge.py
@@ -331,10 +331,10 @@ def parse_args():
                 "-c",
                 "--chunk-size",
             ],
-            "default": 1_000_000,
+            "default": 40_000_000,
             "metavar": "n",
             "type": int,
-            "help": "Chunk size (default 1_000_000)",
+            "help": "Chunk size (default 40_000_000)",
         },
         {
             "name": "--ignore-size",

--- a/dask_cuda/benchmarks/local_cupy_map_overlap.py
+++ b/dask_cuda/benchmarks/local_cupy_map_overlap.py
@@ -76,11 +76,11 @@ async def run(args):
         ) as client:
             scheduler_workers = await client.run_on_scheduler(get_scheduler_workers)
 
-            await client.run(setup_memory_pool, disable_pool=args.no_rmm_pool)
+            await client.run(setup_memory_pool, disable_pool=args.disable_rmm_pool)
             # Create an RMM pool on the scheduler due to occasional deserialization
             # of CUDA objects. May cause issues with InfiniBand otherwise.
             await client.run_on_scheduler(
-                setup_memory_pool, 1e9, disable_pool=args.no_rmm_pool
+                setup_memory_pool, 1e9, disable_pool=args.disable_rmm_pool
             )
 
             took_list = []

--- a/dask_cuda/benchmarks/local_cupy_transpose_sum.py
+++ b/dask_cuda/benchmarks/local_cupy_transpose_sum.py
@@ -62,11 +62,11 @@ async def run(args):
         ) as client:
             scheduler_workers = await client.run_on_scheduler(get_scheduler_workers)
 
-            await client.run(setup_memory_pool, disable_pool=args.no_rmm_pool)
+            await client.run(setup_memory_pool, disable_pool=args.disable_rmm_pool)
             # Create an RMM pool on the scheduler due to occasional deserialization
             # of CUDA objects. May cause issues with InfiniBand otherwise.
             await client.run_on_scheduler(
-                setup_memory_pool, 1e9, disable_pool=args.no_rmm_pool
+                setup_memory_pool, 1e9, disable_pool=args.disable_rmm_pool
             )
 
             took_list = []

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -26,9 +26,11 @@ def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]
         help="Write dask profile report (E.g. dask-report.html)",
     )
     parser.add_argument(
-        "--no-rmm-pool",
-        action="store_true",
-        help="Do not set RMM memory pool" "from the Client",
+        "--rmm-pool-size",
+        default=None,
+        type=float,
+        help="The size of the RMM memory pool. By default, 1/2 of "
+        "the total GPU memory is used.",
     )
     parser.add_argument(
         "--disable-rmm-pool", action="store_true", help="Disable the RMM memory pool"
@@ -187,9 +189,10 @@ def setup_memory_pool(pool_size=None, disable_pool=False):
 
     import rmm
 
-    rmm.reinitialize(
-        pool_allocator=not disable_pool,
-        devices=0,
-        initial_pool_size=pool_size,
-    )
-    cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)
+    if not disable_pool:
+        rmm.reinitialize(
+            pool_allocator=True,
+            devices=0,
+            initial_pool_size=pool_size,
+        )
+        cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -26,8 +26,9 @@ def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]
         help="Write dask profile report (E.g. dask-report.html)",
     )
     parser.add_argument(
-        "--no-rmm-pool", action="store_true", help="Do not set RMM memory pool" \
-        "from the Client",
+        "--no-rmm-pool",
+        action="store_true",
+        help="Do not set RMM memory pool" "from the Client",
     )
     parser.add_argument(
         "--disable-rmm-pool", action="store_true", help="Disable the RMM memory pool"
@@ -187,6 +188,8 @@ def setup_memory_pool(pool_size=None, disable_pool=False):
     import rmm
 
     rmm.reinitialize(
-        pool_allocator=not disable_pool, devices=0, initial_pool_size=pool_size,
+        pool_allocator=not disable_pool,
+        devices=0,
+        initial_pool_size=pool_size,
     )
     cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -26,7 +26,11 @@ def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]
         help="Write dask profile report (E.g. dask-report.html)",
     )
     parser.add_argument(
-        "--no-rmm-pool", action="store_true", help="Disable the RMM memory pool"
+        "--no-rmm-pool", action="store_true", help="Do not set RMM memory pool" \
+        "from the Client",
+    )
+    parser.add_argument(
+        "--disable-rmm-pool", action="store_true", help="Disable the RMM memory pool"
     )
     parser.add_argument(
         "--enable-tcp-over-ucx",


### PR DESCRIPTION
`--no-rmm-pool` now disables the pool entirely
`--disable-rmm-pool` will reinitialize rmm, however, the pool allocator is false

These names are not great and I'd be happy to change them