### PR TITLE
Proxify ignore some types

### DIFF
--- a/dask_cuda/get_device_memory_objects.py
+++ b/dask_cuda/get_device_memory_objects.py
@@ -93,8 +93,8 @@ def get_device_memory_objects_register_cudf():
     @dispatch.register(cudf.core.index.RangeIndex)
     def get_device_memory_objects_cudf_range_index(obj):
         # Avoid materializing RangeIndex. This introduce some inaccuracies
-        # in total device memory usage but we accept the memory use of
-        # RangeIndexes are limited.
+        # in total device memory usage, which we accept because the memory
+        # use of RangeIndexes are limited.
         return []
 
     @dispatch.register(cudf.core.index.Index)

--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -15,6 +15,11 @@ cupy.cuda.set_allocator(None)
 one_item_array = lambda: cupy.arange(1)
 one_item_nbytes = one_item_array().nbytes
 
+# While testing we want to proxify `cupy.ndarray` even though
+# it is on the ignore_type list by default.
+dask_cuda.proxify_device_objects.dispatch.dispatch(cupy.ndarray)
+dask_cuda.proxify_device_objects.ignore_types = ()
+
 
 def test_one_item_limit():
     dhf = ProxifyHostFile(device_memory_limit=one_item_nbytes)

--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -226,25 +226,6 @@ def test_fixed_attribute_length(backend):
         assert pxy._obj_pxy_is_serialized()
 
 
-@pytest.mark.parametrize("backend", ["numpy", "cupy"])
-def test_proxy_object_of_array_on_dots(backend):
-    """Check that a proxied array behaves as a regular (numpy or cupy) array"""
-
-    np = pytest.importorskip(backend)
-
-    # Make sure that equality works, which we use to test the other operators
-    org = np.arange(9).reshape((3, 3)) + 1
-    pxy = proxify_device_objects(org.copy(), {}, [])
-    assert (org == pxy).all()
-    assert (org + 1 != pxy).all()
-
-    for op in [np.dot]:
-        res = op(org, org)
-        assert (op(pxy, pxy) == res).all()
-        assert (op(org, pxy) == res).all()
-        assert (op(pxy, org) == res).all()
-
-
 def test_fixed_attribute_name():
     """Test fixed attribute `x.name` access
 

--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -226,6 +226,25 @@ def test_fixed_attribute_length(backend):
         assert pxy._obj_pxy_is_serialized()
 
 
+@pytest.mark.parametrize("backend", ["numpy", "cupy"])
+def test_proxy_object_of_array_on_dots(backend):
+    """Check that a proxied array behaves as a regular (numpy or cupy) array"""
+
+    np = pytest.importorskip(backend)
+
+    # Make sure that equality works, which we use to test the other operators
+    org = np.arange(9).reshape((3, 3)) + 1
+    pxy = proxify_device_objects(org.copy(), {}, [])
+    assert (org == pxy).all()
+    assert (org + 1 != pxy).all()
+
+    for op in [np.dot]:
+        res = op(org, org)
+        assert (op(pxy, pxy) == res).all()
+        assert (op(org, pxy) == res).all()
+        assert (op(pxy, org) == res).all()
+
+
 def test_fixed_attribute_name():
     """Test fixed attribute `x.name` access
 


### PR DESCRIPTION
This PR makes it possible to _not_ proxify some types. 
For now, this disable proxification of `cupy.ndarray` until we find a good solution to handle them.

