### PR TITLE
Add sphinx-click to docs Conda environment

### DIFF
--- a/conda/environments/builddocs_py37.yml
+++ b/conda/environments/builddocs_py37.yml
@@ -4,5 +4,6 @@ channels:
 - conda-forge
 dependencies:
 - rapids-doc-env
+- sphinx-click
 - pandas
 - dask


### PR DESCRIPTION
Adds sphinx-click to the Conda environment used by RTD, which is necessary now because of #561. Fixes doc builds, which are currently failing.