### PR TITLE
Add support for `CudaAsyncMemoryResource`

### DIFF
--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -121,8 +121,8 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 
     .. note::
         The asynchronous allocator requires CUDA Toolkit 11.2 or newer. It is also
-        incompatible with RMM pools and managed memory, and will be preferred over them
-        if both are enabled.""",
+        incompatible with RMM pools and managed memory, trying to enable both will
+        result in an exception.""",
 )
 @click.option(
     "--rmm-log-directory",

--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -129,8 +129,8 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     default=None,
     help="Directory to write per-worker RMM log files to; the client "
     "and scheduler are not logged here."
-    "NOTE: Logging will only be enabled if --rmm-pool-size or "
-    "--rmm-managed-memory are specified.",
+    "NOTE: Logging will only be enabled if --rmm-pool-size, "
+    "--rmm-managed-memory, or --rmm-async are specified.",
 )
 @click.option(
     "--reconnect/--no-reconnect",

--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -122,7 +122,7 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     .. note::
         The asynchronous allocator requires CUDA Toolkit 11.2 or newer. It is also
         incompatible with RMM pools and managed memory, trying to enable both will
-        result in an exception.""",
+        result in failure.""",
 )
 @click.option(
     "--rmm-log-directory",

--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -103,6 +103,12 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     "and not cluster-wide!",
 )
 @click.option(
+    "--rmm-pool-async/--no-rmm-pool-async",
+    default=False,
+    show_default=True,
+    help="Use an ``rmm.mr.CudaAsyncMemoryResource`` when initializing an RMM pool.",
+)
+@click.option(
     "--rmm-managed-memory/--no-rmm-managed-memory",
     default=False,
     help="If enabled, initialize each worker with RMM and set it to "
@@ -210,6 +216,7 @@ def main(
     memory_limit,
     device_memory_limit,
     rmm_pool_size,
+    rmm_pool_async,
     rmm_managed_memory,
     rmm_log_directory,
     pid_file,
@@ -254,6 +261,7 @@ def main(
         memory_limit,
         device_memory_limit,
         rmm_pool_size,
+        rmm_pool_async,
         rmm_managed_memory,
         rmm_log_directory,
         pid_file,

--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -103,12 +103,6 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     "and not cluster-wide!",
 )
 @click.option(
-    "--rmm-pool-async/--no-rmm-pool-async",
-    default=False,
-    show_default=True,
-    help="Use an ``rmm.mr.CudaAsyncMemoryResource`` when initializing an RMM pool.",
-)
-@click.option(
     "--rmm-managed-memory/--no-rmm-managed-memory",
     default=False,
     help="If enabled, initialize each worker with RMM and set it to "
@@ -117,6 +111,18 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     "(non-managed) memory type."
     "WARNING: managed memory is currently incompatible with NVLink, "
     "trying to enable both will result in an exception.",
+)
+@click.option(
+    "--rmm-async/--no-rmm-async",
+    default=False,
+    show_default=True,
+    help="""Initialize each worker withh RMM and set it to use RMM's asynchronous
+    allocator. See ``rmm.mr.CudaAsyncMemoryResource`` for more info.
+
+    .. note::
+        The asynchronous allocator requires CUDA Toolkit 11.2 or newer. It is also
+        incompatible with RMM pools and managed memory, and will be preferred over them
+        if both are enabled.""",
 )
 @click.option(
     "--rmm-log-directory",
@@ -216,8 +222,8 @@ def main(
     memory_limit,
     device_memory_limit,
     rmm_pool_size,
-    rmm_pool_async,
     rmm_managed_memory,
+    rmm_async,
     rmm_log_directory,
     pid_file,
     resources,
@@ -261,8 +267,8 @@ def main(
         memory_limit,
         device_memory_limit,
         rmm_pool_size,
-        rmm_pool_async,
         rmm_managed_memory,
+        rmm_async,
         rmm_log_directory,
         pid_file,
         resources,

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -55,6 +55,7 @@ class CUDAWorker:
         memory_limit="auto",
         device_memory_limit="auto",
         rmm_pool_size=None,
+        rmm_pool_async=False,
         rmm_managed_memory=False,
         rmm_log_directory=None,
         pid_file=None,
@@ -212,7 +213,12 @@ class CUDAWorker:
                 env={"CUDA_VISIBLE_DEVICES": cuda_visible_devices(i)},
                 plugins={
                     CPUAffinity(get_cpu_affinity(i)),
-                    RMMSetup(rmm_pool_size, rmm_managed_memory, rmm_log_directory),
+                    RMMSetup(
+                        rmm_pool_size,
+                        rmm_pool_async,
+                        rmm_managed_memory,
+                        rmm_log_directory,
+                    ),
                 },
                 name=name if nprocs == 1 or not name else name + "-" + str(i),
                 local_directory=local_directory,

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -140,6 +140,11 @@ class CUDAWorker:
                     "For installation instructions, please see "
                     "https://github.com/rapidsai/rmm"
                 )  # pragma: no cover
+            if rmm_async:
+                raise ValueError(
+                    """RMM pool and managed memory are incompatible with asynchronous
+                    allocator"""
+                )
             if rmm_pool_size is not None:
                 rmm_pool_size = parse_bytes(rmm_pool_size)
         else:

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -142,8 +142,8 @@ class CUDAWorker:
                 )  # pragma: no cover
             if rmm_async:
                 raise ValueError(
-                    """RMM pool and managed memory are incompatible with asynchronous
-                    allocator"""
+                    "RMM pool and managed memory are incompatible with asynchronous "
+                    "allocator"
                 )
             if rmm_pool_size is not None:
                 rmm_pool_size = parse_bytes(rmm_pool_size)

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -55,8 +55,8 @@ class CUDAWorker:
         memory_limit="auto",
         device_memory_limit="auto",
         rmm_pool_size=None,
-        rmm_pool_async=False,
         rmm_managed_memory=False,
+        rmm_async=False,
         rmm_log_directory=None,
         pid_file=None,
         resources=None,
@@ -214,10 +214,7 @@ class CUDAWorker:
                 plugins={
                     CPUAffinity(get_cpu_affinity(i)),
                     RMMSetup(
-                        rmm_pool_size,
-                        rmm_pool_async,
-                        rmm_managed_memory,
-                        rmm_log_directory,
+                        rmm_pool_size, rmm_managed_memory, rmm_async, rmm_log_directory,
                     ),
                 },
                 name=name if nprocs == 1 or not name else name + "-" + str(i),

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -126,8 +126,8 @@ class LocalCUDACluster(LocalCluster):
             result in an exception.
     rmm_log_directory: str
         Directory to write per-worker RMM log files to; the client and scheduler
-        are not logged here. Logging will only be enabled if ``rmm_pool_size`` or
-        ``rmm_managed_memory`` are specified.
+        are not logged here. Logging will only be enabled if ``rmm_pool_size``,
+        ``rmm_managed_memory``, or ``rmm_async`` are specified.
     jit_unspill: bool
         If ``True``, enable just-in-time unspilling. This is experimental and doesn't
         support memory spilling to disk. Please see ``proxy_object.ProxyObject`` and

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -151,12 +151,12 @@ class LocalCUDACluster(LocalCluster):
         If ``enable_infiniband`` or ``enable_nvlink`` is ``True`` and protocol is not
         ``"ucx"``.
     ValueError
-       If ``ucx_net_devices=""``, if NVLink and RMM managed memory are
-       both enabled, if RMM pools / managed memory and asynchronous allocator are both
-       enabled, or if ``ucx_net_devices="auto"`` and:
+        If ``ucx_net_devices=""``, if NVLink and RMM managed memory are
+        both enabled, if RMM pools / managed memory and asynchronous allocator are both
+        enabled, or if ``ucx_net_devices="auto"`` and:
 
-        - UCX-Py is not installed or wasn't compiled with hwloc support or
-        - ``enable_infiniband=False``
+            - UCX-Py is not installed or wasn't compiled with hwloc support; or
+            - ``enable_infiniband=False``
 
     See Also
     --------

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -108,6 +108,8 @@ class LocalCUDACluster(LocalCluster):
         .. note::
             The size is a per worker (i.e., per GPU) configuration, and not
             cluster-wide!
+    rmm_pool_async: bool, default False
+        Use an ``rmm.mr.CudaAsyncMemoryResource`` when initializing an RMM pool.
     rmm_managed_memory: bool
         If ``True``, initialize each worker with RMM and set it to use managed
         memory. If ``False``, RMM may still be used if ``rmm_pool_size`` is specified,
@@ -168,6 +170,7 @@ class LocalCUDACluster(LocalCluster):
         enable_rdmacm=False,
         ucx_net_devices=None,
         rmm_pool_size=None,
+        rmm_pool_async=False,
         rmm_managed_memory=False,
         rmm_log_directory=None,
         jit_unspill=None,
@@ -200,6 +203,7 @@ class LocalCUDACluster(LocalCluster):
         )
 
         self.rmm_pool_size = rmm_pool_size
+        self.rmm_pool_async = rmm_pool_async
         self.rmm_managed_memory = rmm_managed_memory
         if rmm_pool_size is not None or rmm_managed_memory:
             try:
@@ -331,6 +335,7 @@ class LocalCUDACluster(LocalCluster):
                     CPUAffinity(get_cpu_affinity(worker_count)),
                     RMMSetup(
                         self.rmm_pool_size,
+                        self.rmm_pool_async,
                         self.rmm_managed_memory,
                         self.rmm_log_directory,
                     ),

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -222,10 +222,10 @@ class LocalCUDACluster(LocalCluster):
                     "is not available. For installation instructions, please "
                     "see https://github.com/rapidsai/rmm"
                 )  # pragma: no cover
-            if self.rmm_async:
+            if rmm_async:
                 raise ValueError(
-                    """RMM pool and managed memory are incompatible with asynchronous
-                    allocator"""
+                    "RMM pool and managed memory are incompatible with asynchronous "
+                    "allocator"
                 )
             if self.rmm_pool_size is not None:
                 self.rmm_pool_size = parse_bytes(self.rmm_pool_size)

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -119,7 +119,7 @@ def test_rmm_async(loop):  # noqa: F811
                 "127.0.0.1:9369",
                 "--host",
                 "127.0.0.1",
-                "--rmm-pool-async",
+                "--rmm-async",
                 "--no-dashboard",
             ]
         ):

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -78,6 +78,31 @@ def test_rmm_pool(loop):  # noqa: F811
                     assert v is rmm.mr.PoolMemoryResource
 
 
+def test_rmm_pool_async(loop):  # noqa: F811
+    rmm = pytest.importorskip("rmm")
+    with popen(["dask-scheduler", "--port", "9369", "--no-dashboard"]):
+        with popen(
+            [
+                "dask-cuda-worker",
+                "127.0.0.1:9369",
+                "--host",
+                "127.0.0.1",
+                "--rmm-pool-size",
+                "2 GB",
+                "--rmm-pool-async",
+                "--no-dashboard",
+            ]
+        ):
+            with Client("127.0.0.1:9369", loop=loop) as client:
+                assert wait_workers(client, n_gpus=get_n_gpus())
+
+                memory_resource_type = client.run(
+                    rmm.mr.get_current_device_resource_type
+                )
+                for v in memory_resource_type.values():
+                    assert v is rmm.mr.CudaMemoryResource
+
+
 def test_rmm_managed(loop):  # noqa: F811
     rmm = pytest.importorskip("rmm")
     with popen(["dask-scheduler", "--port", "9369", "--no-dashboard"]):

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -146,25 +146,6 @@ async def test_rmm_pool():
                 assert v is rmm.mr.PoolMemoryResource
 
 
-@pytest.mark.skipif(
-    ((_driver_version, _runtime_version) < (11020, 11020)),
-    reason="cudaMallocAsync not supported",
-)
-@gen_test(timeout=20)
-async def test_rmm_pool_async():
-    rmm = pytest.importorskip("rmm")
-
-    async with LocalCUDACluster(
-        rmm_pool_size="2GB", rmm_pool_async=True, asynchronous=True,
-    ) as cluster:
-        async with Client(cluster, asynchronous=True) as client:
-            memory_resource_type = await client.run(
-                rmm.mr.get_current_device_resource_type
-            )
-            for v in memory_resource_type.values():
-                assert v is rmm.mr.PoolMemoryResource
-
-
 @gen_test(timeout=20)
 async def test_rmm_managed():
     rmm = pytest.importorskip("rmm")
@@ -176,6 +157,23 @@ async def test_rmm_managed():
             )
             for v in memory_resource_type.values():
                 assert v is rmm.mr.ManagedMemoryResource
+
+
+@pytest.mark.skipif(
+    ((_driver_version, _runtime_version) < (11020, 11020)),
+    reason="cudaMallocAsync not supported",
+)
+@gen_test(timeout=20)
+async def test_rmm_async():
+    rmm = pytest.importorskip("rmm")
+
+    async with LocalCUDACluster(rmm_pool_async=True, asynchronous=True,) as cluster:
+        async with Client(cluster, asynchronous=True) as client:
+            memory_resource_type = await client.run(
+                rmm.mr.get_current_device_resource_type
+            )
+            for v in memory_resource_type.values():
+                assert v is rmm.mr.CudaAsyncMemoryResource
 
 
 @gen_test(timeout=20)

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -167,7 +167,7 @@ async def test_rmm_managed():
 async def test_rmm_async():
     rmm = pytest.importorskip("rmm")
 
-    async with LocalCUDACluster(rmm_pool_async=True, asynchronous=True,) as cluster:
+    async with LocalCUDACluster(rmm_async=True, asynchronous=True,) as cluster:
         async with Client(cluster, asynchronous=True) as client:
             memory_resource_type = await client.run(
                 rmm.mr.get_current_device_resource_type

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -142,6 +142,21 @@ async def test_rmm_pool():
 
 
 @gen_test(timeout=20)
+async def test_rmm_pool_async():
+    rmm = pytest.importorskip("rmm")
+
+    async with LocalCUDACluster(
+        rmm_pool_size="2GB", rmm_pool_async=True, asynchronous=True,
+    ) as cluster:
+        async with Client(cluster, asynchronous=True) as client:
+            memory_resource_type = await client.run(
+                rmm.mr.get_current_device_resource_type
+            )
+            for v in memory_resource_type.values():
+                assert v is rmm.mr.CudaMemoryResource
+
+
+@gen_test(timeout=20)
 async def test_rmm_managed():
     rmm = pytest.importorskip("rmm")
 

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -32,8 +32,9 @@ class CPUAffinity:
 
 
 class RMMSetup:
-    def __init__(self, nbytes, managed_memory, log_directory):
+    def __init__(self, nbytes, pool_async, managed_memory, log_directory):
         self.nbytes = nbytes
+        self.pool_async = pool_async
         self.managed_memory = managed_memory
         self.logging = log_directory is not None
         self.log_directory = log_directory
@@ -41,6 +42,11 @@ class RMMSetup:
     def setup(self, worker=None):
         if self.nbytes is not None or self.managed_memory is True:
             import rmm
+
+            if self.pool_async is True:
+                rmm.mr.set_current_device_resource(
+                    rmm.mr.PoolMemoryResource(rmm.mr.CudaAsyncMemoryResource())
+                )
 
             pool_allocator = False if self.nbytes is None else True
 

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -40,31 +40,23 @@ class RMMSetup:
         self.log_directory = log_directory
 
     def setup(self, worker=None):
-        if self.async_alloc is True:
+        if self.nbytes is not None or self.managed_memory or self.async_alloc:
             import rmm
 
-            rmm.mr.set_current_device_resource(rmm.mr.CudaAsyncMemoryResource())
+            if self.async_alloc:
+                rmm.mr.set_current_device_resource(rmm.mr.CudaAsyncMemoryResource())
+            else:
+                pool_allocator = False if self.nbytes is None else True
 
-            rmm.reinitialize(
-                logging=self.logging,
-                log_file_name=get_rmm_log_file_name(
-                    worker, self.logging, self.log_directory
-                ),
-            )
-        elif self.nbytes is not None or self.managed_memory is True:
-            import rmm
-
-            pool_allocator = False if self.nbytes is None else True
-
-            rmm.reinitialize(
-                pool_allocator=pool_allocator,
-                managed_memory=self.managed_memory,
-                initial_pool_size=self.nbytes,
-                logging=self.logging,
-                log_file_name=get_rmm_log_file_name(
-                    worker, self.logging, self.log_directory
-                ),
-            )
+                rmm.reinitialize(
+                    pool_allocator=pool_allocator,
+                    managed_memory=self.managed_memory,
+                    initial_pool_size=self.nbytes,
+                    logging=self.logging,
+                    log_file_name=get_rmm_log_file_name(
+                        worker, self.logging, self.log_directory
+                    ),
+                )
 
 
 def unpack_bitmask(x, mask_bits=64):

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -45,6 +45,12 @@ class RMMSetup:
 
             if self.async_alloc:
                 rmm.mr.set_current_device_resource(rmm.mr.CudaAsyncMemoryResource())
+                if self.logging:
+                    rmm.enable_logging(
+                        log_file_name=get_rmm_log_file_name(
+                            worker, self.logging, self.log_directory
+                        )
+                    )
             else:
                 pool_allocator = False if self.nbytes is None else True
 

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -40,29 +40,30 @@ class RMMSetup:
         self.log_directory = log_directory
 
     def setup(self, worker=None):
-        if self.nbytes is not None or self.managed_memory or self.async_alloc:
+        if self.async_alloc:
             import rmm
 
-            if self.async_alloc:
-                rmm.mr.set_current_device_resource(rmm.mr.CudaAsyncMemoryResource())
-                if self.logging:
-                    rmm.enable_logging(
-                        log_file_name=get_rmm_log_file_name(
-                            worker, self.logging, self.log_directory
-                        )
-                    )
-            else:
-                pool_allocator = False if self.nbytes is None else True
-
-                rmm.reinitialize(
-                    pool_allocator=pool_allocator,
-                    managed_memory=self.managed_memory,
-                    initial_pool_size=self.nbytes,
-                    logging=self.logging,
+            rmm.mr.set_current_device_resource(rmm.mr.CudaAsyncMemoryResource())
+            if self.logging:
+                rmm.enable_logging(
                     log_file_name=get_rmm_log_file_name(
                         worker, self.logging, self.log_directory
-                    ),
+                    )
                 )
+        elif self.nbytes is not None or self.managed_memory:
+            import rmm
+
+            pool_allocator = False if self.nbytes is None else True
+
+            rmm.reinitialize(
+                pool_allocator=pool_allocator,
+                managed_memory=self.managed_memory,
+                initial_pool_size=self.nbytes,
+                logging=self.logging,
+                log_file_name=get_rmm_log_file_name(
+                    worker, self.logging, self.log_directory
+                ),
+            )
 
 
 def unpack_bitmask(x, mask_bits=64):


### PR DESCRIPTION
Closes #565

Adds the `--rmm-pool-async`/`rmm_pool_async` option to the CLI and cluster to enable the use of `rmm.mr.CudaAsyncMemoryResource` in the RMM initialization.