### PR TITLE
Remove `--death-timeout` from option from `dask-cuda-worker`

### DIFF
--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -145,12 +145,6 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     "Use with dask-scheduler --scheduler-file",
 )
 @click.option(
-    "--death-timeout",
-    type=str,
-    default=None,
-    help="Seconds to wait for a scheduler before closing",
-)
-@click.option(
     "--dashboard-prefix", type=str, default=None, help="Prefix for the Dashboard"
 )
 @click.option(
@@ -225,7 +219,6 @@ def main(
     local_directory,
     scheduler_file,
     interface,
-    death_timeout,
     preload,
     dashboard_prefix,
     tls_ca_file,
@@ -270,7 +263,6 @@ def main(
         local_directory,
         scheduler_file,
         interface,
-        death_timeout,
         preload,
         dashboard_prefix,
         security,

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -64,7 +64,6 @@ class CUDAWorker:
         local_directory=None,
         scheduler_file=None,
         interface=None,
-        death_timeout=None,
         preload=[],
         dashboard_prefix=None,
         security=None,

--- a/dask_cuda/tests/test_spill.py
+++ b/dask_cuda/tests/test_spill.py
@@ -199,7 +199,6 @@ async def test_cupy_cluster_device_spill(params):
             silence_logs=False,
             dashboard_address=None,
             asynchronous=True,
-            death_timeout=60,
             device_memory_limit=params["device_memory_limit"],
             memory_limit=params["memory_limit"],
             memory_target_fraction=params["host_target"],
@@ -366,7 +365,6 @@ async def test_cudf_cluster_device_spill(params):
             memory_target_fraction=params["host_target"],
             memory_spill_fraction=params["host_spill"],
             memory_pause_fraction=params["host_pause"],
-            death_timeout=60,
             asynchronous=True,
         ) as cluster:
             async with Client(cluster, asynchronous=True) as client:


### PR DESCRIPTION
This removes `death_timeout` from the `dask-cuda-worker` CLI and `CUDAWorker`, as it previously was not being used for anything. I think we could get it working by passing its value on to the nanny processes being spawned by `CUDAWorker`, but @pentschev suggested it might be better to remove it since its lack of functionality hasn't really been a problem up until now.