### PR TITLE
JIT-Unspill Compatibility Mode

### DIFF
--- a/dask_cuda/__init__.py
+++ b/dask_cuda/__init__.py
@@ -1,9 +1,11 @@
 import dask
+import dask.dataframe.core
 import dask.dataframe.shuffle
 
 from ._version import get_versions
 from .cuda_worker import CUDAWorker
 from .explicit_comms.dataframe.shuffle import get_rearrange_by_column_tasks_wrapper
+from .proxify_device_objects import proxify_decorator, unproxify_decorator
 from .local_cuda_cluster import LocalCUDACluster
 
 __version__ = get_versions()["version"]
@@ -14,3 +16,10 @@ del get_versions
 dask.dataframe.shuffle.rearrange_by_column_tasks = get_rearrange_by_column_tasks_wrapper(
     dask.dataframe.shuffle.rearrange_by_column_tasks
 )
+
+
+# Monkey patching Dask to make use of proxify and unproxify in compatibility mode
+dask.dataframe.shuffle.shuffle_group = proxify_decorator(
+    dask.dataframe.shuffle.shuffle_group
+)
+dask.dataframe.core._concat = unproxify_decorator(dask.dataframe.core._concat)

--- a/dask_cuda/proxify_device_objects.py
+++ b/dask_cuda/proxify_device_objects.py
@@ -114,14 +114,15 @@ def unproxify_device_objects(obj: Any, skip_explicit_proxies: bool = False):
     ret: Any
         A copy of `obj` where all CUDA device objects are unproxify
     """
-    typ = type(obj)
-    if typ is dict:
+    if isinstance(obj, dict):
         return {
             k: unproxify_device_objects(v, skip_explicit_proxies)
             for k, v in obj.items()
         }
-    if typ in (list, tuple, set, frozenset):
-        return typ(unproxify_device_objects(i, skip_explicit_proxies) for i in obj)
+    if isinstance(obj, (list, tuple, set, frozenset)):
+        return type(obj)(
+            unproxify_device_objects(i, skip_explicit_proxies) for i in obj
+        )
 
     if hasattr(obj, "_obj_pxy"):
         if not skip_explicit_proxies or not obj._obj_pxy["explicit_proxy"]:

--- a/dask_cuda/proxify_device_objects.py
+++ b/dask_cuda/proxify_device_objects.py
@@ -49,8 +49,8 @@ def _register_ignore_types():
 
 def proxify_device_objects(
     obj: Any,
-    proxied_id_to_proxy: MutableMapping[int, ProxyObject],
-    found_proxies: List[ProxyObject],
+    proxied_id_to_proxy: MutableMapping[int, ProxyObject] = None,
+    found_proxies: List[ProxyObject] = None,
     excl_proxies: bool = False,
 ):
     """ Wrap device objects in ProxyObject
@@ -66,9 +66,11 @@ def proxify_device_objects(
     proxied_id_to_proxy: MutableMapping[int, ProxyObject]
         Dict mapping the id() of proxied objects (CUDA device objects) to
         their proxy and is updated with all new proxied objects found in `obj`.
+        If None, use an empty dict.
     found_proxies: List[ProxyObject]
         List of found proxies in `obj`. Notice, this includes all proxies found,
         including those already in `proxied_id_to_proxy`.
+        If None, use an empty list.
     excl_proxies: bool
         Don't add found objects that are already ProxyObject to found_proxies.
 
@@ -78,6 +80,11 @@ def proxify_device_objects(
         A copy of `obj` where all CUDA device objects are wrapped in ProxyObject
     """
     _register_ignore_types()
+
+    if proxied_id_to_proxy is None:
+        proxied_id_to_proxy = {}
+    if found_proxies is None:
+        found_proxies = []
     return dispatch(obj, proxied_id_to_proxy, found_proxies, excl_proxies)
 
 

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -143,7 +143,7 @@ class ProxifyHostFile(MutableMapping):
     ----------
     device_memory_limit: int
         Number of bytes of CUDA device memory used before spilling to host.
-    compatibility_mode: bool
+    compatibility_mode: bool or None
         Enables compatibility-mode, which means that items are un-proxified before
         retrieval. This makes it possible to get some of the JIT-unspill benefits
         without having to be ProxyObject compatible. In order to still allow specific

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -72,6 +72,7 @@ def asproxy(obj, serializers=None, subclass=None) -> "ProxyObject":
             is_cuda_object=is_device_object(obj),
             subclass=subclass_serialized,
             serializers=None,
+            explicit_proxy=False,
         )
     if serializers is not None:
         ret._obj_pxy_serialize(serializers=serializers)
@@ -175,6 +176,9 @@ class ProxyObject:
     serializers: list(str), optional
         List of serializers to use to serialize `obj`. If None, `obj`
         isn't serialized.
+    explicit_proxy: bool
+        Mark the proxy object as "explicit", which means that the user allows it
+        as input argument to dask tasks even in compatibility-mode.
     """
 
     def __init__(
@@ -186,6 +190,7 @@ class ProxyObject:
         is_cuda_object: bool,
         subclass: bytes,
         serializers: Optional[List[str]],
+        explicit_proxy: bool,
     ):
         self._obj_pxy = {
             "obj": obj,
@@ -195,6 +200,7 @@ class ProxyObject:
             "is_cuda_object": is_cuda_object,
             "subclass": subclass,
             "serializers": serializers,
+            "explicit_proxy": explicit_proxy,
         }
         self._obj_pxy_lock = threading.RLock()
         self._obj_pxy_cache = {}
@@ -227,6 +233,7 @@ class ProxyObject:
             "is_cuda_object",
             "subclass",
             "serializers",
+            "explicit_proxy",
         ]
         return OrderedDict([(a, self._obj_pxy[a]) for a in args])
 

--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -1,6 +1,9 @@
+import numpy as np
 import pytest
 from pandas.testing import assert_frame_equal
 
+import dask
+import dask.dataframe
 from dask.dataframe.shuffle import shuffle_group
 from distributed import Client
 
@@ -216,3 +219,34 @@ def test_proxify_device_objects_of_cupy_array():
             assert (op(pxy, org) == res).all()
     finally:
         dask_cuda.proxify_device_objects.ignore_types = ()
+
+
+@pytest.mark.parametrize("npartitions", [1, 2, 3])
+def test_compatibility_mode_dataframe_shuffle(npartitions):
+    cudf = pytest.importorskip("cudf")
+
+    def is_proxy_object(x):
+        return "ProxyObject" in str(type(x))
+
+    # With compatibility mode off, we expect to encounter proxy objects
+    with dask.config.set(jit_unspill_compatibility_mode=False):
+        with dask_cuda.LocalCUDACluster(n_workers=1, jit_unspill=True) as cluster:
+            with Client(cluster):
+                ddf = dask.dataframe.from_pandas(
+                    cudf.DataFrame({"key": np.arange(10)}), npartitions=npartitions
+                )
+                res = ddf.shuffle(on="key", shuffle="tasks").persist()
+                res = res.map_partitions(is_proxy_object).compute()
+                assert all(res.to_list())
+
+    # With compatibility mode on, we shouldn't encounter any proxy objects
+    with dask.config.set(jit_unspill_compatibility_mode=True):
+        with dask_cuda.LocalCUDACluster(n_workers=1, jit_unspill=True) as cluster:
+            with Client(cluster):
+                ddf = dask.dataframe.from_pandas(
+                    cudf.DataFrame({"key": np.arange(10)}), npartitions=npartitions
+                )
+                res = ddf.shuffle(on="key", shuffle="tasks").persist()
+                assert "ProxyObject" not in str(type(res.compute()))
+                res = res.map_partitions(is_proxy_object).compute()
+                assert not any(res.to_list())

--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -222,31 +222,28 @@ def test_proxify_device_objects_of_cupy_array():
 
 
 @pytest.mark.parametrize("npartitions", [1, 2, 3])
-def test_compatibility_mode_dataframe_shuffle(npartitions):
+@pytest.mark.parametrize("compatibility_mode", [True, False])
+def test_compatibility_mode_dataframe_shuffle(compatibility_mode, npartitions):
     cudf = pytest.importorskip("cudf")
 
     def is_proxy_object(x):
         return "ProxyObject" in str(type(x))
 
-    # With compatibility mode off, we expect to encounter proxy objects
-    with dask.config.set(jit_unspill_compatibility_mode=False):
+    with dask.config.set(jit_unspill_compatibility_mode=compatibility_mode):
         with dask_cuda.LocalCUDACluster(n_workers=1, jit_unspill=True) as cluster:
             with Client(cluster):
                 ddf = dask.dataframe.from_pandas(
                     cudf.DataFrame({"key": np.arange(10)}), npartitions=npartitions
                 )
                 res = ddf.shuffle(on="key", shuffle="tasks").persist()
-                res = res.map_partitions(is_proxy_object).compute()
-                assert all(res.to_list())
 
-    # With compatibility mode on, we shouldn't encounter any proxy objects
-    with dask.config.set(jit_unspill_compatibility_mode=True):
-        with dask_cuda.LocalCUDACluster(n_workers=1, jit_unspill=True) as cluster:
-            with Client(cluster):
-                ddf = dask.dataframe.from_pandas(
-                    cudf.DataFrame({"key": np.arange(10)}), npartitions=npartitions
-                )
-                res = ddf.shuffle(on="key", shuffle="tasks").persist()
-                assert "ProxyObject" not in str(type(res.compute()))
+                # With compatibility mode on, we shouldn't encounter any proxy objects
+                if compatibility_mode:
+                    assert "ProxyObject" not in str(type(res.compute()))
                 res = res.map_partitions(is_proxy_object).compute()
-                assert not any(res.to_list())
+                res = res.to_list()
+
+                if compatibility_mode:
+                    assert not any(res)  # No proxy objects
+                else:
+                    assert all(res)  # Only proxy objects


### PR DESCRIPTION
This PR introduces _Compatibility Mode_:
```python
class ProxifyHostFile(MutableMapping):
    """Host file that proxify stored data
    ...

    compatibility_mode: bool
        Enables compatibility-mode, which means that items are un-proxified before
        retrieval. This makes it possible to get some of the JIT-unspill benefits
        without having to be ProxyObject compatible. In order to still allow specific
        ProxyObjects, set the `mark_as_explicit_proxies=True` when proxifying with
        `proxify_device_objects()`. If None, the "jit-unspill-compatibility-mode"
        config value are used, which defaults to False.
    """
```