### PR TITLE
Add device synchonization for local CuPy benchmarks with Dask profiling

### DIFF
--- a/dask_cuda/benchmarks/local_cupy.py
+++ b/dask_cuda/benchmarks/local_cupy.py
@@ -87,7 +87,10 @@ async def _run(client, args):
     if args.profile is not None:
         async with performance_report(filename=args.profile):
             t1 = clock()
-            await client.compute(func(*func_args))
+            res = client.compute(func(*func_args))
+            await client.gather(res)
+            if args.type == "gpu":
+                await client.run(lambda xp: xp.cuda.Device().synchronize(), xp)
             took = clock() - t1
     else:
         t1 = clock()

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ copyright = "2020, NVIDIA"
 author = "NVIDIA"
 
 # The full version, including alpha/beta/rc tags.
-from dask_cuda import __version__ as release
+from dask_cuda import __version__ as release  # noqa: E402
 
 # The short X.Y version.
 version = ".".join(release.split(".")[:2])


### PR DESCRIPTION
This PR ensures CUDA device synchronization for local CuPy benchmarks when profiling with Dask performance reports.

Prior to this, the run times of benchmarks running over UCX would vary drastically depending on if a performance report was generated or not:

```
>>> python local_cupy.py -p ucx --ucx-net-devices auto
Roundtrip benchmark
--------------------------
Operation          | transpose_sum
User size          | 10000
User second size   | 1000
User chunk-size    | 2500
Compute shape      | (10000, 10000)
Compute chunk-size | (2500, 2500)
Ignore-size        | 1.05 MB
Protocol           | ucx
Device(s)          | 0
Worker Thread(s)   | 1
==========================
Wall-clock         | npartitions
--------------------------
2.78 s             | 16
2.02 s             | 16
2.02 s             | 16
==========================
(w1,w2)            | 25% 50% 75% (total nbytes)
--------------------------

>>> python local_cupy.py -p ucx --ucx-net-devices auto --profile dask-report.html
Roundtrip benchmark
--------------------------
Operation          | transpose_sum
User size          | 10000
User second size   | 1000
User chunk-size    | 2500
Compute shape      | (10000, 10000)
Compute chunk-size | (2500, 2500)
Ignore-size        | 1.05 MB
Protocol           | ucx
Device(s)          | 0
Worker Thread(s)   | 1
==========================
Wall-clock         | npartitions
--------------------------
2.79 s             | 16
49.28 ms           | 16
49.22 ms           | 16
==========================
(w1,w2)            | 25% 50% 75% (total nbytes)
--------------------------
```

Additionally, I suppressed flake8 rule E402 in `docs/source/conf.py`, as that had been causing the pre-commit hooks to fail up until now. I'm okay with removing that change if it would be better suited for a separate PR.