### PR TITLE
Add --interface and --no-silence-logs options to benchmarks

### DIFF
--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -110,6 +110,18 @@ def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]
         "Ignored if protocol is 'tcp'",
     )
     parser.add_argument(
+        "--interface",
+        default=None,
+        type=str,
+        dest="interface",
+        help="Network interface Dask processes will use to listen for connections."
+    )
+    parser.add_argument(
+        "--no-silence-logs",
+        action="store_true",
+        help="By default Dask logs are silenced, this argument unsilence them."
+    )
+    parser.add_argument(
         "--multi-node",
         action="store_true",
         dest="multi_node",
@@ -216,7 +228,10 @@ def get_cluster_options(args):
             "enable_infiniband": args.enable_infiniband,
             "enable_nvlink": args.enable_nvlink,
             "enable_rdmacm": args.enable_rdmacm,
+            "interface": args.interface,
         }
+        if args.no_silence_logs:
+            cluster_kwargs["silence_logs"] = False
 
     return {
         "class": Cluster,

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -114,12 +114,12 @@ def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]
         default=None,
         type=str,
         dest="interface",
-        help="Network interface Dask processes will use to listen for connections."
+        help="Network interface Dask processes will use to listen for connections.",
     )
     parser.add_argument(
         "--no-silence-logs",
         action="store_true",
-        help="By default Dask logs are silenced, this argument unsilence them."
+        help="By default Dask logs are silenced, this argument unsilence them.",
     )
     parser.add_argument(
         "--multi-node",


### PR DESCRIPTION
New arguments for benchmarks that allow specifying listening interface (important for RDMACM) and to print logs (useful for debugging).