### PR TITLE
[gpuCI] Forward-merge branch-0.19 to branch-0.20 [skip ci]

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -33,7 +33,7 @@ export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1
 
 # Install dask and distributed from master branch. Usually needed during
 # development time and disabled before a new dask-cuda release.
-export INSTALL_DASK_MASTER=1
+export INSTALL_DASK_MASTER=0
 
 ################################################################################
 # SETUP - Check environment

--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -24,8 +24,8 @@ requirements:
     - setuptools
   run:
     - python
-    - dask >=2.4.0
-    - distributed >=2.18.0
+    - dask >=2.22.0,<=2021.4.0
+    - distributed >=2.22.0,<=2021.4.0
     - pynvml >=8.0.3
     - numpy >=1.16.0
     - numba >=0.50.0,!=0.51.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-dask>=2.9.0
-distributed>=2.18.0
+dask>=2.22.0,<=2021.04.0
+distributed>=2.22.0,<=2021.04.0
 pynvml>=8.0.3
 numpy>=1.16.0
 numba>=0.40.1


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.19` that creates a PR to keep `branch-0.20` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.