### PR TITLE
Recipe cleanup

### DIFF
--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -19,7 +19,7 @@ build:
     - VERSION_SUFFIX
 
 requirements:
-  build:
+  host:
     - python
     - setuptools
   run:

--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -20,10 +20,10 @@ build:
 
 requirements:
   build:
-    - python x.x
+    - python
     - setuptools
   run:
-    - python x.x
+    - python
     - dask >=2.4.0
     - distributed >=2.18.0
     - pynvml >=8.0.3


### PR DESCRIPTION
* Drop old `x.x` syntax (has been deprecated for a while and is not needed)
* Switch `build` to `host` (this is how dependencies that are linked against should be listed)