### PR TITLE
Add option to enable RMM logging

### DIFF
--- a/dask_cuda/benchmarks/local_cudf_merge.py
+++ b/dask_cuda/benchmarks/local_cudf_merge.py
@@ -213,11 +213,15 @@ def main(args):
             setup_memory_pool,
             pool_size=args.rmm_pool_size,
             disable_pool=args.disable_rmm_pool,
+            log_directory=args.rmm_log_directory,
         )
         # Create an RMM pool on the scheduler due to occasional deserialization
         # of CUDA objects. May cause issues with InfiniBand otherwise.
         client.run_on_scheduler(
-            setup_memory_pool, 1e9, disable_pool=args.disable_rmm_pool
+            setup_memory_pool,
+            pool_size=1e9,
+            disable_pool=args.disable_rmm_pool,
+            log_directory=args.rmm_log_directory,
         )
 
     scheduler_workers = client.run_on_scheduler(get_scheduler_workers)

--- a/dask_cuda/benchmarks/local_cudf_shuffle.py
+++ b/dask_cuda/benchmarks/local_cudf_shuffle.py
@@ -100,11 +100,15 @@ def main(args):
             setup_memory_pool,
             pool_size=args.rmm_pool_size,
             disable_pool=args.disable_rmm_pool,
+            log_directory=args.rmm_log_directory,
         )
         # Create an RMM pool on the scheduler due to occasional deserialization
         # of CUDA objects. May cause issues with InfiniBand otherwise.
         client.run_on_scheduler(
-            setup_memory_pool, 1e9, disable_pool=args.disable_rmm_pool
+            setup_memory_pool,
+            pool_size=1e9,
+            disable_pool=args.disable_rmm_pool,
+            log_directory=args.rmm_log_directory,
         )
 
     scheduler_workers = client.run_on_scheduler(get_scheduler_workers)

--- a/dask_cuda/benchmarks/local_cupy.py
+++ b/dask_cuda/benchmarks/local_cupy.py
@@ -130,11 +130,18 @@ async def run(args):
         ) as client:
             scheduler_workers = await client.run_on_scheduler(get_scheduler_workers)
 
-            await client.run(setup_memory_pool, disable_pool=args.disable_rmm_pool)
+            await client.run(
+                setup_memory_pool,
+                disable_pool=args.disable_rmm_pool,
+                log_directory=args.rmm_log_directory,
+            )
             # Create an RMM pool on the scheduler due to occasional deserialization
             # of CUDA objects. May cause issues with InfiniBand otherwise.
             await client.run_on_scheduler(
-                setup_memory_pool, 1e9, disable_pool=args.disable_rmm_pool
+                setup_memory_pool,
+                pool_size=1e9,
+                disable_pool=args.disable_rmm_pool,
+                log_directory=args.rmm_log_directory,
             )
 
             took_list = []

--- a/dask_cuda/benchmarks/local_cupy_map_overlap.py
+++ b/dask_cuda/benchmarks/local_cupy_map_overlap.py
@@ -80,11 +80,18 @@ async def run(args):
         ) as client:
             scheduler_workers = await client.run_on_scheduler(get_scheduler_workers)
 
-            await client.run(setup_memory_pool, disable_pool=args.disable_rmm_pool)
+            await client.run(
+                setup_memory_pool,
+                disable_pool=args.disable_rmm_pool,
+                log_directory=args.rmm_log_directory,
+            )
             # Create an RMM pool on the scheduler due to occasional deserialization
             # of CUDA objects. May cause issues with InfiniBand otherwise.
             await client.run_on_scheduler(
-                setup_memory_pool, 1e9, disable_pool=args.disable_rmm_pool
+                setup_memory_pool,
+                pool_size=1e9,
+                disable_pool=args.disable_rmm_pool,
+                log_directory=args.rmm_log_directory,
             )
 
             took_list = []

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -48,7 +48,7 @@ def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]
         default=None,
         type=str,
         help="Directory to write worker and scheduler RMM log files to. "
-        "Has no effect if RMM memory pool is disabled.",
+        "Logging is only enabled if RMM memory pool is enabled.",
     )
     parser.add_argument(
         "--all-to-all", action="store_true", help="Run all-to-all before computation",

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -47,9 +47,8 @@ def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]
         "--rmm-log-directory",
         default=None,
         type=str,
-        help="Directory to write per-worker RMM log files to. If users "
-        "want logging from the client or scheduler, that must be set "
-        "separately. Has no effect if RMM memory pool is disabled.",
+        help="Directory to write worker and scheduler RMM log files to. "
+        "Has no effect if RMM memory pool is disabled.",
     )
     parser.add_argument(
         "--all-to-all", action="store_true", help="Run all-to-all before computation",

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -236,6 +236,8 @@ def setup_memory_pool(
 
     import rmm
 
+    from dask_cuda.utils import get_rmm_log_file_name
+
     logging = log_directory is not None
 
     if not disable_pool:
@@ -244,21 +246,7 @@ def setup_memory_pool(
             devices=0,
             initial_pool_size=pool_size,
             logging=logging,
-            log_file_name=os.path.join(
-                log_directory,
-                "rmm_log_%s.txt"
-                % (
-                    (
-                        dask_worker.name.split("/")[-1]
-                        if isinstance(dask_worker.name, str)
-                        else dask_worker.name
-                    )
-                    if hasattr(dask_worker, "name")
-                    else "scheduler"
-                ),
-            )
-            if logging
-            else None,
+            log_file_name=get_rmm_log_file_name(dask_worker, logging, log_directory),
         )
         cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)
 

--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -113,6 +113,15 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     "trying to enable both will result in an exception.",
 )
 @click.option(
+    "--rmm-logging/--no-rmm-logging",
+    default=None,
+    help="If enabled, generate RMM debug logs to file in the current "
+    "working directory. If left unspecified, falls back to the value "
+    "of rmm.logging in local Dask configuration."
+    "NOTE: Has no effect if --rmm-pool-size is not specified and "
+    "--rmm-managed-memory is not enabled.",
+)
+@click.option(
     "--reconnect/--no-reconnect",
     default=True,
     help="Reconnect to scheduler if disconnected",
@@ -209,6 +218,7 @@ def main(
     device_memory_limit,
     rmm_pool_size,
     rmm_managed_memory,
+    rmm_logging,
     pid_file,
     resources,
     dashboard,
@@ -253,6 +263,7 @@ def main(
         device_memory_limit,
         rmm_pool_size,
         rmm_managed_memory,
+        rmm_logging,
         pid_file,
         resources,
         dashboard,

--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -113,11 +113,11 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     "trying to enable both will result in an exception.",
 )
 @click.option(
-    "--rmm-logging/--no-rmm-logging",
+    "--rmm-log-directory"
     default=None,
-    help="If enabled, generate RMM debug logs to file in the current "
-    "working directory. If left unspecified, falls back to the value "
-    "of rmm.logging in local Dask configuration."
+    help="Directory to write per-worker RMM log files to. If users "
+    "want logging from the client or scheduler, that must be set "
+    "separately."
     "NOTE: Has no effect if --rmm-pool-size is not specified and "
     "--rmm-managed-memory is not enabled.",
 )
@@ -218,7 +218,7 @@ def main(
     device_memory_limit,
     rmm_pool_size,
     rmm_managed_memory,
-    rmm_logging,
+    rmm_log_directory,
     pid_file,
     resources,
     dashboard,
@@ -263,7 +263,7 @@ def main(
         device_memory_limit,
         rmm_pool_size,
         rmm_managed_memory,
-        rmm_logging,
+        rmm_log_directory,
         pid_file,
         resources,
         dashboard,

--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -113,7 +113,7 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     "trying to enable both will result in an exception.",
 )
 @click.option(
-    "--rmm-logging/--no-rmm-logging",
+    "--rmm-log-directory"
     default=None,
     help="If enabled, generate RMM debug logs to file in the current "
     "working directory. If left unspecified, falls back to the value "

--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -113,11 +113,11 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     "trying to enable both will result in an exception.",
 )
 @click.option(
-    "--rmm-log-directory"
+    "--rmm-log-directory",
     default=None,
-    help="If enabled, generate RMM debug logs to file in the current "
-    "working directory. If left unspecified, falls back to the value "
-    "of rmm.logging in local Dask configuration."
+    help="Directory to write per-worker RMM log files to. If users "
+    "want logging from the client or scheduler, that must be set "
+    "separately."
     "NOTE: Has no effect if --rmm-pool-size is not specified and "
     "--rmm-managed-memory is not enabled.",
 )
@@ -218,7 +218,7 @@ def main(
     device_memory_limit,
     rmm_pool_size,
     rmm_managed_memory,
-    rmm_logging,
+    rmm_log_directory,
     pid_file,
     resources,
     dashboard,
@@ -263,7 +263,7 @@ def main(
         device_memory_limit,
         rmm_pool_size,
         rmm_managed_memory,
-        rmm_logging,
+        rmm_log_directory,
         pid_file,
         resources,
         dashboard,

--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -113,7 +113,7 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     "trying to enable both will result in an exception.",
 )
 @click.option(
-    "--rmm-log-directory"
+    "--rmm-log-directory",
     default=None,
     help="Directory to write per-worker RMM log files to. If users "
     "want logging from the client or scheduler, that must be set "

--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -113,11 +113,11 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     "trying to enable both will result in an exception.",
 )
 @click.option(
-    "--rmm-log-directory",
+    "--rmm-logging/--no-rmm-logging",
     default=None,
-    help="Directory to write per-worker RMM log files to. If users "
-    "want logging from the client or scheduler, that must be set "
-    "separately."
+    help="If enabled, generate RMM debug logs to file in the current "
+    "working directory. If left unspecified, falls back to the value "
+    "of rmm.logging in local Dask configuration."
     "NOTE: Has no effect if --rmm-pool-size is not specified and "
     "--rmm-managed-memory is not enabled.",
 )
@@ -218,7 +218,7 @@ def main(
     device_memory_limit,
     rmm_pool_size,
     rmm_managed_memory,
-    rmm_log_directory,
+    rmm_logging,
     pid_file,
     resources,
     dashboard,
@@ -263,7 +263,7 @@ def main(
         device_memory_limit,
         rmm_pool_size,
         rmm_managed_memory,
-        rmm_log_directory,
+        rmm_logging,
         pid_file,
         resources,
         dashboard,

--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -115,11 +115,10 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 @click.option(
     "--rmm-log-directory",
     default=None,
-    help="Directory to write per-worker RMM log files to. If users "
-    "want logging from the client or scheduler, that must be set "
-    "separately."
-    "NOTE: Has no effect if --rmm-pool-size is not specified and "
-    "--rmm-managed-memory is not enabled.",
+    help="Directory to write per-worker RMM log files to; the client "
+    "and scheduler are not logged here."
+    "NOTE: Logging will only be enabled if --rmm-pool-size or "
+    "--rmm-managed-memory are specified.",
 )
 @click.option(
     "--reconnect/--no-reconnect",

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -56,7 +56,7 @@ class CUDAWorker:
         device_memory_limit="auto",
         rmm_pool_size=None,
         rmm_managed_memory=False,
-        rmm_log_directory=None,
+        rmm_logging=None,
         pid_file=None,
         resources=None,
         dashboard=True,
@@ -156,6 +156,10 @@ class CUDAWorker:
                 "RMM managed memory and NVLink are currently incompatible."
             )
 
+        if rmm_logging is None:
+            rmm_logging = dask.config.get("rmm.logging", False)
+        rmm_logging = bool(rmm_logging)
+
         # Ensure this parent dask-cuda-worker process uses the same UCX
         # configuration as child worker processes created by it.
         initialize(
@@ -213,7 +217,7 @@ class CUDAWorker:
                 env={"CUDA_VISIBLE_DEVICES": cuda_visible_devices(i)},
                 plugins={
                     CPUAffinity(get_cpu_affinity(i)),
-                    RMMSetup(rmm_pool_size, rmm_managed_memory, rmm_log_directory),
+                    RMMSetup(rmm_pool_size, rmm_managed_memory, rmm_logging),
                 },
                 name=name if nprocs == 1 or not name else name + "-" + str(i),
                 local_directory=local_directory,

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -56,7 +56,7 @@ class CUDAWorker:
         device_memory_limit="auto",
         rmm_pool_size=None,
         rmm_managed_memory=False,
-        rmm_logging=None,
+        rmm_log_directory=None,
         pid_file=None,
         resources=None,
         dashboard=True,
@@ -156,10 +156,6 @@ class CUDAWorker:
                 "RMM managed memory and NVLink are currently incompatible."
             )
 
-        if rmm_logging is None:
-            rmm_logging = dask.config.get("rmm.logging", False)
-        rmm_logging = bool(rmm_logging)
-
         # Ensure this parent dask-cuda-worker process uses the same UCX
         # configuration as child worker processes created by it.
         initialize(
@@ -217,7 +213,7 @@ class CUDAWorker:
                 env={"CUDA_VISIBLE_DEVICES": cuda_visible_devices(i)},
                 plugins={
                     CPUAffinity(get_cpu_affinity(i)),
-                    RMMSetup(rmm_pool_size, rmm_managed_memory, rmm_logging),
+                    RMMSetup(rmm_pool_size, rmm_managed_memory, rmm_log_directory),
                 },
                 name=name if nprocs == 1 or not name else name + "-" + str(i),
                 local_directory=local_directory,

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -56,6 +56,7 @@ class CUDAWorker:
         device_memory_limit="auto",
         rmm_pool_size=None,
         rmm_managed_memory=False,
+        rmm_logging=None,
         pid_file=None,
         resources=None,
         dashboard=True,
@@ -155,6 +156,10 @@ class CUDAWorker:
                 "RMM managed memory and NVLink are currently incompatible."
             )
 
+        if rmm_logging is None:
+            rmm_logging = dask.config.get("rmm.logging", False)
+        rmm_logging = bool(rmm_logging)
+
         # Ensure this parent dask-cuda-worker process uses the same UCX
         # configuration as child worker processes created by it.
         initialize(
@@ -212,7 +217,7 @@ class CUDAWorker:
                 env={"CUDA_VISIBLE_DEVICES": cuda_visible_devices(i)},
                 plugins={
                     CPUAffinity(get_cpu_affinity(i)),
-                    RMMSetup(rmm_pool_size, rmm_managed_memory),
+                    RMMSetup(rmm_pool_size, rmm_managed_memory, rmm_logging),
                 },
                 name=name if nprocs == 1 or not name else name + "-" + str(i),
                 local_directory=local_directory,

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -95,12 +95,10 @@ class LocalCUDACluster(LocalCluster):
         but in that case with default (non-managed) memory type.
         WARNING: managed memory is currently incompatible with NVLink, trying
         to enable both will result in an exception.
-    rmm_logging: bool
-        Enables per-worker RMM logging when set to ``True``. Default is
-        ``False``. Falls back on the value of  ``rmm.logging`` in local Dask
-        configuration if left unspecified. If users want logging from the client
-        or scheduler, that would need to be set separately. Has no effect if
-        `rmm_pool_size` is not specified and `rmm_managed_memory` is disabled.
+    rmm_log_directory: str
+        Directory to write per-worker RMM log files to. If users want logging
+        from the client or scheduler, that must be set separately. Has no effect
+        if `rmm_pool_size` is not specified and `rmm_managed_memory` is disabled.
     jit_unspill: bool
         If True, enable just-in-time unspilling. This is experimental and doesn't
         support memory spilling to disk. Please see proxy_object.ProxyObject and
@@ -147,7 +145,7 @@ class LocalCUDACluster(LocalCluster):
         ucx_net_devices=None,
         rmm_pool_size=None,
         rmm_managed_memory=False,
-        rmm_logging=None,
+        rmm_log_directory=None,
         jit_unspill=None,
         **kwargs,
     ):
@@ -197,10 +195,6 @@ class LocalCUDACluster(LocalCluster):
                     "https://dask-cuda.readthedocs.io/en/latest/ucx.html"
                     "#important-notes for more details"
                 )
-
-        if rmm_logging is None:
-            rmm_logging = dask.config.get("rmm.logging", False)
-        self.rmm_logging = bool(rmm_logging)
 
         if not processes:
             raise ValueError(
@@ -306,7 +300,7 @@ class LocalCUDACluster(LocalCluster):
                 "plugins": {
                     CPUAffinity(get_cpu_affinity(worker_count)),
                     RMMSetup(
-                        self.rmm_pool_size, self.rmm_managed_memory, self.rmm_logging
+                        self.rmm_pool_size, self.rmm_managed_memory, self.rmm_log_directory
                     ),
                 },
             }

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -96,9 +96,9 @@ class LocalCUDACluster(LocalCluster):
         WARNING: managed memory is currently incompatible with NVLink, trying
         to enable both will result in an exception.
     rmm_log_directory: str
-        Directory to write per-worker RMM log files to. If users want logging
-        from the client or scheduler, that must be set separately. Has no effect
-        if `rmm_pool_size` is not specified and `rmm_managed_memory` is disabled.
+        Directory to write per-worker RMM log files to; the client and scheduler
+        are not logged here. Logging will only be enabled if `rmm_pool_size` or
+        `rmm_managed_memory` are specified.
     jit_unspill: bool
         If True, enable just-in-time unspilling. This is experimental and doesn't
         support memory spilling to disk. Please see proxy_object.ProxyObject and

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -97,9 +97,10 @@ class LocalCUDACluster(LocalCluster):
         to enable both will result in an exception.
     rmm_logging: bool
         Enables per-worker RMM logging when set to ``True``. Default is
-        ``False``. If users want logging from the client or scheduler, that
-        would need to be set separately. Has no effect if `rmm_pool_size` is not
-        specified and `rmm_managed_memory` is disabled.
+        ``False``. Falls back on the value of  ``rmm.logging`` in local Dask
+        configuration if left unspecified. If users want logging from the client
+        or scheduler, that would need to be set separately. Has no effect if
+        `rmm_pool_size` is not specified and `rmm_managed_memory` is disabled.
     jit_unspill: bool
         If True, enable just-in-time unspilling. This is experimental and doesn't
         support memory spilling to disk. Please see proxy_object.ProxyObject and

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -196,6 +196,8 @@ class LocalCUDACluster(LocalCluster):
                     "#important-notes for more details"
                 )
 
+        self.rmm_log_directory = rmm_log_directory
+
         if not processes:
             raise ValueError(
                 "Processes are necessary in order to use multiple GPUs with Dask"

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -300,7 +300,9 @@ class LocalCUDACluster(LocalCluster):
                 "plugins": {
                     CPUAffinity(get_cpu_affinity(worker_count)),
                     RMMSetup(
-                        self.rmm_pool_size, self.rmm_managed_memory, self.rmm_log_directory
+                        self.rmm_pool_size,
+                        self.rmm_managed_memory,
+                        self.rmm_log_directory,
                     ),
                 },
             }

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -95,10 +95,12 @@ class LocalCUDACluster(LocalCluster):
         but in that case with default (non-managed) memory type.
         WARNING: managed memory is currently incompatible with NVLink, trying
         to enable both will result in an exception.
-    rmm_log_directory: str
-        Directory to write per-worker RMM log files to. If users want logging
-        from the client or scheduler, that must be set separately. Has no effect
-        if `rmm_pool_size` is not specified and `rmm_managed_memory` is disabled.
+    rmm_logging: bool
+        Enables per-worker RMM logging when set to ``True``. Default is
+        ``False``. Falls back on the value of  ``rmm.logging`` in local Dask
+        configuration if left unspecified. If users want logging from the client
+        or scheduler, that would need to be set separately. Has no effect if
+        `rmm_pool_size` is not specified and `rmm_managed_memory` is disabled.
     jit_unspill: bool
         If True, enable just-in-time unspilling. This is experimental and doesn't
         support memory spilling to disk. Please see proxy_object.ProxyObject and
@@ -145,7 +147,7 @@ class LocalCUDACluster(LocalCluster):
         ucx_net_devices=None,
         rmm_pool_size=None,
         rmm_managed_memory=False,
-        rmm_log_directory=None,
+        rmm_logging=None,
         jit_unspill=None,
         **kwargs,
     ):
@@ -195,6 +197,10 @@ class LocalCUDACluster(LocalCluster):
                     "https://dask-cuda.readthedocs.io/en/latest/ucx.html"
                     "#important-notes for more details"
                 )
+
+        if rmm_logging is None:
+            rmm_logging = dask.config.get("rmm.logging", False)
+        self.rmm_logging = bool(rmm_logging)
 
         if not processes:
             raise ValueError(
@@ -300,9 +306,7 @@ class LocalCUDACluster(LocalCluster):
                 "plugins": {
                     CPUAffinity(get_cpu_affinity(worker_count)),
                     RMMSetup(
-                        self.rmm_pool_size,
-                        self.rmm_managed_memory,
-                        self.rmm_log_directory,
+                        self.rmm_pool_size, self.rmm_managed_memory, self.rmm_logging
                     ),
                 },
             }

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -306,7 +306,7 @@ class LocalCUDACluster(LocalCluster):
                 "plugins": {
                     CPUAffinity(get_cpu_affinity(worker_count)),
                     RMMSetup(
-                        self.rmm_pool_size, self.rmm_managed_memory, self.rmm_logging
+                        self.rmm_pool_size, self.rmm_managed_memory, self.rmm_log_directory
                     ),
                 },
             }

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -132,10 +132,7 @@ async def test_all_to_all():
 async def test_rmm_pool():
     rmm = pytest.importorskip("rmm")
 
-    async with LocalCUDACluster(
-        rmm_pool_size="2GB",
-        asynchronous=True,
-    ) as cluster:
+    async with LocalCUDACluster(rmm_pool_size="2GB", asynchronous=True,) as cluster:
         async with Client(cluster, asynchronous=True) as client:
             memory_resource_type = await client.run(
                 rmm.mr.get_current_device_resource_type
@@ -148,10 +145,7 @@ async def test_rmm_pool():
 async def test_rmm_managed():
     rmm = pytest.importorskip("rmm")
 
-    async with LocalCUDACluster(
-        rmm_managed_memory=True,
-        asynchronous=True,
-    ) as cluster:
+    async with LocalCUDACluster(rmm_managed_memory=True, asynchronous=True,) as cluster:
         async with Client(cluster, asynchronous=True) as client:
             memory_resource_type = await client.run(
                 rmm.mr.get_current_device_resource_type
@@ -165,9 +159,7 @@ async def test_rmm_logging():
     rmm = pytest.importorskip("rmm")
 
     async with LocalCUDACluster(
-        rmm_pool_size="2GB",
-        rmm_log_directory=".",
-        asynchronous=True,
+        rmm_pool_size="2GB", rmm_log_directory=".", asynchronous=True,
     ) as cluster:
         async with Client(cluster, asynchronous=True) as client:
             memory_resource_type = await client.run(

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -132,7 +132,10 @@ async def test_all_to_all():
 async def test_rmm_pool():
     rmm = pytest.importorskip("rmm")
 
-    async with LocalCUDACluster(rmm_pool_size="2GB", asynchronous=True) as cluster:
+    async with LocalCUDACluster(
+        rmm_pool_size="2GB",
+        asynchronous=True,
+    ) as cluster:
         async with Client(cluster, asynchronous=True) as client:
             memory_resource_type = await client.run(
                 rmm.mr.get_current_device_resource_type
@@ -145,13 +148,33 @@ async def test_rmm_pool():
 async def test_rmm_managed():
     rmm = pytest.importorskip("rmm")
 
-    async with LocalCUDACluster(rmm_managed_memory=True, asynchronous=True) as cluster:
+    async with LocalCUDACluster(
+        rmm_managed_memory=True,
+        asynchronous=True,
+    ) as cluster:
         async with Client(cluster, asynchronous=True) as client:
             memory_resource_type = await client.run(
                 rmm.mr.get_current_device_resource_type
             )
             for v in memory_resource_type.values():
                 assert v is rmm.mr.ManagedMemoryResource
+
+
+@gen_test(timeout=20)
+async def test_rmm_logging():
+    rmm = pytest.importorskip("rmm")
+
+    async with LocalCUDACluster(
+        rmm_pool_size="2GB",
+        rmm_log_directory=".",
+        asynchronous=True,
+    ) as cluster:
+        async with Client(cluster, asynchronous=True) as client:
+            memory_resource_type = await client.run(
+                rmm.mr.get_current_device_resource_type
+            )
+            for v in memory_resource_type.values():
+                assert v is rmm.mr.LoggingResourceAdaptor
 
 
 @gen_test(timeout=20)

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -35,7 +35,7 @@ class RMMSetup:
     def __init__(self, nbytes, managed_memory, logging):
         self.nbytes = nbytes
         self.managed_memory = managed_memory
-        self.logging = logging
+        self.logging = (log_directory is not None)
 
     def setup(self, worker=None):
         if self.nbytes is not None or self.managed_memory is True:
@@ -43,8 +43,8 @@ class RMMSetup:
 
             pool_allocator = False if self.nbytes is None else True
             worker.rmm_log_file_name = os.path.join(
-                worker.local_directory, "rmm_log.txt"
-            )
+                log_directory, f"rmm_log_{worker.name}.txt"
+            ) if self.logging else None
 
             rmm.reinitialize(
                 pool_allocator=pool_allocator,

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -35,16 +35,19 @@ class RMMSetup:
     def __init__(self, nbytes, managed_memory, log_directory):
         self.nbytes = nbytes
         self.managed_memory = managed_memory
-        self.logging = (log_directory is not None)
+        self.logging = log_directory is not None
+        self.log_directory = log_directory
 
     def setup(self, worker=None):
         if self.nbytes is not None or self.managed_memory is True:
             import rmm
 
             pool_allocator = False if self.nbytes is None else True
-            worker.rmm_log_file_name = os.path.join(
-                log_directory, f"rmm_log_{worker.name}.txt"
-            ) if self.logging else None
+            worker.rmm_log_file_name = (
+                os.path.join(self.log_directory, f"rmm_log_{worker.name}.txt")
+                if self.logging
+                else None
+            )
 
             rmm.reinitialize(
                 pool_allocator=pool_allocator,

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -49,17 +49,9 @@ class RMMSetup:
                 managed_memory=self.managed_memory,
                 initial_pool_size=self.nbytes,
                 logging=self.logging,
-                log_file_name=os.path.join(
-                    self.log_directory,
-                    "rmm_log_%s.txt"
-                    % (
-                        worker.name.split("/")[-1]
-                        if isinstance(worker.name, str)
-                        else worker.name
-                    ),
-                )
-                if self.logging
-                else None,
+                log_file_name=get_rmm_log_file_name(
+                    worker, self.logging, self.log_directory
+                ),
             )
 
 
@@ -331,6 +323,26 @@ def get_preload_options(
         preload_options["preload_argv"].extend(initialize_ucx_argv)
 
     return preload_options
+
+
+def get_rmm_log_file_name(dask_worker, logging=False, log_directory=None):
+    return (
+        os.path.join(
+            log_directory,
+            "rmm_log_%s.txt"
+            % (
+                (
+                    dask_worker.name.split("/")[-1]
+                    if isinstance(dask_worker.name, str)
+                    else dask_worker.name
+                )
+                if hasattr(dask_worker, "name")
+                else "scheduler"
+            ),
+        )
+        if logging
+        else None
+    )
 
 
 def wait_workers(

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -32,20 +32,26 @@ class CPUAffinity:
 
 
 class RMMSetup:
-    def __init__(self, nbytes, managed_memory):
+    def __init__(self, nbytes, managed_memory, logging):
         self.nbytes = nbytes
         self.managed_memory = managed_memory
+        self.logging = logging
 
     def setup(self, worker=None):
         if self.nbytes is not None or self.managed_memory is True:
             import rmm
 
             pool_allocator = False if self.nbytes is None else True
+            worker.rmm_log_file_name = os.path.join(
+                worker.local_directory, "rmm_log.txt"
+            )
 
             rmm.reinitialize(
                 pool_allocator=pool_allocator,
                 managed_memory=self.managed_memory,
                 initial_pool_size=self.nbytes,
+                logging=self.logging,
+                log_file_name=worker.rmm_log_file_name,
             )
 
 

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -32,10 +32,10 @@ class CPUAffinity:
 
 
 class RMMSetup:
-    def __init__(self, nbytes, managed_memory, logging):
+    def __init__(self, nbytes, managed_memory, log_directory):
         self.nbytes = nbytes
         self.managed_memory = managed_memory
-        self.logging = logging
+        self.logging = (log_directory is not None)
 
     def setup(self, worker=None):
         if self.nbytes is not None or self.managed_memory is True:
@@ -43,8 +43,8 @@ class RMMSetup:
 
             pool_allocator = False if self.nbytes is None else True
             worker.rmm_log_file_name = os.path.join(
-                worker.local_directory, "rmm_log.txt"
-            )
+                log_directory, f"rmm_log_{worker.name}.txt"
+            ) if self.logging else None
 
             rmm.reinitialize(
                 pool_allocator=pool_allocator,

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -43,18 +43,23 @@ class RMMSetup:
             import rmm
 
             pool_allocator = False if self.nbytes is None else True
-            worker.rmm_log_file_name = (
-                os.path.join(self.log_directory, f"rmm_log_{worker.name}.txt")
-                if self.logging
-                else None
-            )
 
             rmm.reinitialize(
                 pool_allocator=pool_allocator,
                 managed_memory=self.managed_memory,
                 initial_pool_size=self.nbytes,
                 logging=self.logging,
-                log_file_name=worker.rmm_log_file_name,
+                log_file_name=os.path.join(
+                    self.log_directory,
+                    "rmm_log_%s.txt"
+                    % (
+                        worker.name.split("/")[-1]
+                        if isinstance(worker.name, str)
+                        else worker.name
+                    ),
+                )
+                if self.logging
+                else None,
             )
 
 

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -32,21 +32,18 @@ class CPUAffinity:
 
 
 class RMMSetup:
-    def __init__(self, nbytes, managed_memory, log_directory):
+    def __init__(self, nbytes, managed_memory, logging):
         self.nbytes = nbytes
         self.managed_memory = managed_memory
-        self.logging = log_directory is not None
-        self.log_directory = log_directory
+        self.logging = logging
 
     def setup(self, worker=None):
         if self.nbytes is not None or self.managed_memory is True:
             import rmm
 
             pool_allocator = False if self.nbytes is None else True
-            worker.rmm_log_file_name = (
-                os.path.join(self.log_directory, f"rmm_log_{worker.name}.txt")
-                if self.logging
-                else None
+            worker.rmm_log_file_name = os.path.join(
+                worker.local_directory, "rmm_log.txt"
             )
 
             rmm.reinitialize(

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -32,19 +32,22 @@ class CPUAffinity:
 
 
 class RMMSetup:
-    def __init__(self, nbytes, managed_memory, logging):
+    def __init__(self, nbytes, managed_memory, log_directory):
         self.nbytes = nbytes
         self.managed_memory = managed_memory
-        self.logging = (log_directory is not None)
+        self.logging = log_directory is not None
+        self.log_directory = log_directory
 
     def setup(self, worker=None):
         if self.nbytes is not None or self.managed_memory is True:
             import rmm
 
             pool_allocator = False if self.nbytes is None else True
-            worker.rmm_log_file_name = os.path.join(
-                log_directory, f"rmm_log_{worker.name}.txt"
-            ) if self.logging else None
+            worker.rmm_log_file_name = (
+                os.path.join(self.log_directory, f"rmm_log_{worker.name}.txt")
+                if self.logging
+                else None
+            )
 
             rmm.reinitialize(
                 pool_allocator=pool_allocator,


### PR DESCRIPTION
Continuation of #322; this PR adds:

- Keyword argument `rmm_log_directory` to `LocalCUDACluster` and `CUDAWorker` to enable per-worker RMM logging to a specified directory
- Option `--rmm-log-directory` to the `dask-cuda-worker` CLI to achieve the same as above
- Option `--rmm-log-directory` to the benchmarks to enable worker *and* scheduler RMM logging
- Tests to `test_local_cuda_cluster.py` and `test_dask_cuda_worker.py` to check that logging is happening

The log files use the following naming convention:

- `rmm_log_<N>.dev0.txt` for workers spawned through the construction of a cluster
- `rmm_log_<IP>:<PORT>.dev0.txt` for workers spawned using the CLI
- `rmm_log_scheduler.dev0.txt` for schedulers

Some questions:

- Should we leave `dev0` in the log file names? It seems redundant, but I didn't really put much time into seeing if we could stop RMM from appending that to the file names.
- Are the tests sufficient? Right now they are only checking that the memory resources are `rmm.mr.LoggingResourceAdaptors` when logging is enabled but a check that the files were actually generated could be nice.
- Should we consider adding logging to the scheduler/client?

cc @jakirkham @pentschev 