### PR TITLE
Fail if scheduler starts with '-' in dask-cuda-worker

### DIFF
--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -235,6 +235,13 @@ def main(
     else:
         security = None
 
+    if isinstance(scheduler, str) and scheduler.startswith("-"):
+        raise ValueError(
+            "The scheduler address can't start with '-'. Please check "
+            "your command line arguments, you probably attempted to use "
+            "unsupported one. Scheduler address: %s" % scheduler
+        )
+
     worker = CUDAWorker(
         scheduler,
         host,

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+import subprocess
 
 import pytest
 
@@ -98,3 +99,9 @@ def test_rmm_managed(loop):  # noqa: F811
                 )
                 for v in memory_resource_type.values():
                     assert v is rmm.mr.ManagedMemoryResource
+
+
+def test_unknown_argument():
+    ret = subprocess.run(["dask-cuda-worker", "--my-argument"], capture_output=True)
+    assert ret.returncode != 0
+    assert b"Scheduler address: --my-argument" in ret.stderr


### PR DESCRIPTION
Fixes https://github.com/rapidsai/dask-cuda/issues/472