### PR TITLE
Make threads per worker consistent

### DIFF
--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -64,7 +64,7 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     "an ethernet interface is used for connection, and not an InfiniBand "
     "interface (if one is available).",
 )
-@click.option("--nthreads", type=int, default=0, help="Number of threads per process.")
+@click.option("--nthreads", type=int, default=1, help="Number of threads per process.")
 @click.option(
     "--name",
     type=str,

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import asyncio
 import atexit
-import multiprocessing
 import os
 import warnings
 

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -49,7 +49,7 @@ class CUDAWorker:
         self,
         scheduler=None,
         host=None,
-        nthreads=0,
+        nthreads=1,
         name=None,
         memory_limit="auto",
         device_memory_limit="auto",
@@ -86,8 +86,8 @@ class CUDAWorker:
         except KeyError:
             nprocs = get_n_gpus()
 
-        if not nthreads:
-            nthreads = min(1, multiprocessing.cpu_count() // nprocs)
+        if nthreads < 1:
+            raise ValueError("nthreads must be higher than 0.")
 
         memory_limit = parse_memory_limit(memory_limit, nthreads, total_cores=nprocs)
 

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -142,6 +142,9 @@ class LocalCUDACluster(LocalCluster):
         # initialization happens before we can set CUDA_VISIBLE_DEVICES
         os.environ["RAPIDS_NO_INITIALIZE"] = "True"
 
+        if threads_per_worker < 1:
+            raise ValueError("threads_per_worker must be higher than 0.")
+
         if CUDA_VISIBLE_DEVICES is None:
             CUDA_VISIBLE_DEVICES = cuda_visible_devices(0)
         if isinstance(CUDA_VISIBLE_DEVICES, str):

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -214,8 +214,7 @@ class LocalCUDACluster(LocalCluster):
 
         if ucx_net_devices == "auto":
             try:
-                from ucp._libs.topological_distance import \
-                    TopologicalDistance  # NOQA
+                from ucp._libs.topological_distance import TopologicalDistance  # NOQA
             except ImportError:
                 raise ValueError(
                     "ucx_net_devices set to 'auto' but UCX-Py is not "

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -514,10 +514,7 @@ def obj_pxy_dask_deserialize(header, frames):
         subclass = ProxyObject
     else:
         subclass = pickle.loads(meta["subclass"])
-    return subclass(
-        obj=(header["proxied-header"], frames),
-        **header["obj-pxy-meta"],
-    )
+    return subclass(obj=(header["proxied-header"], frames), **header["obj-pxy-meta"],)
 
 
 @dask.dataframe.utils.hash_object_dispatch.register(ProxyObject)

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -44,7 +44,9 @@ def test_cuda_visible_devices_and_memory_limit_and_nthreads(loop):  # noqa: F811
 
                     workers = client.scheduler_info()["workers"]
                     for w in workers.values():
-                        assert w["memory_limit"] == MEMORY_LIMIT // len(workers) * nthreads
+                        assert (
+                            w["memory_limit"] == MEMORY_LIMIT // len(workers) * nthreads
+                        )
 
                     assert len(expected) == 0
     finally:

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -12,8 +12,9 @@ from distributed.utils_test import popen
 from dask_cuda.utils import get_n_gpus, wait_workers
 
 
-def test_cuda_visible_devices_and_memory_limit(loop):  # noqa: F811
+def test_cuda_visible_devices_and_memory_limit_and_nthreads(loop):  # noqa: F811
     os.environ["CUDA_VISIBLE_DEVICES"] = "2,3,7,8"
+    nthreads = 4
     try:
         with popen(["dask-scheduler", "--port", "9359", "--no-dashboard"]):
             with popen(
@@ -24,6 +25,8 @@ def test_cuda_visible_devices_and_memory_limit(loop):  # noqa: F811
                     "127.0.0.1",
                     "--device-memory-limit",
                     "1 MB",
+                    "--nthreads",
+                    str(nthreads),
                     "--no-dashboard",
                 ]
             ):
@@ -41,7 +44,7 @@ def test_cuda_visible_devices_and_memory_limit(loop):  # noqa: F811
 
                     workers = client.scheduler_info()["workers"]
                     for w in workers.values():
-                        assert w["memory_limit"] == MEMORY_LIMIT // len(workers)
+                        assert w["memory_limit"] == MEMORY_LIMIT // len(workers) * nthreads
 
                     assert len(expected) == 0
     finally:

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -109,14 +109,8 @@ async def test_n_workers():
 
 @gen_test(timeout=20)
 async def test_threads_per_worker():
-    async with LocalCUDACluster(
-        threads_per_worker=4, asynchronous=True
-    ) as cluster:
-        assert all(
-            ws.nthreads == 4 for ws in cluster.scheduler.workers.values()
-        )
-        #assert len(cluster.workers) == 2
-        #assert len(cluster.worker_spec) == 2
+    async with LocalCUDACluster(threads_per_worker=4, asynchronous=True) as cluster:
+        assert all(ws.nthreads == 4 for ws in cluster.scheduler.workers.values())
 
 
 @gen_test(timeout=20)

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -108,6 +108,18 @@ async def test_n_workers():
 
 
 @gen_test(timeout=20)
+async def test_threads_per_worker():
+    async with LocalCUDACluster(
+        threads_per_worker=4, asynchronous=True
+    ) as cluster:
+        assert all(
+            ws.nthreads == 4 for ws in cluster.scheduler.workers.values()
+        )
+        #assert len(cluster.workers) == 2
+        #assert len(cluster.worker_spec) == 2
+
+
+@gen_test(timeout=20)
 async def test_all_to_all():
     async with LocalCUDACluster(
         CUDA_VISIBLE_DEVICES="0,1", asynchronous=True


### PR DESCRIPTION
This allows user specifying the number of threads per worker, supersedes #405 .