### PR TITLE
ProxifyHostFile: tracking of external objects

### DIFF
--- a/dask_cuda/explicit_comms/dataframe/shuffle.py
+++ b/dask_cuda/explicit_comms/dataframe/shuffle.py
@@ -11,12 +11,13 @@ import dask
 import dask.dataframe
 import distributed
 from dask.base import compute_as_if_collection, tokenize
-from dask.dataframe.core import DataFrame, _concat
+from dask.dataframe.core import DataFrame, _concat as dd_concat
 from dask.dataframe.shuffle import shuffle_group
 from dask.delayed import delayed
 from distributed import wait
 from distributed.protocol import nested_deserialize, to_serialize
 
+from ...proxify_host_file import ProxifyHostFile
 from .. import comms
 
 
@@ -46,6 +47,7 @@ def sort_in_parts(
     rank_to_out_part_ids: Dict[int, List[int]],
     ignore_index: bool,
     concat_dfs_of_same_output_partition: bool,
+    concat,
 ) -> Dict[int, List[List[DataFrame]]]:
     """ Sort the list of grouped dataframes in `in_parts`
 
@@ -96,7 +98,7 @@ def sort_in_parts(
             for i in range(len(rank_to_out_parts_list[rank])):
                 if len(rank_to_out_parts_list[rank][i]) > 1:
                     rank_to_out_parts_list[rank][i] = [
-                        _concat(
+                        concat(
                             rank_to_out_parts_list[rank][i], ignore_index=ignore_index
                         )
                     ]
@@ -144,11 +146,30 @@ async def local_shuffle(
     eps = s["eps"]
     assert s["rank"] in workers
 
+    try:
+        hostfile = first(iter(in_parts[0].values()))._obj_pxy.get(
+            "hostfile", lambda: None
+        )()
+    except AttributeError:
+        hostfile = None
+
+    if isinstance(hostfile, ProxifyHostFile):
+
+        def concat(args, ignore_index=False):
+            if len(args) < 2:
+                return args[0]
+
+            return hostfile.add_external(dd_concat(args, ignore_index=ignore_index))
+
+    else:
+        concat = dd_concat
+
     rank_to_out_parts_list = sort_in_parts(
         in_parts,
         rank_to_out_part_ids,
         ignore_index,
         concat_dfs_of_same_output_partition=True,
+        concat=concat,
     )
 
     # Communicate all the dataframe-partitions all-to-all. The result is
@@ -176,7 +197,7 @@ async def local_shuffle(
         dfs.extend(rank_to_out_parts_list[myrank][i])
         rank_to_out_parts_list[myrank][i] = None
         if len(dfs) > 1:
-            ret.append(_concat(dfs, ignore_index=ignore_index))
+            ret.append(concat(dfs, ignore_index=ignore_index))
         else:
             ret.append(dfs[0])
     return ret

--- a/dask_cuda/proxify_device_objects.py
+++ b/dask_cuda/proxify_device_objects.py
@@ -41,6 +41,10 @@ def proxify(obj, proxied_id_to_proxy, found_proxies, subclass=None):
     _id = id(obj)
     if _id in proxied_id_to_proxy:
         ret = proxied_id_to_proxy[_id]
+        finalize = ret._obj_pxy.get("external_finalize", None)
+        if finalize:
+            finalize()
+            proxied_id_to_proxy[_id] = ret = asproxy(obj, subclass=subclass)
     else:
         proxied_id_to_proxy[_id] = ret = asproxy(obj, subclass=subclass)
     found_proxies.append(ret)
@@ -67,6 +71,14 @@ def proxify_device_object_proxy_object(obj, proxied_id_to_proxy, found_proxies):
         if _id in proxied_id_to_proxy:
             obj = proxied_id_to_proxy[_id]
         else:
+            proxied_id_to_proxy[_id] = obj
+
+    finalize = obj._obj_pxy.get("external_finalize", None)
+    if finalize:
+        finalize()
+        obj = obj._obj_pxy_copy()
+        if not obj._obj_pxy_is_serialized():
+            _id = id(obj._obj_pxy["obj"])
             proxied_id_to_proxy[_id] = obj
 
     found_proxies.append(obj)

--- a/dask_cuda/proxify_device_objects.py
+++ b/dask_cuda/proxify_device_objects.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, List, MutableMapping
 
 from dask.utils import Dispatch
 
@@ -9,7 +9,7 @@ dispatch = Dispatch(name="proxify_device_objects")
 
 def proxify_device_objects(
     obj: Any,
-    proxied_id_to_proxy: Dict[int, ProxyObject],
+    proxied_id_to_proxy: MutableMapping[int, ProxyObject],
     found_proxies: List[ProxyObject],
 ):
     """ Wrap device objects in ProxyObject
@@ -22,7 +22,7 @@ def proxify_device_objects(
     ----------
     obj: Any
         Object to search through or wrap in a ProxyObject.
-    proxied_id_to_proxy: Dict[int, ProxyObject]
+    proxied_id_to_proxy: MutableMapping[int, ProxyObject]
         Dict mapping the id() of proxied objects (CUDA device objects) to
         their proxy and is updated with all new proxied objects found in `obj`.
     found_proxies: List[ProxyObject]

--- a/dask_cuda/proxify_device_objects.py
+++ b/dask_cuda/proxify_device_objects.py
@@ -56,7 +56,6 @@ def proxify_device_object_default(obj, proxied_id_to_proxy, found_proxies):
 
 @dispatch.register(ProxyObject)
 def proxify_device_object_proxy_object(obj, proxied_id_to_proxy, found_proxies):
-
     # We deserialize CUDA-serialized objects since it is very cheap and
     # makes it easy to administrate device memory usage
     if obj._obj_pxy_is_serialized() and "cuda" in obj._obj_pxy["serializers"]:

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -182,10 +182,13 @@ class ProxifyHostFile(MutableMapping):
             return total_dev_mem_usage, dev_buf_access
 
     def add_external(self, obj):
-        # Notice, since `self.store` isn't modified no lock is needed
+        # Notice, since `self.store` isn't modified, no lock is needed
         found_proxies: List[ProxyObject] = []
-        proxied_id_to_proxy = self.proxies_tally.get_proxied_id_to_proxy()
-        ret = proxify_device_objects(obj, proxied_id_to_proxy, found_proxies)
+        proxied_id_to_proxy = {}
+        # Notice, we are excluding found objects that are already proxies
+        ret = proxify_device_objects(
+            obj, proxied_id_to_proxy, found_proxies, excl_proxies=True
+        )
         last_access = time.time()
         self_weakref = weakref.ref(self)
         for p in found_proxies:

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -207,7 +207,7 @@ class ProxifyHostFile(MutableMapping):
         ret = proxify_device_objects(
             obj, proxied_id_to_proxy, found_proxies, excl_proxies=True
         )
-        last_access = time.time()
+        last_access = time.monotonic()
         self_weakref = weakref.ref(self)
         for p in found_proxies:
             name = id(p)
@@ -235,7 +235,7 @@ class ProxifyHostFile(MutableMapping):
             self.store[key] = proxify_device_objects(
                 value, proxied_id_to_proxy, found_proxies
             )
-            last_access = time.time()
+            last_access = time.monotonic()
             self_weakref = weakref.ref(self)
             for p in found_proxies:
                 p._obj_pxy["hostfile"] = self_weakref

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -182,6 +182,7 @@ class ProxifyHostFile(MutableMapping):
             return total_dev_mem_usage, dev_buf_access
 
     def add_external(self, obj):
+        # Notice, since `self.store` isn't modified no lock is needed
         found_proxies: List[ProxyObject] = []
         proxied_id_to_proxy = self.proxies_tally.get_proxied_id_to_proxy()
         ret = proxify_device_objects(obj, proxied_id_to_proxy, found_proxies)
@@ -218,12 +219,7 @@ class ProxifyHostFile(MutableMapping):
             for p in found_proxies:
                 p._obj_pxy["hostfile"] = self_weakref
                 p._obj_pxy["last_access"] = last_access
-
-                external_finalize = p._obj_pxy.get("external_finalize", None)
-                if external_finalize is not None:
-                    external_finalize()
-                    del p._obj_pxy["external"]
-                    del p._obj_pxy["external_finalize"]
+                assert "external" not in p._obj_pxy
 
             self.proxies_tally.add_key(key, found_proxies)
             self.maybe_evict()

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -164,7 +164,7 @@ class ProxifyHostFile(MutableMapping):
         with self.lock:
             # Notice, multiple proxy object can point to different non-overlapping
             # parts of the same device buffer.
-            ret = DefaultDict(list)
+            ret = defaultdict(list)
             for proxy in self.proxies_tally.get_unspilled_proxies():
                 for dev_buffer in proxy._obj_pxy_get_device_memory_objects():
                     ret[dev_buffer].append(proxy)

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -199,6 +199,12 @@ class ProxyObject:
         self._obj_pxy_lock = threading.RLock()
         self._obj_pxy_cache = {}
 
+    def __del__(self):
+        """In order to call `external_finalize()` ASAP, we call it here"""
+        external_finalize = self._obj_pxy.get("external_finalize", None)
+        if external_finalize is not None:
+            external_finalize()
+
     def _obj_pxy_get_init_args(self, include_obj=True):
         """Return the attributes needed to initialize a ProxyObject
 

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -321,7 +321,7 @@ class ProxyObject:
                     external = self._obj_pxy.get("external", self)
                     hostfile.proxies_tally.unspill_proxy(external)
 
-            self._obj_pxy["last_access"] = time.time()
+            self._obj_pxy["last_access"] = time.monotonic()
             return self._obj_pxy["obj"]
 
     def _obj_pxy_is_cuda_object(self) -> bool:

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -277,7 +277,8 @@ class ProxyObject:
                 self._obj_pxy["serializers"] = serializers
                 hostfile = self._obj_pxy.get("hostfile", lambda: None)()
                 if hostfile is not None:
-                    hostfile.proxies_tally.spill_proxy(self)
+                    external = self._obj_pxy.get("external", self)
+                    hostfile.proxies_tally.spill_proxy(external)
 
             # Invalidate the (possible) cached "device_memory_objects"
             self._obj_pxy_cache.pop("device_memory_objects", None)
@@ -311,7 +312,8 @@ class ProxyObject:
                 self._obj_pxy["obj"] = distributed.protocol.deserialize(header, frames)
                 self._obj_pxy["serializers"] = None
                 if hostfile is not None:
-                    hostfile.proxies_tally.unspill_proxy(self)
+                    external = self._obj_pxy.get("external", self)
+                    hostfile.proxies_tally.unspill_proxy(external)
 
             self._obj_pxy["last_access"] = time.time()
             return self._obj_pxy["obj"]

--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -156,10 +156,22 @@ def test_externals():
 def test_externals_setitem():
     dhf = ProxifyHostFile(device_memory_limit=itemsize)
     k1 = dhf.add_external(cupy.arange(1) + 1)
+    assert type(k1) is dask_cuda.proxy_object.ProxyObject
     assert len(dhf) == 0
     assert "external" in k1._obj_pxy
     assert "external_finalize" in k1._obj_pxy
     dhf["k1"] = k1
+    k1 = dhf["k1"]
+    assert type(k1) is dask_cuda.proxy_object.ProxyObject
     assert len(dhf) == 1
-    assert "external" not in dhf["k1"]._obj_pxy
-    assert "external_finalize" not in dhf["k1"]._obj_pxy
+    assert "external" not in k1._obj_pxy
+    assert "external_finalize" not in k1._obj_pxy
+
+    k1 = dhf.add_external(cupy.arange(1) + 1)
+    k1._obj_pxy_serialize(serializers=("dask", "pickle"))
+    dhf["k1"] = k1
+    k1 = dhf["k1"]
+    assert type(k1) is dask_cuda.proxy_object.ProxyObject
+    assert len(dhf) == 1
+    assert "external" not in k1._obj_pxy
+    assert "external_finalize" not in k1._obj_pxy

--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -151,3 +151,15 @@ def test_externals():
     del k2
     assert dhf.proxies_tally.get_dev_mem_usage() == 0
     assert len(list(dhf.proxies_tally.get_unspilled_proxies())) == 0
+
+
+def test_externals_setitem():
+    dhf = ProxifyHostFile(device_memory_limit=itemsize)
+    k1 = dhf.add_external(cupy.arange(1) + 1)
+    assert len(dhf) == 0
+    assert "external" in k1._obj_pxy
+    assert "external_finalize" in k1._obj_pxy
+    dhf["k1"] = k1
+    assert len(dhf) == 1
+    assert "external" not in dhf["k1"]._obj_pxy
+    assert "external_finalize" not in dhf["k1"]._obj_pxy

--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -155,7 +155,7 @@ def test_externals():
 
 def test_externals_setitem():
     dhf = ProxifyHostFile(device_memory_limit=itemsize)
-    k1 = dhf.add_external(cupy.arange(1) + 1)
+    k1 = dhf.add_external(cupy.arange(1))
     assert type(k1) is dask_cuda.proxy_object.ProxyObject
     assert len(dhf) == 0
     assert "external" in k1._obj_pxy
@@ -167,7 +167,7 @@ def test_externals_setitem():
     assert "external" not in k1._obj_pxy
     assert "external_finalize" not in k1._obj_pxy
 
-    k1 = dhf.add_external(cupy.arange(1) + 1)
+    k1 = dhf.add_external(cupy.arange(1))
     k1._obj_pxy_serialize(serializers=("dask", "pickle"))
     dhf["k1"] = k1
     k1 = dhf["k1"]
@@ -175,3 +175,13 @@ def test_externals_setitem():
     assert len(dhf) == 1
     assert "external" not in k1._obj_pxy
     assert "external_finalize" not in k1._obj_pxy
+
+    dhf["k1"] = cupy.arange(1)
+    assert len(dhf.proxies_tally.proxy_id_to_proxy) == 1
+    assert dhf.proxies_tally.get_dev_mem_usage() == itemsize
+    k1 = dhf.add_external(k1)
+    assert len(dhf.proxies_tally.proxy_id_to_proxy) == 1
+    assert dhf.proxies_tally.get_dev_mem_usage() == itemsize
+    k1 = dhf.add_external(dhf["k1"])
+    assert len(dhf.proxies_tally.proxy_id_to_proxy) == 1
+    assert dhf.proxies_tally.get_dev_mem_usage() == itemsize

--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -22,13 +22,13 @@ def test_one_item_limit():
 
     # Check k1 is spilled because of the newer k2
     k1 = dhf["k1"]
+    k2 = dhf["k2"]
     assert k1._obj_pxy_is_serialized()
-    assert not dhf["k2"]._obj_pxy_is_serialized()
+    assert not k2._obj_pxy_is_serialized()
 
     # Accessing k1 spills k2 and unspill k1
     k1_val = k1[0]
     assert k1_val == 1
-    k2 = dhf["k2"]
     assert k2._obj_pxy_is_serialized()
 
     # Duplicate arrays changes nothing
@@ -50,11 +50,11 @@ def test_one_item_limit():
 
     # Deleting k2 does not change anything since k3 still holds a
     # reference to the underlying proxy object
-    assert dhf.proxies_tally.get_dev_mem_usage() == 8
+    assert dhf.proxies_tally.get_dev_mem_usage() == itemsize
     p1 = list(dhf.proxies_tally.get_unspilled_proxies())
     assert len(p1) == 1
     del dhf["k2"]
-    assert dhf.proxies_tally.get_dev_mem_usage() == 8
+    assert dhf.proxies_tally.get_dev_mem_usage() == itemsize
     p2 = list(dhf.proxies_tally.get_unspilled_proxies())
     assert len(p2) == 1
     assert p1[0] is p2[0]


### PR DESCRIPTION
This PR implements tracking of external objects. The idea is that tasks can register objects that should be exposed to spilling when `ProxifyHostFile`  is running out of memory.

Also, this PR makes the long running explicit-comms tasks [`local_shuffle()`](https://github.com/rapidsai/dask-cuda/blob/a574ccb53aac6d2be961e90db8a4f61f7fc80b20/dask_cuda/explicit_comms/dataframe/shuffle.py#L106) use this new feature, which means it shouldn't require more GPU memory than the regular shuffle implementation in Dask.
