### PR TITLE
Hostfile: register the removal of an existing key

### DIFF
--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -148,6 +148,10 @@ class DeviceHostFile(ZictBase):
         self.fast = self.host_buffer if memory_limit == 0 else self.host_buffer.fast
 
     def __setitem__(self, key, value):
+        if key in self.device_buffer:
+            # Make sure we register the removal of an existing key
+            del self[key]
+
         if is_device_object(value):
             self.device_keys.add(key)
             self.device_buffer[key] = value

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -183,6 +183,10 @@ class ProxifyHostFile(MutableMapping):
 
     def __setitem__(self, key, value):
         with self.lock:
+            if key in self.store:
+                # Make sure we register the removal of an existing key
+                del self[key]
+
             found_proxies = []
             proxied_id_to_proxy = self.proxies_tally.get_proxied_id_to_proxy()
             self.store[key] = proxify_device_objects(

--- a/dask_cuda/tests/test_device_host_file.py
+++ b/dask_cuda/tests/test_device_host_file.py
@@ -137,6 +137,11 @@ def test_device_host_file_step_by_step(tmp_path):
     assert set(dhf.host.keys()) == set()
     assert set(dhf.disk.keys()) == set()
 
+    dhf["x"] = b
+    dhf["x"] = a
+    assert set(dhf.device.keys()) == set()
+    assert set(dhf.host.keys()) == set(["x"])
+
 
 @pytest.mark.parametrize("collection", [dict, list, tuple])
 @pytest.mark.parametrize("length", [0, 1, 3, 6])

--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -59,6 +59,10 @@ def test_one_item_limit():
     assert len(p2) == 1
     assert p1[0] is p2[0]
 
+    # Overwriting "k3" with a non-cuda object, should be noticed
+    dhf["k3"] = "non-cuda-object"
+    assert dhf.proxies_tally.get_dev_mem_usage() == 0
+
 
 @pytest.mark.parametrize("jit_unspill", [True, False])
 def test_local_cuda_cluster(jit_unspill):


### PR DESCRIPTION
This PR makes sure that hostfiles register the removal of an existing key. They didn't do that before when mixing CUDA and non-CUDA objects. 