### PR TITLE
Explicit-comms shuffle: make sure partition order are maintained

### DIFF
--- a/dask_cuda/explicit_comms/dataframe/shuffle.py
+++ b/dask_cuda/explicit_comms/dataframe/shuffle.py
@@ -330,6 +330,7 @@ def shuffle(
                 ignore_index,
             )
     distributed.wait(list(result_futures.values()))
+    del df_groups
 
     # Step (c): extract individual dataframe-partitions
     name = f"explicit-comms-shuffle-getitem-{tokenize(name)}"

--- a/dask_cuda/explicit_comms/dataframe/shuffle.py
+++ b/dask_cuda/explicit_comms/dataframe/shuffle.py
@@ -343,6 +343,7 @@ def shuffle(
                 meta = delayed(make_meta)(
                     delayed(getitem)(result_futures[rank], i)
                 ).compute()
+    assert meta is not None
 
     divs = [None] * (len(dsk) + 1)
     return new_dd_object(dsk, name, meta, divs).persist()

--- a/dask_cuda/explicit_comms/dataframe/shuffle.py
+++ b/dask_cuda/explicit_comms/dataframe/shuffle.py
@@ -11,8 +11,9 @@ import dask
 import dask.dataframe
 import distributed
 from dask.base import compute_as_if_collection, tokenize
-from dask.dataframe.core import DataFrame, _concat as dd_concat
+from dask.dataframe.core import DataFrame, _concat as dd_concat, new_dd_object
 from dask.dataframe.shuffle import shuffle_group
+from dask.dataframe.utils import make_meta
 from dask.delayed import delayed
 from distributed import wait
 from distributed.protocol import nested_deserialize, to_serialize
@@ -53,7 +54,7 @@ def sort_in_parts(
     concat_dfs_of_same_output_partition: bool,
     concat,
 ) -> Dict[int, List[List[DataFrame]]]:
-    """ Sort the list of grouped dataframes in `in_parts`
+    """Sort the list of grouped dataframes in `in_parts`
 
     It returns a dict that for each worker-rank specifies the output partitions:
     '''
@@ -331,12 +332,15 @@ def shuffle(
     distributed.wait(list(result_futures.values()))
 
     # Step (c): extract individual dataframe-partitions
-    ret = []
+    name = f"explicit-comms-shuffle-getitem-{tokenize(name)}"
+    dsk = {}
     for rank, parts in rank_to_out_part_ids.items():
-        for i in range(len(parts)):
-            ret.append(delayed(getitem)(result_futures[rank], i))
-    del result_futures
-    return dask.dataframe.from_delayed(ret, verify_meta=False).persist()
+        for i, part_id in enumerate(parts):
+            dsk[(name, part_id)] = (getitem, result_futures[rank], i)
+
+    meta = delayed(make_meta)(delayed(getitem)(result_futures[rank], 0)).compute()
+    divs = [None] * (len(dsk) + 1)
+    return new_dd_object(dsk, name, meta, divs).persist()
 
 
 def get_rearrange_by_column_tasks_wrapper(func):

--- a/dask_cuda/tests/test_explicit_comms.py
+++ b/dask_cuda/tests/test_explicit_comms.py
@@ -217,21 +217,20 @@ def test_dataframe_shuffle(backend, protocol, nworkers):
 
 def _test_dask_use_explicit_comms():
     def check_shuffle(in_cluster):
-        """Check if shuffle use explicit-comms by search for keys named "shuffle"
-
-        The explicit-comms implemention of shuffle doesn't produce any keys
-        named "shuffle"
+        """Check if shuffle use explicit-comms by search for keys named
+        'explicit-comms-shuffle'
         """
+        name = "explicit-comms-shuffle"
         ddf = dd.from_pandas(pd.DataFrame({"key": np.arange(10)}), npartitions=2)
         with dask.config.set(explicit_comms=False):
             res = ddf.shuffle(on="key", npartitions=4, shuffle="tasks")
-            assert any(["shuffle" in str(key) for key in res.dask])
+            assert all(name not in str(key) for key in res.dask)
         with dask.config.set(explicit_comms=True):
             res = ddf.shuffle(on="key", npartitions=4, shuffle="tasks")
             if in_cluster:
-                assert all(["shuffle" not in str(key) for key in res.dask])
+                assert any(name in str(key) for key in res.dask)
             else:  # If not in cluster, we cannot use explicit comms
-                assert any(["shuffle" in str(key) for key in res.dask])
+                assert all(name not in str(key) for key in res.dask)
 
     with LocalCluster(
         protocol="tcp",


### PR DESCRIPTION
This PR fixes a bug in explicit-comms shuffle triggered when used by Dask to merge two data frames. 
The problem was that the partition order wasn't preserved thus two consecutive calls to shuffle didn't guaranteed that the i'th partition of the first data frame matched the i'th partition of the second data frame. This is now fixed.

 