### PR TITLE
Auto-label PRs based on their content [skip-ci]

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,25 +1,25 @@
 # https://github.com/actions/labeler#common-examples
-# Adapted from https://github.com/rapidsai/cudf/blob/main/.github/CODEOWNERS
+# Adapted from https://github.com/rapidsai/dask-cuda/blob/main/.github/CODEOWNERS
 # Labels culled from https://github.com/rapidsai/dask-cuda/labels
 
 Python:
- - python/**
- - notebooks/**
+ - 'dask_cuda/**'
+ - 'notebooks/**'
 
 libdaskcuda:
- - cpp/**
+ - 'cpp/**'
 
 CMake:
- - **/CMakeLists.txt
- - **/cmake/**
+ - '**/CMakeLists.txt'
+ - '**/cmake/**'
 
 Java:
- - java/**
+ - 'java/**'
 
 Ops:
- - .github/**
- - /ci/**
- - conda/**
- - **/Dockerfile
- - **/.dockerignore
- - docker/**
+ - '.github/**'
+ - 'ci/**'
+ - 'conda/**'
+ - '**/Dockerfile'
+ - '**/.dockerignore'
+ - 'docker/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,13 +5,6 @@
 python:
  - 'dask_cuda/**'
 
-cpp:
- - 'cpp/**'
-
-CMake:
- - '**/CMakeLists.txt'
- - '**/cmake/**'
-
 ci:
   - 'ci/**'
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,6 +5,9 @@
 python:
  - 'dask_cuda/**'
 
+doc:
+ - 'docs/**'
+
 gpuCI:
   - 'ci/**'
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,25 @@
+# https://github.com/actions/labeler#common-examples
+# Adapted from https://github.com/rapidsai/cudf/blob/main/.github/CODEOWNERS
+# Labels culled from https://github.com/rapidsai/dask-cuda/labels
+
+Python:
+ - python/**
+ - notebooks/**
+
+libdaskcuda:
+ - cpp/**
+
+CMake:
+ - **/CMakeLists.txt
+ - **/cmake/**
+
+Java:
+ - java/**
+
+Ops:
+ - .github/**
+ - /ci/**
+ - conda/**
+ - **/Dockerfile
+ - **/.dockerignore
+ - docker/**

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,7 +2,7 @@
 # Adapted from https://github.com/rapidsai/dask-cuda/blob/main/.github/CODEOWNERS
 # Labels culled from https://github.com/rapidsai/dask-cuda/labels
 
-Python:
+python:
  - 'dask_cuda/**'
 
 cpp:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,9 +5,8 @@
 python:
  - 'dask_cuda/**'
 
-ci:
+gpuCI:
   - 'ci/**'
 
 conda:
   - 'conda/**'
-

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,22 +4,17 @@
 
 Python:
  - 'dask_cuda/**'
- - 'notebooks/**'
 
-libdaskcuda:
+cpp:
  - 'cpp/**'
 
 CMake:
  - '**/CMakeLists.txt'
  - '**/cmake/**'
 
-Java:
- - 'java/**'
+ci:
+  - 'ci/**'
 
-Ops:
- - '.github/**'
- - 'ci/**'
- - 'conda/**'
- - '**/Dockerfile'
- - '**/.dockerignore'
- - 'docker/**'
+conda:
+  - 'conda/**'
+

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+ triage:
+   runs-on: ubuntu-latest
+   steps:
+   - uses: actions/labeler@main
+     with:
+       repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR adds the GitHub action [PR Labeler](https://github.com/actions/labeler) to auto-label PRs based on their content. 

Labeling is managed with a configuration file `.github/labeler.yml` using the following [options](https://github.com/actions/labeler#usage)