### PR TITLE
ProxyObject: support of pickle

### DIFF
--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -56,7 +56,7 @@ def device_deserialize(header, frames):
 
 @nvtx_annotate("SPILL_D2H", color="red", domain="dask_cuda")
 def device_to_host(obj: object) -> DeviceSerialized:
-    header, frames = serialize(obj, serializers=["dask", "pickle"])
+    header, frames = serialize(obj, serializers=["dask", "pickle"], on_error="raise")
     return DeviceSerialized(header, frames)
 
 

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -1,6 +1,7 @@
 import operator
 import pickle
 import threading
+from collections import OrderedDict
 
 import dask
 import dask.dataframe.methods
@@ -155,15 +156,31 @@ class ProxyObject:
         self._obj_pxy_lock = threading.RLock()
         self.__obj_pxy_cache = {}
 
-    def _obj_pxy_get_meta(self):
-        """Return the metadata of the proxy object.
+    def _obj_pxy_get_init_args(self, include_obj=True):
+        """Return the attributes needed to initialize a ProxyObject
+
+        Notice, the returned dictionary is ordered as the __init__() arguments
+
+        Parameters
+        ----------
+        include_obj: bool
+            Whether to include the "obj" argument or not
 
         Returns
         -------
-        Dictionary of metadata
+        Dictionary of attributes
         """
-        with self._obj_pxy_lock:
-            return {k: self._obj_pxy[k] for k in self._obj_pxy.keys() if k != "obj"}
+        args = [
+            "fixed_attr",
+            "type_serialized",
+            "typename",
+            "is_cuda_object",
+            "subclass",
+            "serializers",
+        ]
+        if include_obj:
+            args.insert(0, "obj")
+        return OrderedDict([(a, self._obj_pxy[a]) for a in args])
 
     def _obj_pxy_serialize(self, serializers):
         """Inplace serialization of the proxied object using the `serializers`
@@ -482,7 +499,8 @@ def obj_pxy_dask_serialize(obj: ProxyObject):
     that proxied CUDA objects are spilled to main memory before communicated.
     """
     header, frames = obj._obj_pxy_serialize(serializers=["dask", "pickle"])
-    return {"proxied-header": header, "obj-pxy-meta": obj._obj_pxy_get_meta()}, frames
+    meta = obj._obj_pxy_get_init_args(include_obj=False)
+    return {"proxied-header": header, "obj-pxy-meta": meta}, frames
 
 
 @distributed.protocol.cuda.cuda_serialize.register(ProxyObject)
@@ -497,7 +515,8 @@ def obj_pxy_cuda_serialize(obj: ProxyObject):
         header, frames = obj._obj_pxy["obj"]
     else:
         header, frames = obj._obj_pxy_serialize(serializers=["cuda", "dask", "pickle"])
-    return {"proxied-header": header, "obj-pxy-meta": obj._obj_pxy_get_meta()}, frames
+    meta = obj._obj_pxy_get_init_args(include_obj=False)
+    return {"proxied-header": header, "obj-pxy-meta": meta}, frames
 
 
 @distributed.protocol.dask_deserialize.register(ProxyObject)

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -170,7 +170,8 @@ class ProxyObject:
         -------
         Dictionary of attributes
         """
-        args = [
+        args = ["obj"] if include_obj else []
+        args += [
             "fixed_attr",
             "type_serialized",
             "typename",
@@ -178,8 +179,6 @@ class ProxyObject:
             "subclass",
             "serializers",
         ]
-        if include_obj:
-            args.insert(0, "obj")
         return OrderedDict([(a, self._obj_pxy[a]) for a in args])
 
     def _obj_pxy_serialize(self, serializers):

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -192,7 +192,7 @@ class ProxyObject:
 
             if self._obj_pxy["serializers"] is None:
                 self._obj_pxy["obj"] = distributed.protocol.serialize(
-                    self._obj_pxy["obj"], serializers
+                    self._obj_pxy["obj"], serializers, on_error="raise"
                 )
                 self._obj_pxy["serializers"] = serializers
 
@@ -514,7 +514,10 @@ def obj_pxy_dask_deserialize(header, frames):
         subclass = ProxyObject
     else:
         subclass = pickle.loads(meta["subclass"])
-    return subclass(obj=(header["proxied-header"], frames), **header["obj-pxy-meta"],)
+    return subclass(
+        obj=(header["proxied-header"], frames),
+        **header["obj-pxy-meta"],
+    )
 
 
 @dask.dataframe.utils.hash_object_dispatch.register(ProxyObject)

--- a/dask_cuda/tests/test_device_host_file.py
+++ b/dask_cuda/tests/test_device_host_file.py
@@ -191,7 +191,7 @@ def test_serialize_cupy_collection(collection, length, value):
         values = res.values() if collection is dict else res
         [assert_func(v, x) for v in values]
 
-    header, frames = serialize(obj, serializers=["pickle"])
+    header, frames = serialize(obj, serializers=["pickle"], on_error="raise")
 
     if HIGHEST_PROTOCOL >= 5:
         assert len(frames) == (1 + len(obj.frames))

--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -200,7 +200,7 @@ def test_spilling_local_cuda_cluster(jit_unspill):
         if jit_unspill:
             # Check that `x` is a proxy object and the proxied DataFrame is serialized
             assert type(x) is proxy_object.ProxyObject
-            assert x._obj_pxy_get_meta()["serializers"] == ["dask", "pickle"]
+            assert x._obj_pxy["serializers"] == ["dask", "pickle"]
         else:
             assert type(x) == cudf.DataFrame
         assert len(x) == 10  # Trigger deserialization
@@ -244,7 +244,7 @@ def test_communicating_proxy_objects(protocol, send_serializers):
     def task(x):
         # Check that the subclass survives the trip from client to worker
         assert isinstance(x, _PxyObjTest)
-        serializers_used = list(x._obj_pxy_get_meta()["serializers"])
+        serializers_used = list(x._obj_pxy["serializers"])
 
         # Check that `x` is serialized with the expected serializers
         if protocol == "ucx":

--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -185,7 +185,7 @@ def test_serialize_of_proxied_cudf(proxy_serializers, dask_serializers):
 
     df = cudf.DataFrame({"a": range(10)})
     pxy = proxy_object.asproxy(df, serializers=proxy_serializers)
-    header, frames = serialize(pxy, serializers=dask_serializers)
+    header, frames = serialize(pxy, serializers=dask_serializers, on_error="raise")
     pxy = deserialize(header, frames)
     assert_frame_equal(df.to_pandas(), pxy.to_pandas())
 


### PR DESCRIPTION
This PR implements `ProxyObject.__reduce__()` in order to support pickle.