### PR TITLE
[gpuCI] Auto-merge branch-0.18 to branch-0.19 [skip ci]

### DIFF
--- a/dask_cuda/benchmarks/local_cupy.py
+++ b/dask_cuda/benchmarks/local_cupy.py
@@ -87,7 +87,10 @@ async def _run(client, args):
     if args.profile is not None:
         async with performance_report(filename=args.profile):
             t1 = clock()
-            await client.compute(func(*func_args))
+            res = client.compute(func(*func_args))
+            await client.gather(res)
+            if args.type == "gpu":
+                await client.run(lambda xp: xp.cuda.Device().synchronize(), xp)
             took = clock() - t1
     else:
         t1 = clock()

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ copyright = "2020, NVIDIA"
 author = "NVIDIA"
 
 # The full version, including alpha/beta/rc tags.
-from dask_cuda import __version__ as release
+from dask_cuda import __version__ as release  # noqa: E402
 
 # The short X.Y version.
 version = ".".join(release.split(".")[:2])


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.18` that creates a PR to keep `branch-0.19` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.