### PR TITLE
Decrease data size to shorten spilling tests time

### DIFF
--- a/dask_cuda/benchmarks/local_cudf_merge.py
+++ b/dask_cuda/benchmarks/local_cudf_merge.py
@@ -11,13 +11,13 @@ from dask.distributed import Client, performance_report, wait
 from dask.utils import format_bytes, format_time, parse_bytes
 
 from dask_cuda import explicit_comms
-from dask_cuda.utils import all_to_all
 from dask_cuda.benchmarks.utils import (
     get_cluster_options,
     get_scheduler_workers,
     parse_benchmark_args,
     setup_memory_pool,
 )
+from dask_cuda.utils import all_to_all
 
 # Benchmarking cuDF merge operation based on
 # <https://gist.github.com/rjzamora/0ffc35c19b5180ab04bbf7c793c45955>
@@ -249,10 +249,7 @@ def main(args):
         for (w1, w2), v in bandwidths.items()
     }
     total_nbytes = {
-        (
-            scheduler_workers[w1].name,
-            scheduler_workers[w2].name,
-        ): format_bytes(sum(nb))
+        (scheduler_workers[w1].name, scheduler_workers[w2].name,): format_bytes(sum(nb))
         for (w1, w2), nb in total_nbytes.items()
     }
 
@@ -307,30 +304,21 @@ def main(args):
 def parse_args():
     special_args = [
         {
-            "name": [
-                "-b",
-                "--backend",
-            ],
+            "name": ["-b", "--backend",],
             "choices": ["dask", "explicit-comms"],
             "default": "dask",
             "type": str,
             "help": "The backend to use.",
         },
         {
-            "name": [
-                "-t",
-                "--type",
-            ],
+            "name": ["-t", "--type",],
             "choices": ["cpu", "gpu"],
             "default": "gpu",
             "type": str,
             "help": "Do merge with GPU or CPU dataframes",
         },
         {
-            "name": [
-                "-c",
-                "--chunk-size",
-            ],
+            "name": ["-c", "--chunk-size",],
             "default": 1_000_000,
             "metavar": "n",
             "type": int,
@@ -359,17 +347,9 @@ def parse_args():
             "action": "store_true",
             "help": "Write output as markdown",
         },
+        {"name": "--runs", "default": 3, "type": int, "help": "Number of runs",},
         {
-            "name": "--runs",
-            "default": 3,
-            "type": int,
-            "help": "Number of runs",
-        },
-        {
-            "name": [
-                "-s",
-                "--set-index",
-            ],
+            "name": ["-s", "--set-index",],
             "action": "store_true",
             "help": "Call set_index on the key column to sort the joined dataframe.",
         },

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -194,8 +194,6 @@ def setup_memory_pool(pool_size=None, disable_pool=False):
 
     if not disable_pool:
         rmm.reinitialize(
-            pool_allocator=True,
-            devices=0,
-            initial_pool_size=pool_size,
+            pool_allocator=True, devices=0, initial_pool_size=pool_size,
         )
         cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)

--- a/dask_cuda/tests/test_spill.py
+++ b/dask_cuda/tests/test_spill.py
@@ -85,23 +85,23 @@ def delayed_worker_assert(total_size, device_chunk_overhead, serialized_chunk_ov
     "params",
     [
         {
-            "device_memory_limit": 1e9,
-            "memory_limit": 4e9,
+            "device_memory_limit": 200e6,
+            "memory_limit": 800e6,
             "host_target": 0.0,
             "host_spill": 0.0,
             "host_pause": None,
             "spills_to_disk": False,
         },
         {
-            "device_memory_limit": 1e9,
-            "memory_limit": 1e9,
+            "device_memory_limit": 200e6,
+            "memory_limit": 200e6,
             "host_target": 0.0,
             "host_spill": 0.0,
             "host_pause": None,
             "spills_to_disk": True,
         },
         {
-            "device_memory_limit": 1e9,
+            "device_memory_limit": 200e6,
             "memory_limit": 0,
             "host_target": 0.0,
             "host_spill": 0.0,
@@ -133,7 +133,7 @@ def test_cupy_device_spill(params):
     def test_device_spill(client, scheduler, worker):
         cupy = pytest.importorskip("cupy")
         rs = da.random.RandomState(RandomState=cupy.random.RandomState)
-        x = rs.random(int(250e6), chunks=10e6)
+        x = rs.random(int(50e6), chunks=2e6)
 
         xx = x.persist()
         yield wait(xx)
@@ -163,23 +163,23 @@ def test_cupy_device_spill(params):
     "params",
     [
         {
-            "device_memory_limit": 1e9,
-            "memory_limit": 4e9,
+            "device_memory_limit": 200e6,
+            "memory_limit": 800e6,
             "host_target": 0.0,
             "host_spill": 0.0,
             "host_pause": None,
             "spills_to_disk": False,
         },
         {
-            "device_memory_limit": 1e9,
-            "memory_limit": 1e9,
+            "device_memory_limit": 200e6,
+            "memory_limit": 200e6,
             "host_target": 0.0,
             "host_spill": 0.0,
             "host_pause": None,
             "spills_to_disk": True,
         },
         {
-            "device_memory_limit": 1e9,
+            "device_memory_limit": 200e6,
             "memory_limit": 0,
             "host_target": 0.0,
             "host_spill": 0.0,
@@ -209,7 +209,7 @@ async def test_cupy_cluster_device_spill(params):
             async with Client(cluster, asynchronous=True) as client:
 
                 rs = da.random.RandomState(RandomState=cupy.random.RandomState)
-                x = rs.random(int(250e6), chunks=10e6)
+                x = rs.random(int(50e6), chunks=2e6)
                 await wait(x)
 
                 xx = x.persist()
@@ -241,23 +241,23 @@ async def test_cupy_cluster_device_spill(params):
     "params",
     [
         {
-            "device_memory_limit": 1e9,
-            "memory_limit": 4e9,
+            "device_memory_limit": 200e6,
+            "memory_limit": 800e6,
             "host_target": 0.0,
             "host_spill": 0.0,
             "host_pause": None,
             "spills_to_disk": False,
         },
         {
-            "device_memory_limit": 1e9,
-            "memory_limit": 1e9,
+            "device_memory_limit": 200e6,
+            "memory_limit": 200e6,
             "host_target": 0.0,
             "host_spill": 0.0,
             "host_pause": None,
             "spills_to_disk": True,
         },
         {
-            "device_memory_limit": 1e9,
+            "device_memory_limit": 200e6,
             "memory_limit": 0,
             "host_target": 0.0,
             "host_spill": 0.0,
@@ -292,7 +292,7 @@ def test_cudf_device_spill(params):
         # https://github.com/numpy/numpy/issues/4983#issuecomment-441332940
         # The same error above happens when spilling datetime64 to disk
         cdf = (
-            dask.datasets.timeseries(dtypes={"x": int, "y": float}, freq="20ms")
+            dask.datasets.timeseries(dtypes={"x": int, "y": float}, freq="100ms")
             .reset_index(drop=True)
             .map_partitions(cudf.from_pandas)
         )
@@ -330,23 +330,23 @@ def test_cudf_device_spill(params):
     "params",
     [
         {
-            "device_memory_limit": 1e9,
-            "memory_limit": 4e9,
+            "device_memory_limit": 200e6,
+            "memory_limit": 800e6,
             "host_target": 0.0,
             "host_spill": 0.0,
             "host_pause": None,
             "spills_to_disk": False,
         },
         {
-            "device_memory_limit": 1e9,
-            "memory_limit": 1e9,
+            "device_memory_limit": 200e6,
+            "memory_limit": 200e6,
             "host_target": 0.0,
             "host_spill": 0.0,
             "host_pause": None,
             "spills_to_disk": True,
         },
         {
-            "device_memory_limit": 1e9,
+            "device_memory_limit": 200e6,
             "memory_limit": 0,
             "host_target": 0.0,
             "host_spill": 0.0,
@@ -375,7 +375,7 @@ async def test_cudf_cluster_device_spill(params):
                 # https://github.com/numpy/numpy/issues/4983#issuecomment-441332940
                 # The same error above happens when spilling datetime64 to disk
                 cdf = (
-                    dask.datasets.timeseries(dtypes={"x": int, "y": float}, freq="20ms")
+                    dask.datasets.timeseries(dtypes={"x": int, "y": float}, freq="100ms")
                     .reset_index(drop=True)
                     .map_partitions(cudf.from_pandas)
                 )

--- a/dask_cuda/tests/test_spill.py
+++ b/dask_cuda/tests/test_spill.py
@@ -375,7 +375,9 @@ async def test_cudf_cluster_device_spill(params):
                 # https://github.com/numpy/numpy/issues/4983#issuecomment-441332940
                 # The same error above happens when spilling datetime64 to disk
                 cdf = (
-                    dask.datasets.timeseries(dtypes={"x": int, "y": float}, freq="100ms")
+                    dask.datasets.timeseries(
+                        dtypes={"x": int, "y": float}, freq="100ms"
+                    )
                     .reset_index(drop=True)
                     .map_partitions(cudf.from_pandas)
                 )


### PR DESCRIPTION
These tests generally take a lot of time, I think it's safe to reduce their sizes so that dask-cuda CI runs faster. Spilling tests alone used to take 228 seconds and take 72 seconds after this PR.