### PR TITLE
Remove kwargs from `LocalCUDACluster`

### DIFF
--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -228,7 +228,7 @@ class LocalCUDACluster(LocalCluster):
         else:
             self.jit_unspill = jit_unspill
 
-        data = kwargs.get("data")
+        data = kwargs.pop("data", None)
         if data is None:
             if self.jit_unspill:
                 data = (

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -160,7 +160,6 @@ class LocalCUDACluster(LocalCluster):
         memory_limit="auto",
         device_memory_limit=0.8,
         CUDA_VISIBLE_DEVICES=None,
-        data=None,
         local_directory=None,
         protocol=None,
         enable_tcp_over_ucx=False,
@@ -229,6 +228,7 @@ class LocalCUDACluster(LocalCluster):
         else:
             self.jit_unspill = jit_unspill
 
+        data = kwargs.get("data")
         if data is None:
             if self.jit_unspill:
                 data = (

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -157,7 +157,6 @@ class LocalCUDACluster(LocalCluster):
         self,
         n_workers=None,
         threads_per_worker=1,
-        processes=True,
         memory_limit="auto",
         device_memory_limit=0.8,
         CUDA_VISIBLE_DEVICES=None,
@@ -224,11 +223,6 @@ class LocalCUDACluster(LocalCluster):
                 )
 
         self.rmm_log_directory = rmm_log_directory
-
-        if not processes:
-            raise ValueError(
-                "Processes are necessary in order to use multiple GPUs with Dask"
-            )
 
         if jit_unspill is None:
             self.jit_unspill = dask.config.get("jit-unspill", default=False)

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -223,6 +223,11 @@ class LocalCUDACluster(LocalCluster):
 
         self.rmm_log_directory = rmm_log_directory
 
+        if not kwargs.pop("processes", True):
+            raise ValueError(
+                "Processes are necessary in order to use multiple GPUs with Dask"
+            )
+
         if jit_unspill is None:
             self.jit_unspill = dask.config.get("jit-unspill", default=False)
         else:

--- a/dask_cuda/tests/test_explicit_comms.py
+++ b/dask_cuda/tests/test_explicit_comms.py
@@ -265,7 +265,6 @@ def _test_jit_unspill(protocol):
         dashboard_address=None,
         n_workers=1,
         threads_per_worker=1,
-        processes=True,
         jit_unspill=True,
         device_memory_limit="1B",
     ) as cluster:

--- a/dask_cuda/tests/test_spill.py
+++ b/dask_cuda/tests/test_spill.py
@@ -195,7 +195,6 @@ async def test_cupy_cluster_device_spill(params):
         async with LocalCUDACluster(
             1,
             scheduler_port=0,
-            processes=True,
             silence_logs=False,
             dashboard_address=None,
             asynchronous=True,


### PR DESCRIPTION
Based on some discussions in #561, this PR removes some kwargs from `LocalCUDACluster` that may not be needed:

- `processes` doesn't have any impact on its construction (other than throwing a `ValueError` if it's set false); this should be safe to remove altogether
- `data` is pretty complex and it isn't commonly specified, so it can be removed from the named arguments and accessed through the `kwargs` object if it is specified