### PR TITLE
Replace compute() calls on CuPy benchmarks by persist()

### DIFF
--- a/dask_cuda/benchmarks/local_cupy.py
+++ b/dask_cuda/benchmarks/local_cupy.py
@@ -87,12 +87,11 @@ async def _run(client, args):
     if args.profile is not None:
         async with performance_report(filename=args.profile):
             t1 = clock()
-            await client.compute(func(*func_args))
+            await wait(client.persist(func(*func_args)))
             took = clock() - t1
     else:
         t1 = clock()
-        res = client.compute(func(*func_args))
-        await client.gather(res)
+        await wait(client.persist(func(*func_args)))
         if args.type == "gpu":
             await client.run(lambda xp: xp.cuda.Device().synchronize(), xp)
         took = clock() - t1

--- a/dask_cuda/benchmarks/local_cupy_map_overlap.py
+++ b/dask_cuda/benchmarks/local_cupy_map_overlap.py
@@ -42,11 +42,15 @@ async def _run(client, args):
     if args.profile is not None:
         async with performance_report(filename=args.profile):
             t1 = clock()
-            await client.compute(x.map_overlap(mean_filter, args.kernel_size, shape=ks))
+            await wait(
+                client.persist(x.map_overlap(mean_filter, args.kernel_size, shape=ks))
+            )
             took = clock() - t1
     else:
         t1 = clock()
-        await client.compute(x.map_overlap(mean_filter, args.kernel_size, shape=ks))
+        await wait(
+            client.persist(x.map_overlap(mean_filter, args.kernel_size, shape=ks))
+        )
         took = clock() - t1
 
     return (took, x.npartitions)


### PR DESCRIPTION
Based on the discussion from https://github.com/rapidsai/dask-cuda/issues/536, the CuPy benchmarks were using `compute()` instead of `persist()`, thus causing the data to be sent back to the client, and our intent is not to benchmark that step, this PR fixes that behavior.

I've targeted branch-0.19 for now because of the code freeze, it isn't 100% critical IMO to have this in 0.18, but certainly I'd prefer that. WDYT @quasiben @jakirkham ?