### PR TITLE
[REVIEW] FIX Move codecov upload to gpu build script

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -120,6 +120,6 @@ else
 fi
 
 if [ -n "\${CODECOV_TOKEN}" ]; then
-    codecov -t \$CODECOV_TOKEN
+    codecov -t $CODECOV_TOKEN
 fi
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -119,7 +119,7 @@ else
     fi
 fi
 
-if [ -n "\${CODECOV_TOKEN}" ]; then
+if [ -n "${CODECOV_TOKEN}" ]; then
     codecov -t $CODECOV_TOKEN
 fi
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -118,3 +118,8 @@ else
         py.test --cache-clear -vs `python -c "import distributed.diagnostics.tests.test_nvml as m;print(m.__file__)"`
     fi
 fi
+
+if [ -n "\${CODECOV_TOKEN}" ]; then
+    codecov -t \$CODECOV_TOKEN
+fi
+


### PR DESCRIPTION
This moves a block from the Jenkins build into the build script. Simplifies the Jenkins builds slightly and fixes a very rare case where tests may error and not be properly caught due to EXITCODE intricacies.