### PR TITLE
Explicit-comms: lock workers

### DIFF
--- a/dask_cuda/explicit_comms/comms.py
+++ b/dask_cuda/explicit_comms/comms.py
@@ -1,14 +1,42 @@
 import asyncio
 import concurrent.futures
+import contextlib
 import time
 import uuid
 from typing import List, Optional
 
 import distributed.comm
-from distributed import Client, MultiLock, default_client, get_worker
+from distributed import Client, default_client, get_worker
 from distributed.comm.addressing import parse_address, parse_host_port, unparse_address
 
 _default_comms = None
+
+
+def get_multi_lock_or_null_context(multi_lock_context, *args, **kwargs):
+    """Return either a MultiLock or a NULL context
+
+    Parameters
+    ----------
+    multi_lock_context: bool
+        If True return MultiLock context else return a NULL context that
+        doesn't do anything
+
+    *args, **kwargs:
+        Arguments parsed to the MultiLock creation
+
+    Returns
+    -------
+    context: context
+        Either `MultiLock(*args, **kwargs)` or a NULL context
+    """
+    if multi_lock_context:
+        from distributed import MultiLock
+
+        return MultiLock(*args, **kwargs)
+    else:
+        # Use a null context that doesn't do anything
+        # TODO: use `contextlib.nullcontext()` from Python 3.7+
+        return contextlib.suppress()
 
 
 def default_comms(client: Optional[Client] = None) -> "CommsContext":
@@ -208,6 +236,9 @@ class CommsContext:
             Arguments for `coroutine`
         workers: list, optional
             List of workers. Default is all workers
+        lock_workers: bool, optional
+            Use distributed.MultiLock to get exclusive access to the workers. Use
+            this flag to support parallel runs.
 
         Returns
         -------
@@ -217,23 +248,17 @@ class CommsContext:
         if workers is None:
             workers = self.worker_addresses
 
-        if lock_workers:
-            lock = MultiLock(lock_names=workers)
-            lock.acquire()
-
-        ret = []
-        for worker in workers:
-            ret.append(
-                self.client.submit(
-                    _run_coroutine_on_worker,
-                    self.sessionId,
-                    coroutine,
-                    args,
-                    workers=[worker],
-                    pure=False,
+        with get_multi_lock_or_null_context(lock_workers, workers):
+            ret = []
+            for worker in workers:
+                ret.append(
+                    self.client.submit(
+                        _run_coroutine_on_worker,
+                        self.sessionId,
+                        coroutine,
+                        args,
+                        workers=[worker],
+                        pure=False,
+                    )
                 )
-            )
-        ret = self.client.gather(ret)
-        if lock_workers:
-            lock.release()
-        return ret
+            return self.client.gather(ret)

--- a/dask_cuda/tests/test_explicit_comms.py
+++ b/dask_cuda/tests/test_explicit_comms.py
@@ -314,11 +314,16 @@ def test_lock_workers():
     Testing `run(...,lock_workers=True)` by spawning 30 runs with overlapping
     and non-overlapping worker sets.
     """
+    try:
+        from distributed import MultiLock  # noqa F401
+    except ImportError as e:
+        pytest.skip(str(e))
+
     with LocalCluster(
         protocol="tcp",
         dashboard_address=None,
-        n_workers=4,
-        threads_per_worker=30,
+        n_workers=3,
+        threads_per_worker=10,
         processes=True,
     ) as cluster:
         ps = []

--- a/dask_cuda/tests/test_explicit_comms.py
+++ b/dask_cuda/tests/test_explicit_comms.py
@@ -322,12 +322,12 @@ def test_lock_workers():
     with LocalCluster(
         protocol="tcp",
         dashboard_address=None,
-        n_workers=3,
-        threads_per_worker=10,
+        n_workers=4,
+        threads_per_worker=5,
         processes=True,
     ) as cluster:
         ps = []
-        for _ in range(10):
+        for _ in range(5):
             for ranks in [[0, 1], [1, 3], [2, 3]]:
                 ps.append(
                     mp.Process(

--- a/dask_cuda/tests/test_explicit_comms.py
+++ b/dask_cuda/tests/test_explicit_comms.py
@@ -1,3 +1,4 @@
+import asyncio
 import multiprocessing as mp
 
 import numpy as np
@@ -7,7 +8,7 @@ import pytest
 import dask
 from dask import dataframe as dd
 from dask.dataframe.shuffle import partitioning_index
-from distributed import Client
+from distributed import Client, get_worker
 from distributed.deploy.local import LocalCluster
 
 import dask_cuda
@@ -22,8 +23,8 @@ ucp = pytest.importorskip("ucp")
 # that UCX options of the different tests doesn't conflict.
 
 
-async def my_rank(state):
-    return state["rank"]
+async def my_rank(state, arg):
+    return state["rank"] + arg
 
 
 def _test_local_cluster(protocol):
@@ -36,7 +37,7 @@ def _test_local_cluster(protocol):
     ) as cluster:
         with Client(cluster) as client:
             c = comms.CommsContext(client)
-            assert sum(c.run(my_rank)) == sum(range(4))
+            assert sum(c.run(my_rank, 0)) == sum(range(4))
 
 
 @pytest.mark.parametrize("protocol", ["tcp", "ucx"])
@@ -291,3 +292,47 @@ def test_jit_unspill(protocol):
     p.start()
     p.join()
     assert not p.exitcode
+
+
+def _test_lock_workers(scheduler_address, ranks):
+    async def f(_):
+        worker = get_worker()
+        if hasattr(worker, "running"):
+            assert not worker.running
+        worker.running = True
+        await asyncio.sleep(0.5)
+        assert worker.running
+        worker.running = False
+
+    with Client(scheduler_address) as client:
+        c = comms.CommsContext(client)
+        c.run(f, workers=[c.worker_addresses[r] for r in ranks], lock_workers=True)
+
+
+def test_lock_workers():
+    """
+    Testing `run(...,lock_workers=True)` by spawning 30 runs with overlapping
+    and non-overlapping worker sets.
+    """
+    with LocalCluster(
+        protocol="tcp",
+        dashboard_address=None,
+        n_workers=4,
+        threads_per_worker=30,
+        processes=True,
+    ) as cluster:
+        ps = []
+        for _ in range(10):
+            for ranks in [[0, 1], [1, 3], [2, 3]]:
+                ps.append(
+                    mp.Process(
+                        target=_test_lock_workers,
+                        args=(cluster.scheduler_address, ranks),
+                    )
+                )
+                ps[-1].start()
+
+        for p in ps:
+            p.join()
+
+        assert all(p.exitcode == 0 for p in ps)


### PR DESCRIPTION
This PR uses https://github.com/dask/distributed/pull/4503 to support locking of workers before submitting an explicit-comms job.

- [x] Implement `CommsContext.run(..., lock_workers=False)`
- [x] Implement tests