### PR TITLE
update builddocs dependency requirements

### DIFF
--- a/conda/environments/builddocs_py37.yml
+++ b/conda/environments/builddocs_py37.yml
@@ -4,6 +4,4 @@ channels:
 - conda-forge
 dependencies:
 - rapids-doc-env
-- distributed
-- dask
 - pandas

--- a/conda/environments/builddocs_py37.yml
+++ b/conda/environments/builddocs_py37.yml
@@ -4,3 +4,6 @@ channels:
 - conda-forge
 dependencies:
 - rapids-doc-env
+- distributed
+- dask
+- pandas

--- a/conda/environments/builddocs_py37.yml
+++ b/conda/environments/builddocs_py37.yml
@@ -5,3 +5,4 @@ channels:
 dependencies:
 - rapids-doc-env
 - pandas
+- dask


### PR DESCRIPTION
We are currently getting errors when building dask-cuda:

```
Running Sphinx v3.2.1

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/dask-cuda/conda/latest/lib/python3.8/site-packages/dask/dataframe/__init__.py", line 2, in <module>
    from .core import (
  File "/home/docs/checkouts/readthedocs.org/user_builds/dask-cuda/conda/latest/lib/python3.8/site-packages/dask/dataframe/core.py", line 10, in <module>
    import pandas as pd
ModuleNotFoundError: No module named 'pandas'
```

This PR adds Pandas and dask requirements

I believe we will need @rapidsai/ops to approve/merge