### PR TITLE
cuDF-style operations & NVTX annotations for local CuPy benchmark

### DIFF
--- a/dask_cuda/benchmarks/local_cupy.py
+++ b/dask_cuda/benchmarks/local_cupy.py
@@ -109,17 +109,6 @@ async def _run(client, args):
         func_args = (x, y)
 
         func = lambda x, y: x + y
-    elif args.operation == "col_mask":
-        rng = start_range(message="make array(s)", color="green")
-        x = rs.normal(10, 1, (args.size,), chunks=args.chunk_size).persist()
-        y = rs.normal(10, 1, (args.size,), chunks=args.chunk_size).persist()
-        await wait(x)
-        await wait(y)
-        end_range(rng)
-
-        func_args = (x, y)
-
-        func = lambda x, y: x[y > 0]
     elif args.operation == "col_gather":
         rng = start_range(message="make array(s)", color="green")
         x = rs.normal(10, 1, (args.size,), chunks=args.chunk_size).persist()

--- a/dask_cuda/benchmarks/local_cupy.py
+++ b/dask_cuda/benchmarks/local_cupy.py
@@ -112,7 +112,9 @@ async def _run(client, args):
     elif args.operation == "col_gather":
         rng = start_range(message="make array(s)", color="green")
         x = rs.normal(10, 1, (args.size,), chunks=args.chunk_size).persist()
-        idx = rs.randint(0, len(x), (args.second_size,), chunks=args.chunk_size).persist()
+        idx = rs.randint(
+            0, len(x), (args.second_size,), chunks=args.chunk_size
+        ).persist()
         await wait(x)
         await wait(idx)
         end_range(rng)

--- a/dask_cuda/benchmarks/local_cupy.py
+++ b/dask_cuda/benchmarks/local_cupy.py
@@ -112,14 +112,14 @@ async def _run(client, args):
     elif args.operation == "col_gather":
         rng = start_range(message="make array(s)", color="green")
         x = rs.normal(10, 1, (args.size,), chunks=args.chunk_size).persist()
-        i = rs.randint(0, len(x), (args.second_size,), chunks=args.chunk_size).persist()
+        idx = rs.randint(0, len(x), (args.second_size,), chunks=args.chunk_size).persist()
         await wait(x)
-        await wait(i)
+        await wait(idx)
         end_range(rng)
 
-        func_args = (x, i)
+        func_args = (x, idx)
 
-        func = lambda x, y: x[i]
+        func = lambda x, idx: x[idx]
 
     shape = x.shape
     chunksize = x.chunksize

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -3,6 +3,7 @@ import os
 from datetime import datetime
 
 from dask.distributed import SSHCluster
+from dask.utils import parse_bytes
 
 from dask_cuda.local_cuda_cluster import LocalCUDACluster
 
@@ -36,9 +37,9 @@ def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]
     parser.add_argument(
         "--rmm-pool-size",
         default=None,
-        type=float,
-        help="The size of the RMM memory pool. By default, 1/2 of "
-        "the total GPU memory is used.",
+        type=parse_bytes,
+        help="The size of the RMM memory pool. Can be an integer (bytes) or a string "
+        "(like '4GB' or '5000M'). By default, 1/2 of the total GPU memory is used.",
     )
     parser.add_argument(
         "--disable-rmm-pool", action="store_true", help="Disable the RMM memory pool"


### PR DESCRIPTION
This PR adds the following to the local CuPy benchmark:

- Binary column sum and gather operations to simulate cuDF workloads
- NVTX annotations for the array creation + execution of operations
- `args.rmm_pool_size` to the worker memory pool setup so user-defined pool sizes work

Some questions:

- Any other binary operations that would be good to add here?
- Is it useful to annotate the creation of the arrays or would we only want to focus on the execution?

cc @shwina 