### PR TITLE
Make package versions consistent between Conda recipe and `requirements.txt`

### DIFF
--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -23,7 +23,8 @@ requirements:
     - python
     - setuptools
   run:
-  {% for package in data.get('packages') %}
+    - python
+  {% for package in data.get('install_requires', []) %}
     - {{ package }}
   {% endfor %}
 

--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -2,12 +2,12 @@
 
 # Usage:
 #   conda build -c conda-forge -c defaults .
-{% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
+{% set data=load_setup_py_data() %}
 {% set git_revision_count=environ.get('GIT_DESCRIBE_NUMBER', 0) %}
 {% set py_version=environ.get('CONDA_PY', 36) %}
 package:
   name: dask-cuda
-  version: {{ version }}
+  version: {{ data.get('version') }}
 
 source:
   path: ../../..
@@ -23,12 +23,9 @@ requirements:
     - python
     - setuptools
   run:
-    - python
-    - dask >=2.4.0
-    - distributed >=2.18.0
-    - pynvml >=8.0.3
-    - numpy >=1.16.0
-    - numba >=0.50.0,!=0.51.0
+  {% for package in data.get('packages') %}
+    - {{ package }}
+  {% endfor %}
 
 test:
   imports:

--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -2,12 +2,12 @@
 
 # Usage:
 #   conda build -c conda-forge -c defaults .
-{% set data=load_setup_py_data() %}
+{% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set git_revision_count=environ.get('GIT_DESCRIBE_NUMBER', 0) %}
 {% set py_version=environ.get('CONDA_PY', 36) %}
 package:
   name: dask-cuda
-  version: {{ data.get('version') }}
+  version: {{ version }}
 
 source:
   path: ../../..
@@ -24,9 +24,11 @@ requirements:
     - setuptools
   run:
     - python
-  {% for package in data.get('install_requires', []) %}
-    - {{ package }}
-  {% endfor %}
+    - dask >=2.9.0
+    - distributed >=2.18.0
+    - pynvml >=8.0.3
+    - numpy >=1.16.0
+    - numba >=0.50.0,!=0.51.0
 
 test:
   imports:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ dask>=2.9.0
 distributed>=2.18.0
 pynvml>=8.0.3
 numpy>=1.16.0
-numba>=0.40.1
+numba>=0.50.0,!=0.51.0


### PR DESCRIPTION
Keeps the versions of Numba and Dask consistent across the Conda recipe and requirements file - see [#569 (comment)](https://github.com/rapidsai/dask-cuda/issues/569#issuecomment-819028783)