### PR TITLE
Add support for connecting a CUDAWorker to a cluster object

### DIFF
--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -15,6 +15,7 @@ from distributed.proctitle import (
     enable_proctitle_on_children,
     enable_proctitle_on_current,
 )
+from distributed.deploy.cluster import Cluster
 from distributed.utils import parse_bytes
 from distributed.worker import parse_memory_limit
 
@@ -136,6 +137,9 @@ class CUDAWorker:
                 "Need to provide scheduler address like\n"
                 "dask-worker SCHEDULER_ADDRESS:8786"
             )
+
+        if isinstance(scheduler, Cluster):
+            scheduler = scheduler.scheduler_address
 
         if interface and host:
             raise ValueError("Can not specify both interface and host")

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -162,8 +162,10 @@ class LocalCUDACluster(LocalCluster):
         CUDA_VISIBLE_DEVICES = list(map(int, CUDA_VISIBLE_DEVICES))
         if n_workers is None:
             n_workers = len(CUDA_VISIBLE_DEVICES)
+        if n_workers < 1:
+            raise RuntimeError("Number of workers cannot be less than 1.")
         self.host_memory_limit = parse_memory_limit(
-            memory_limit, threads_per_worker, n_workers or 1
+            memory_limit, threads_per_worker, n_workers
         )
         self.device_memory_limit = device_memory_limit
 
@@ -283,9 +285,7 @@ class LocalCUDACluster(LocalCluster):
         visible_devices = cuda_visible_devices(worker_count, self.cuda_visible_devices)
         spec["options"].update(
             {
-                "env": {
-                    "CUDA_VISIBLE_DEVICES": visible_devices,
-                },
+                "env": {"CUDA_VISIBLE_DEVICES": visible_devices,},
                 "plugins": {
                     CPUAffinity(get_cpu_affinity(worker_count)),
                     RMMSetup(self.rmm_pool_size, self.rmm_managed_memory),

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -163,7 +163,7 @@ class LocalCUDACluster(LocalCluster):
         if n_workers is None:
             n_workers = len(CUDA_VISIBLE_DEVICES)
         self.host_memory_limit = parse_memory_limit(
-            memory_limit, threads_per_worker, n_workers
+            memory_limit, threads_per_worker, n_workers or 1
         )
         self.device_memory_limit = device_memory_limit
 
@@ -283,7 +283,9 @@ class LocalCUDACluster(LocalCluster):
         visible_devices = cuda_visible_devices(worker_count, self.cuda_visible_devices)
         spec["options"].update(
             {
-                "env": {"CUDA_VISIBLE_DEVICES": visible_devices,},
+                "env": {
+                    "CUDA_VISIBLE_DEVICES": visible_devices,
+                },
                 "plugins": {
                     CPUAffinity(get_cpu_affinity(worker_count)),
                     RMMSetup(self.rmm_pool_size, self.rmm_managed_memory),

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -163,7 +163,7 @@ class LocalCUDACluster(LocalCluster):
         if n_workers is None:
             n_workers = len(CUDA_VISIBLE_DEVICES)
         if n_workers < 1:
-            raise RuntimeError("Number of workers cannot be less than 1.")
+            raise ValueError("Number of workers cannot be less than 1.")
         self.host_memory_limit = parse_memory_limit(
             memory_limit, threads_per_worker, n_workers
         )

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -159,6 +159,5 @@ async def test_cluster_worker():
         assert len(cluster.workers) == 0
         async with Client(cluster, asynchronous=True) as client:
             new_worker = CUDAWorker(cluster)
-            await new_worker
             await client.wait_for_workers(1)
             await new_worker.close()

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -156,5 +156,6 @@ async def test_cluster_worker():
         assert len(cluster.workers) == 1
         async with Client(cluster, asynchronous=True) as client:
             new_worker = CUDAWorker(cluster)
+            await new_worker
             await client.wait_for_workers(2)
             await new_worker.close()

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -151,13 +151,10 @@ async def test_rmm_managed():
 @gen_test(timeout=20)
 async def test_cluster_worker():
     async with LocalCUDACluster(
-        scheduler_port=0,
-        asynchronous=True,
-        device_memory_limit=1,
-        n_workers=0,
+        scheduler_port=0, asynchronous=True, device_memory_limit=1, n_workers=1,
     ) as cluster:
-        assert len(cluster.workers) == 0
+        assert len(cluster.workers) == 1
         async with Client(cluster, asynchronous=True) as client:
             new_worker = CUDAWorker(cluster)
-            await client.wait_for_workers(1)
+            await client.wait_for_workers(2)
             await new_worker.close()


### PR DESCRIPTION
While working on remote clusters like in Dask Cloudprovider or Dask Kubernetes it became apparent that you may end up wasting the local GPU.

For instance if I launch a GPU cluster on AWS from a GPU session in Sagemaker the Sagemaker GPU is not part of the cluster.

```python
from dask_cloudprovider import EC2Cluster
from dask.distributed import Client

cluster = EC2Cluster(**gpu_kwargs)
client = Client(cluster)  # Cluster with remote GPUs
```

This PR makes it possible to include the local GPU in the cluster in the same way you would connect a client.

```python
from dask_cloudprovider import EC2Cluster
from dask.distributed import Client
from dask_cuda import CUDAWorker

cluster = EC2Cluster(**gpu_kwargs)
local_worker = CUDAWorker(cluster)
client = Client(cluster)  # Cluster with remote GPUs and local GPU
```