### PR TITLE
Fix UCX examples for InfiniBand

### DIFF
--- a/examples/ucx/client_initialize.py
+++ b/examples/ucx/client_initialize.py
@@ -1,5 +1,7 @@
 import click
+import cupy
 
+from dask import array as da
 from dask.distributed import Client
 
 from dask_cuda.initialize import initialize
@@ -27,7 +29,7 @@ def main(
     ucx_net_devices = None
 
     if enable_infiniband:
-        enable_rdmacm = True
+        # enable_rdmacm = True  # RDMACM not working right now
         ucx_net_devices = "mlx5_0:1"
 
     # set up environment
@@ -40,7 +42,15 @@ def main(
     )
 
     # initialize client
-    client = Client(address)  # noqa F841
+    client = Client(address)
+
+    # client code here
+    rs = da.random.RandomState(RandomState=cupy.random.RandomState)
+    x = rs.random((10000, 10000), chunks=1000)
+    x.sum().compute()
+
+    # shutdown client
+    client.shutdown()
 
 
 if __name__ == "__main__":

--- a/examples/ucx/client_initialize.py
+++ b/examples/ucx/client_initialize.py
@@ -44,12 +44,12 @@ def main(
     # initialize client
     client = Client(address)
 
-    # client code here
+    # user code here
     rs = da.random.RandomState(RandomState=cupy.random.RandomState)
     x = rs.random((10000, 10000), chunks=1000)
     x.sum().compute()
 
-    # shutdown client
+    # shutdown cluster
     client.shutdown()
 
 

--- a/examples/ucx/local_cuda_cluster.py
+++ b/examples/ucx/local_cuda_cluster.py
@@ -1,5 +1,7 @@
 import click
+import cupy
 
+from dask import array as da
 from dask.distributed import Client
 from dask.utils import parse_bytes
 
@@ -40,7 +42,7 @@ def main(
     ucx_net_devices = None
 
     if enable_infiniband:
-        enable_rdmacm = True
+        # enable_rdmacm = True  # RDMACM not working right now
         ucx_net_devices = "auto"
 
     if (enable_infiniband or enable_nvlink) and not interface:
@@ -60,7 +62,15 @@ def main(
     )
 
     # initialize client
-    client = Client(cluster)  # noqa F841
+    client = Client(cluster)
+
+    # client code here
+    rs = da.random.RandomState(RandomState=cupy.random.RandomState)
+    x = rs.random((10000, 10000), chunks=1000)
+    x.sum().compute()
+
+    # shutdown client
+    client.shutdown()
 
 
 if __name__ == "__main__":

--- a/examples/ucx/local_cuda_cluster.py
+++ b/examples/ucx/local_cuda_cluster.py
@@ -64,12 +64,12 @@ def main(
     # initialize client
     client = Client(cluster)
 
-    # client code here
+    # user code here
     rs = da.random.RandomState(RandomState=cupy.random.RandomState)
     x = rs.random((10000, 10000), chunks=1000)
     x.sum().compute()
 
-    # shutdown client
+    # shutdown cluster
     client.shutdown()
 
 


### PR DESCRIPTION
Some small changes to the UCX examples to fix some IB-related issues I discussed with @pentschev:

- Disables RDMACM for all examples; right now this isn't working, but when it is we can uncomment out the original lines
- Use `--scheduler-file` to link `dask-scheduler` to `dask-cuda-workers`, as `localhost` cannot be used when IB is enabled
- Add a small workload for the client and shut it down in the cluster and client setup examples