### PR TITLE
Work on deadlock issue 431

### DIFF
--- a/dask_cuda/explicit_comms/utils.py
+++ b/dask_cuda/explicit_comms/utils.py
@@ -2,8 +2,7 @@ from collections import defaultdict
 
 from toolz import first
 
-from dask import dataframe as dd
-from distributed import default_client, get_client, wait
+from distributed import get_client, wait
 
 
 def extract_ddf_partitions(ddf):
@@ -21,29 +20,3 @@ def extract_ddf_partitions(ddf):
         )  # If multiple workers have the part, we pick the first worker
         ret[worker].append(key_to_part[key])
     return ret
-
-
-def get_meta(df):
-    """
-    Return the metadata from a single dataframe
-    :param df: cudf.dataframe
-    :return: Row data from the first row of the dataframe
-    """
-    ret = df.iloc[:0]
-    return ret
-
-
-def dataframes_to_dask_dataframe(futures, client=None):
-    """
-    Convert a list of futures containing Dataframes (pandas or cudf) into a
-    Dask.Dataframe
-
-    :param futures: list of futures containing dataframes
-    :param client: dask.distributed.Client Optional client to use
-    :return: dask.Dataframe a dask.Dataframe
-    """
-    c = default_client() if client is None else client
-    # Convert a list of futures containing dfs back into a dask_cudf
-    dfs = [d for d in futures if d.type != type(None)]  # NOQA
-    meta = c.submit(get_meta, dfs[0]).result()
-    return dd.from_delayed(dfs, meta=meta)

--- a/dask_cuda/tests/test_explicit_comms.py
+++ b/dask_cuda/tests/test_explicit_comms.py
@@ -36,7 +36,6 @@ def _test_local_cluster(protocol):
             assert sum(comms.run(my_rank)) == sum(range(4))
 
 
-@pytest.mark.xfail(reason="https://github.com/rapidsai/dask-cuda/issues/431")
 @pytest.mark.parametrize("protocol", ["tcp", "ucx"])
 def test_local_cluster(protocol):
     p = mp.Process(target=_test_local_cluster, args=(protocol,))
@@ -95,7 +94,6 @@ def _test_dataframe_merge(backend, protocol, n_workers):
                 pd.testing.assert_frame_equal(got, expected)
 
 
-@pytest.mark.xfail(reason="https://github.com/rapidsai/dask-cuda/issues/431")
 @pytest.mark.parametrize("nworkers", [1, 2, 4])
 @pytest.mark.parametrize("backend", ["pandas", "cudf"])
 @pytest.mark.parametrize("protocol", ["tcp", "ucx"])
@@ -178,7 +176,6 @@ def _test_dataframe_shuffle(backend, protocol, n_workers):
             assert all(result.to_list())
 
 
-@pytest.mark.xfail(reason="https://github.com/rapidsai/dask-cuda/issues/431")
 @pytest.mark.parametrize("nworkers", [1, 2, 4])
 @pytest.mark.parametrize("backend", ["pandas", "cudf"])
 @pytest.mark.parametrize("protocol", ["tcp", "ucx"])


### PR DESCRIPTION
This PR adds a `wait` after submitting dataframe operations in explicit-comms. Hopefully this fixes the deadlock issue #431.
I have re-enabled all the explicit-comms tests and I haven't been able to reproduce the deadlock after 9 CI runs and many local runs.

Having said that, I am not totally convinced that the issue is fixed. The underlying issue is properly some kind of race condition that is hard to trigger so please let me know if any of you encounter a deadlock in explicit-comms!
