### PR TITLE
Add note on RMM pool docs mentioning its per worker [skip ci]

### DIFF
--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -99,8 +99,8 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     help="If specified, initialize each worker with an RMM pool of "
     "the given size, otherwise no RMM pool is created. This can be "
     "an integer (bytes) or string (like 5GB or 5000M)."
-    "NOTE: This size is a per worker (i.e., per GPU), and not "
-    "cluster-wide!",
+    "NOTE: This size is a per worker (i.e., per GPU) configuration, "
+    "and not cluster-wide!",
 )
 @click.option(
     "--rmm-managed-memory/--no-rmm-managed-memory",

--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -98,7 +98,9 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     default=None,
     help="If specified, initialize each worker with an RMM pool of "
     "the given size, otherwise no RMM pool is created. This can be "
-    "an integer (bytes) or string (like 5GB or 5000M).",
+    "an integer (bytes) or string (like 5GB or 5000M)."
+    "NOTE: This size is a per worker (i.e., per GPU), and not "
+    "cluster-wide!",
 )
 @click.option(
     "--rmm-managed-memory/--no-rmm-managed-memory",

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -86,6 +86,7 @@ class LocalCUDACluster(LocalCluster):
     rmm_pool_size: None, int or str
         When None (default), no RMM pool is initialized. If a different value
         is given, it can be an integer (bytes) or string (like 5GB or 5000M).
+        NOTE: This size is a per worker (i.e., per GPU), and not cluster-wide!
     rmm_managed_memory: bool
         If True, initialize each worker with RMM and set it to use managed
         memory. If False, RMM may still be used if `rmm_pool_size` is specified,

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -86,7 +86,8 @@ class LocalCUDACluster(LocalCluster):
     rmm_pool_size: None, int or str
         When None (default), no RMM pool is initialized. If a different value
         is given, it can be an integer (bytes) or string (like 5GB or 5000M).
-        NOTE: This size is a per worker (i.e., per GPU), and not cluster-wide!
+        NOTE: The size is a per worker (i.e., per GPU) configuration, and
+        not cluster-wide!
     rmm_managed_memory: bool
         If True, initialize each worker with RMM and set it to use managed
         memory. If False, RMM may still be used if `rmm_pool_size` is specified,

--- a/docs/source/worker.rst
+++ b/docs/source/worker.rst
@@ -65,7 +65,7 @@ New configuration options::
                                     pool is created. This can be an integer
                                     (bytes) or string (like 5GB or 5000M).
                                     NOTE: This size is a per worker (i.e., per
-                                    GPU), and not cluster-wide!
+                                    GPU) configuration, and not cluster-wide!
 
     --enable-tcp-over-ucx / --disable-tcp-over-ucx
                                     Enable TCP communication over UCX

--- a/docs/source/worker.rst
+++ b/docs/source/worker.rst
@@ -64,6 +64,8 @@ New configuration options::
                                     RMM pool of the given size, otherwise no RMM
                                     pool is created. This can be an integer
                                     (bytes) or string (like 5GB or 5000M).
+                                    NOTE: This size is a per worker (i.e., per
+                                    GPU), and not cluster-wide!
 
     --enable-tcp-over-ucx / --disable-tcp-over-ucx
                                     Enable TCP communication over UCX


### PR DESCRIPTION
I've recently seen some confusion on RMM pool being though as a cluster-wide size, this PR clarifies it's per worker.