### PR TITLE
Support UUID in CUDA_VISIBLE_DEVICES

### DIFF
--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -20,10 +20,10 @@ from distributed.worker import parse_memory_limit
 
 from .device_host_file import DeviceHostFile
 from .initialize import initialize
-from .local_cuda_cluster import cuda_visible_devices
 from .utils import (
     CPUAffinity,
     RMMSetup,
+    cuda_visible_devices,
     get_cpu_affinity,
     get_device_total_memory,
     get_n_gpus,

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -12,36 +12,13 @@ from .initialize import initialize
 from .utils import (
     CPUAffinity,
     RMMSetup,
+    cuda_visible_devices,
     get_cpu_affinity,
     get_device_total_memory,
-    get_n_gpus,
     get_ucx_config,
     get_ucx_net_devices,
     parse_cuda_visible_device,
 )
-
-
-def cuda_visible_devices(i, visible=None):
-    """Cycling values for CUDA_VISIBLE_DEVICES environment variable
-
-    Examples
-    --------
-    >>> cuda_visible_devices(0, range(4))
-    '0,1,2,3'
-    >>> cuda_visible_devices(3, range(8))
-    '3,4,5,6,7,0,1,2'
-    """
-    if visible is None:
-        try:
-            visible = map(
-                parse_cuda_visible_device, os.environ["CUDA_VISIBLE_DEVICES"].split(",")
-            )
-        except KeyError:
-            visible = range(get_n_gpus())
-    visible = list(visible)
-
-    L = visible[i:] + visible[:i]
-    return ",".join(map(str, L))
 
 
 class LocalCUDACluster(LocalCluster):

--- a/dask_cuda/tests/test_utils.py
+++ b/dask_cuda/tests/test_utils.py
@@ -4,6 +4,7 @@ import pytest
 from numba import cuda
 
 from dask_cuda.utils import (
+    cuda_visible_devices,
     get_cpu_affinity,
     get_device_total_memory,
     get_gpu_count,
@@ -14,7 +15,6 @@ from dask_cuda.utils import (
     parse_cuda_visible_device,
     unpack_bitmask,
 )
-from dask_cuda.local_cuda_cluster import cuda_visible_devices
 
 
 def test_get_n_gpus():

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -393,7 +393,7 @@ def all_to_all(client):
 def parse_cuda_visible_device(dev):
     """Parses a single CUDA device identifier
 
-    A device identifier must either be an intenger, a string containing an
+    A device identifier must either be an integer, a string containing an
     integer or a string containing the device's UUID, beginning with prefix
     'GPU-' or 'MIG-GPU'.
 

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -418,3 +418,26 @@ def parse_cuda_visible_device(dev):
                 "Devices in CUDA_VISIBLE_DEVICES must be comma-separated integers "
                 "or strings beginning with 'GPU-' or 'MIG-GPU-' prefixes."
             )
+
+
+def cuda_visible_devices(i, visible=None):
+    """Cycling values for CUDA_VISIBLE_DEVICES environment variable
+
+    Examples
+    --------
+    >>> cuda_visible_devices(0, range(4))
+    '0,1,2,3'
+    >>> cuda_visible_devices(3, range(8))
+    '3,4,5,6,7,0,1,2'
+    """
+    if visible is None:
+        try:
+            visible = map(
+                parse_cuda_visible_device, os.environ["CUDA_VISIBLE_DEVICES"].split(",")
+            )
+        except KeyError:
+            visible = range(get_n_gpus())
+    visible = list(visible)
+
+    L = visible[i:] + visible[:i]
+    return ",".join(map(str, L))

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -406,7 +406,8 @@ def parse_cuda_visible_device(dev):
     >>> parse_cuda_visible_device('Foo')
     Traceback (most recent call last):
     ...
-    ValueError: Devices in CUDA_VISIBLE_DEVICES must be comma-separated integers or strings beginning with 'GPU-' or 'MIG-GPU-' prefixes.
+    ValueError: Devices in CUDA_VISIBLE_DEVICES must be comma-separated integers or
+    strings beginning with 'GPU-' or 'MIG-GPU-' prefixes.
     """
     try:
         return int(dev)

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -388,3 +388,33 @@ async def _all_to_all(client):
 
 def all_to_all(client):
     return client.sync(_all_to_all, client=client, asynchronous=client.asynchronous)
+
+
+def parse_cuda_visible_device(dev):
+    """Parses a single CUDA device identifier
+
+    A device identifier must either be an intenger, a string containing an
+    integer or a string containing the device's UUID, beginning with prefix
+    'GPU-' or 'MIG-GPU'.
+
+    >>> parse_cuda_visible_device(2)
+    2
+    >>> parse_cuda_visible_device('2')
+    2
+    >>> parse_cuda_visible_device('GPU-9baca7f5-0f2f-01ac-6b05-8da14d6e9005')
+    'GPU-9baca7f5-0f2f-01ac-6b05-8da14d6e9005'
+    >>> parse_cuda_visible_device('Foo')
+    Traceback (most recent call last):
+    ...
+    ValueError: Devices in CUDA_VISIBLE_DEVICES must be comma-separated integers or strings beginning with 'GPU-' or 'MIG-GPU-' prefixes.
+    """
+    try:
+        return int(dev)
+    except ValueError:
+        if any(dev.startswith(prefix) for prefix in ["GPU-", "MIG-GPU-"]):
+            return dev
+        else:
+            raise ValueError(
+                "Devices in CUDA_VISIBLE_DEVICES must be comma-separated integers "
+                "or strings beginning with 'GPU-' or 'MIG-GPU-' prefixes."
+            )


### PR DESCRIPTION
Originally seen first in https://github.com/rapidsai/dask-cuda/issues/435 , this should allow specifying GPUs by their UUIDs in `CUDA_VISIBLE_DEVICES`.