### PR TITLE
Fixing Dataframe merge benchmark

### DIFF
--- a/dask_cuda/benchmarks/local_cudf_merge.py
+++ b/dask_cuda/benchmarks/local_cudf_merge.py
@@ -1,6 +1,7 @@
+import contextlib
 import math
 from collections import defaultdict
-from time import perf_counter as clock
+from time import perf_counter
 from warnings import filterwarnings
 
 import numpy
@@ -134,7 +135,7 @@ def get_random_ddf(chunk_size, num_chunks, frac_match, chunk_type, args):
     return ddf
 
 
-def merge(args, ddf1, ddf2, write_profile):
+def merge(args, ddf1, ddf2):
 
     # Allow default broadcast behavior, unless
     # "--shuffle-join" or "--broadcast-join" was
@@ -142,22 +143,11 @@ def merge(args, ddf1, ddf2, write_profile):
     # precedence)
     broadcast = False if args.shuffle_join else (True if args.broadcast_join else None)
 
-    # Lazy merge/join operation
-    ddf_join = ddf1.merge(ddf2, on=["key"], how="inner", broadcast=broadcast,)
+    # The merge/join operation
+    ddf_join = ddf1.merge(ddf2, on=["key"], how="inner", broadcast=broadcast)
     if args.set_index:
         ddf_join = ddf_join.set_index("key")
-
-    # Execute the operations to benchmark
-    if write_profile is not None:
-        with performance_report(filename=args.profile):
-            t1 = clock()
-            wait(ddf_join.persist())
-            took = clock() - t1
-    else:
-        t1 = clock()
-        wait(ddf_join.persist())
-        took = clock() - t1
-    return took
+    wait(ddf_join.persist())
 
 
 def run(client, args, n_workers, write_profile=None):
@@ -176,13 +166,20 @@ def run(client, args, n_workers, write_profile=None):
     data_processed = len(ddf_base) * sum([t.itemsize for t in ddf_base.dtypes])
     data_processed += len(ddf_other) * sum([t.itemsize for t in ddf_other.dtypes])
 
-    if args.backend == "dask":
-        took = merge(args, ddf_base, ddf_other, write_profile)
-    else:
-        with dask.config.set(explicit_comms=True):
-            took = merge(args, ddf_base, ddf_other, write_profile)
+    # Get contexts to use (defaults to null contexts that doesn't do anything)
+    ctx1, ctx2 = contextlib.nullcontext(), contextlib.nullcontext()
+    if args.backend == "explicit-comms":
+        ctx1 = dask.config.set(explicit_comms=True)
+    if write_profile is not None:
+        ctx2 = performance_report(filename=args.profile)
 
-    return (data_processed, took)
+    with ctx1:
+        with ctx2:
+            t1 = perf_counter()
+            merge(args, ddf_base, ddf_other)
+            t2 = perf_counter()
+
+    return (data_processed, t2 - t1)
 
 
 def main(args):

--- a/dask_cuda/benchmarks/local_cudf_shuffle.py
+++ b/dask_cuda/benchmarks/local_cudf_shuffle.py
@@ -1,3 +1,4 @@
+import contextlib
 from collections import defaultdict
 from time import perf_counter as clock
 from warnings import filterwarnings
@@ -22,17 +23,16 @@ from dask_cuda.utils import all_to_all
 
 
 def shuffle_dask(args, df, write_profile):
-    # Execute the operations to benchmark
-    if write_profile is not None:
-        with performance_report(filename=args.profile):
-            t1 = clock()
-            wait(shuffle(df, index="data", shuffle="tasks").persist())
-            took = clock() - t1
+    if write_profile is None:
+        ctx = contextlib.nullcontext()
     else:
+        ctx = performance_report(filename=args.profile)
+
+    # Execute the operations to benchmark
+    with ctx:
         t1 = clock()
         wait(shuffle(df, index="data", shuffle="tasks").persist())
-        took = clock() - t1
-    return took
+        return clock() - t1
 
 
 def shuffle_explicit_comms(args, df):


### PR DESCRIPTION
The `local_cudf_merge.py` benchmark didn't time all of the merge operation when using `explicit-comms` as the backend.