### PR TITLE
Fix versioneer

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include versioneer.py
+include dask_cuda/_version.py

--- a/setup.py
+++ b/setup.py
@@ -9,17 +9,11 @@ import versioneer
 with open(os.path.join(os.path.dirname(__file__), "README.md")) as f:
     long_description = f.read()
 
-if "GIT_DESCRIBE_TAG" in os.environ:
-    version = os.environ["GIT_DESCRIBE_TAG"] + os.environ.get("VERSION_SUFFIX", "")
-    cmdclass = {}
-else:
-    version = versioneer.get_version()
-    cmdclass = versioneer.get_cmdclass()
 
 setup(
     name="dask-cuda",
-    version=version,
-    cmdclass=cmdclass,
+    version=versioneer.get_version(),
+    cmdclass=versioneer.get_cmdclass(),
     description="Utilities for Dask and CUDA interactions",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Fixes https://github.com/rapidsai/dask-cuda/issues/336

* Adds missing `MANIFEST.in` to include versioneer components
* Always uses versioneer in `setup.py`

Based on local testing this should fix the issue. Also this matches with [versioneer's install instructions]( https://github.com/python-versioneer/python-versioneer/blob/master/INSTALL.md ).

cc @pentschev @quasiben