### PR TITLE
ProxyObject: ignore initial fixed attribute errors

### DIFF
--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -55,7 +55,7 @@ def asproxy(obj, serializers=None, subclass=None) -> "ProxyObject":
                 if callable(val):
                     val = val()
                 fixed_attr[attr] = val
-            except Exception:
+            except (AttributeError, TypeError):
                 pass
 
         if subclass is None:

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -55,7 +55,7 @@ def asproxy(obj, serializers=None, subclass=None) -> "ProxyObject":
                 if callable(val):
                     val = val()
                 fixed_attr[attr] = val
-            except AttributeError:
+            except Exception:
                 pass
 
         if subclass is None:

--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -203,6 +203,42 @@ def test_serialize_of_proxied_cudf(proxy_serializers, dask_serializers):
     assert_frame_equal(df.to_pandas(), pxy.to_pandas())
 
 
+@pytest.mark.parametrize("backend", ["numpy", "cupy"])
+def test_fixed_attributes(backend):
+    """Test fixed attributes access (`x.__len__` and `x.name`).
+
+    Notice, accessing fixed attributes shouldn't de-serialize the proxied object
+    """
+    np = pytest.importorskip(backend)
+
+    # Access `len()`` of an array
+    pxy = proxy_object.asproxy(np.arange(10), serializers=("dask",))
+    assert len(pxy) == 10
+    # Accessing the length shouldn't de-serialize the proxied object
+    assert pxy._obj_pxy_is_serialized()
+
+    # Access `len()` of a scalar
+    pxy = proxy_object.asproxy(np.array(10), serializers=("dask",))
+    with pytest.raises(TypeError) as excinfo:
+        len(pxy)
+        assert "len() of unsized object" in str(excinfo.value)
+        assert pxy._obj_pxy_is_serialized()
+
+    # Access `name` of an array
+    pxy = proxy_object.asproxy(np.arange(10), serializers=("dask",))
+    with pytest.raises(AttributeError) as excinfo:
+        pxy.name
+        assert "has no attribute 'name'" in str(excinfo.value)
+        assert pxy._obj_pxy_is_serialized()
+
+    # Access `name` of a datatype
+    pxy = proxy_object.asproxy(
+        np.arange(10, dtype="int64").dtype, serializers=("pickle",)
+    )
+    assert pxy.name == "int64"
+    assert pxy._obj_pxy_is_serialized()
+
+
 @pytest.mark.parametrize("jit_unspill", [True, False])
 def test_spilling_local_cuda_cluster(jit_unspill):
     """Testing spilling of a proxied cudf dataframe in a local cuda cluster"""

--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -58,10 +58,11 @@ def test_double_proxy_object(serializers_first, serializers_second):
 
 
 @pytest.mark.parametrize("serializers", [None, ("dask", "pickle")])
-def test_proxy_object_of_numpy(serializers):
-    """Check that a proxied numpy array behaves as a regular dataframe"""
+@pytest.mark.parametrize("backend", ["numpy", "cupy"])
+def test_proxy_object_of_array(serializers, backend):
+    """Check that a proxied array behaves as a regular (numpy or cupy) array"""
 
-    np = pytest.importorskip("numpy")
+    np = pytest.importorskip(backend)
 
     # Make sure that equality works, which we use to test the other operators
     org = np.arange(10) + 1


### PR DESCRIPTION
Fixes https://github.com/rapidsai/gpu-bdb/issues/174 by ignoring errors when initializing fixed attributes. Also adds tests of fixed attributes.


#### Rationale
When initialing a `ProxyObject` we probe the *proxied object* in order to retain a copy of the result of accessing fixed attributes like `name` and `__len__()`. Exceptions trigger by this probing is acceptable and can be safely ignored.


