### PR TITLE
Add operations/arguments to local CuPy array benchmark

### DIFF
--- a/dask_cuda/__init__.py
+++ b/dask_cuda/__init__.py
@@ -1,8 +1,9 @@
 import dask
 import dask.dataframe.shuffle
-from .explicit_comms.dataframe.shuffle import get_rearrange_by_column_tasks_wrapper
+
 from ._version import get_versions
 from .cuda_worker import CUDAWorker
+from .explicit_comms.dataframe.shuffle import get_rearrange_by_column_tasks_wrapper
 from .local_cuda_cluster import LocalCUDACluster
 
 __version__ = get_versions()["version"]

--- a/dask_cuda/benchmarks/local_cupy.py
+++ b/dask_cuda/benchmarks/local_cupy.py
@@ -1,5 +1,6 @@
 import asyncio
 from collections import defaultdict
+from json import dump
 from time import perf_counter as clock
 from warnings import filterwarnings
 
@@ -198,7 +199,6 @@ async def run(args):
                 print(fmt % (d1, d2, bw[0], bw[1], bw[2], total_nbytes[(d1, d2)]))
 
             if args.benchmark_json:
-                import json
 
                 d = {
                     "operation": args.operation,
@@ -229,7 +229,7 @@ async def run(args):
                     },
                 }
                 with open(args.benchmark_json, "w") as fp:
-                    json.dump(d, fp, indent=2)
+                    dump(d, fp, indent=2)
 
             # An SSHCluster will not automatically shut down, we have to
             # ensure it does.

--- a/dask_cuda/benchmarks/local_cupy.py
+++ b/dask_cuda/benchmarks/local_cupy.py
@@ -41,15 +41,6 @@ async def _run(client, args):
         func_args = (x, y)
 
         func = lambda x, y: x.dot(y)
-    elif args.operation == "cross":
-        x = rs.random((args.size, args.size), chunks=args.chunk_size).persist()
-        y = rs.random((args.size, args.size), chunks=args.chunk_size).persist()
-        await wait(x)
-        await wait(y)
-
-        func_args = (x, y)
-
-        func = lambda x, y: x.cross(y)
     elif args.operation == "svd":
         x = rs.random(
             (args.size, args.second_size),
@@ -260,7 +251,7 @@ def parse_args():
             "default": "transpose_sum",
             "type": str,
             "help": "The operation to run, valid options are: "
-            "'transpose_sum' (default), 'dot', 'cross', 'fft', 'svd', 'sum', 'mean', 'slice'.",
+            "'transpose_sum' (default), 'dot', 'fft', 'svd', 'sum', 'mean', 'slice'.",
         },
         {
             "name": ["-c", "--chunk-size",],

--- a/dask_cuda/benchmarks/local_cupy.py
+++ b/dask_cuda/benchmarks/local_cupy.py
@@ -200,6 +200,26 @@ async def run(args):
                 )
                 print(fmt % (d1, d2, bw[0], bw[1], bw[2], total_nbytes[(d1, d2)]))
 
+            if args.benchmark_json:
+                import json
+
+                d = {
+                    "operation": args.operation,
+                    "size": args.size,
+                    "second_size": args.second_size,
+                    "chunk_size": args.chunk_size,
+                    "compute_size": size,
+                    "compute_chunk_size": chunksize,
+                    "ignore_size": format_bytes(args.ignore_size),
+                    "protocol": args.protocol,
+                    "devs": args.devs,
+                    "threads_per_worker": args.threads_per_worker,
+                    "times": took_list,
+                    "bandwiths": sorted(bandwidths.items()),
+                }
+                with open(args.benchmark_json, "w") as fp:
+                    json.dump(d, fp, indent=2)
+
             # An SSHCluster will not automatically shut down, we have to
             # ensure it does.
             if args.multi_node:
@@ -250,6 +270,12 @@ def parse_args():
             "help": "Ignore messages smaller than this (default '1 MB')",
         },
         {"name": "--runs", "default": 3, "type": int, "help": "Number of runs",},
+        {
+            "name": "--benchmark-json",
+            "default": None,
+            "type": str,
+            "help": "Dump a JSON report of benchmarks (optional).",
+        },
     ]
 
     return parse_benchmark_args(

--- a/dask_cuda/benchmarks/local_cupy.py
+++ b/dask_cuda/benchmarks/local_cupy.py
@@ -41,6 +41,15 @@ async def _run(client, args):
         func_args = (x, y)
 
         func = lambda x, y: x.dot(y)
+    elif args.operation == "cross":
+        x = rs.random((args.size, args.size), chunks=args.chunk_size).persist()
+        y = rs.random((args.size, args.size), chunks=args.chunk_size).persist()
+        await wait(x)
+        await wait(y)
+
+        func_args = (x, y)
+
+        func = lambda x, y: x.cross(y)
     elif args.operation == "svd":
         x = rs.random(
             (args.size, args.second_size),
@@ -60,6 +69,18 @@ async def _run(client, args):
         func_args = (x,)
 
         func = lambda x: np.fft.fft(x, axis=0)
+    elif args.operation == "sum":
+        x = rs.random((args.size, args.size), chunks=args.chunk_size).persist()
+        await wait(x)
+        func_args = (x,)
+
+        func = lambda x: x.sum()
+    elif args.operation == "mean":
+        x = rs.random((args.size, args.size), chunks=args.chunk_size).persist()
+        await wait(x)
+        func_args = (x,)
+
+        func = lambda x: x.mean()
 
     shape = x.shape
     chunksize = x.chunksize
@@ -213,7 +234,7 @@ def parse_args():
             "default": "transpose_sum",
             "type": str,
             "help": "The operation to run, valid options are: "
-            "'transpose_sum' (default), 'dot', 'fft', 'svd'.",
+            "'transpose_sum' (default), 'dot', 'cross', 'fft', 'svd', 'sum', 'mean'.",
         },
         {
             "name": ["-c", "--chunk-size",],

--- a/dask_cuda/benchmarks/local_cupy.py
+++ b/dask_cuda/benchmarks/local_cupy.py
@@ -81,6 +81,12 @@ async def _run(client, args):
         func_args = (x,)
 
         func = lambda x: x.mean()
+    elif args.operation == "slice":
+        x = rs.random((args.size, args.size), chunks=args.chunk_size).persist()
+        await wait(x)
+        func_args = (x,)
+
+        func = lambda x: x[::3].copy()
 
     shape = x.shape
     chunksize = x.chunksize
@@ -254,7 +260,7 @@ def parse_args():
             "default": "transpose_sum",
             "type": str,
             "help": "The operation to run, valid options are: "
-            "'transpose_sum' (default), 'dot', 'cross', 'fft', 'svd', 'sum', 'mean'.",
+            "'transpose_sum' (default), 'dot', 'cross', 'fft', 'svd', 'sum', 'mean', 'slice'.",
         },
         {
             "name": ["-c", "--chunk-size",],


### PR DESCRIPTION
This PR adds the following operations to the local CuPy array benchmark:

- sum
- mean
- array slicing

This also adds an additional special argument, `--benchmark-json`, which takes an optional path to dump the results of the benchmark in JSON format. This would allow us to generate plots using the output, as discussed in #517.

Some thoughts:

- Should there be an additional argument to specify the array slicing interval (which is currently fixed at 3)?
- Could the JSON output be cleaned up? Currently, a (truncated) sample output file looks like:

```json
{
  "operation": "transpose_sum",
  "size": 10000,
  "second_size": 1000,
  "chunk_size": 2500,
  "compute_size": [
    10000,
    10000
  ],
  "compute_chunk_size": [
    2500,
    2500
  ],
  "ignore_size": "1.05 MB",
  "protocol": "tcp",
  "devs": "0,1,2,3",
  "threads_per_worker": 1,
  "times": [
    {
      "wall_clock": 1.4910394318867475,
      "npartitions": 16
    }
  ],
  "bandwidths": {
    "(00,01)": {
      "25%": "136.34 MB/s",
      "50%": "156.67 MB/s",
      "75%": "163.32 MB/s",
      "total_nbytes": "150.00 MB"
    }
  }
}
```