### PR TITLE
Handle `import`ing relocated dispatch functions

### DIFF
--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -18,6 +18,11 @@ import distributed.utils
 from dask.sizeof import sizeof
 from distributed.worker import dumps_function, loads_function
 
+try:
+    from dask.dataframe.backends import concat_pandas
+except ImportError:
+    from dask.dataframe.methods import concat_pandas
+
 from .get_device_memory_objects import get_device_memory_objects
 from .is_device_object import is_device_object
 
@@ -745,5 +750,5 @@ dask.dataframe.methods.concat_dispatch.register(
 # deserialize all ProxyObjects before concatenating
 dask.dataframe.methods.concat_dispatch.register(
     (pandas.DataFrame, pandas.Series, pandas.Index),
-    unproxify_input_wrapper(dask.dataframe.methods.concat_pandas),
+    unproxify_input_wrapper(concat_pandas),
 )

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -21,23 +21,6 @@ from distributed.worker import dumps_function, loads_function
 from .get_device_memory_objects import get_device_memory_objects
 from .is_device_object import is_device_object
 
-try:
-    from dask.array.backends import concatenate_lookup, einsum_lookup, tensordot_lookup
-    from dask.dataframe.backends import (
-        group_split_dispatch,
-        hash_object_dispatch,
-        make_meta,
-        make_scalar,
-    )
-except ImportError:
-    from dask.array.core import concatenate_lookup, einsum_lookup, tensordot_lookup
-    from dask.dataframe.utils import (
-        group_split_dispatch,
-        hash_object_dispatch,
-        make_meta,
-        make_scalar,
-    )
-
 # List of attributes that should be copied to the proxy at creation, which makes
 # them accessible without deserialization of the proxied object
 _FIXED_ATTRS = ["name", "__len__"]
@@ -743,13 +726,13 @@ def unproxify_input_wrapper(func):
 
 # Register dispatch of ProxyObject on all known dispatch objects
 for dispatch in (
-    hash_object_dispatch,
-    make_meta,
-    make_scalar,
-    group_split_dispatch,
-    tensordot_lookup,
-    einsum_lookup,
-    concatenate_lookup,
+    dask.dataframe.core.hash_object_dispatch,
+    dask.dataframe.core.make_meta,
+    dask.dataframe.utils.make_scalar,
+    dask.dataframe.core.group_split_dispatch,
+    dask.array.core.tensordot_lookup,
+    dask.array.core.einsum_lookup,
+    dask.array.core.concatenate_lookup,
 ):
     dispatch.register(ProxyObject, unproxify_input_wrapper(dispatch))
 

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -21,6 +21,23 @@ from distributed.worker import dumps_function, loads_function
 from .get_device_memory_objects import get_device_memory_objects
 from .is_device_object import is_device_object
 
+try:
+    from dask.array.backends import concatenate_lookup, einsum_lookup, tensordot_lookup
+    from dask.dataframe.backends import (
+        group_split_dispatch,
+        hash_object_dispatch,
+        make_meta,
+        make_scalar,
+    )
+except ImportError:
+    from dask.array.core import concatenate_lookup, einsum_lookup, tensordot_lookup
+    from dask.dataframe.utils import (
+        group_split_dispatch,
+        hash_object_dispatch,
+        make_meta,
+        make_scalar,
+    )
+
 # List of attributes that should be copied to the proxy at creation, which makes
 # them accessible without deserialization of the proxied object
 _FIXED_ATTRS = ["name", "__len__"]
@@ -726,13 +743,13 @@ def unproxify_input_wrapper(func):
 
 # Register dispatch of ProxyObject on all known dispatch objects
 for dispatch in (
-    dask.dataframe.utils.hash_object_dispatch,
-    dask.dataframe.utils.make_meta,
-    dask.dataframe.utils.make_scalar,
-    dask.dataframe.utils.group_split_dispatch,
-    dask.array.core.tensordot_lookup,
-    dask.array.core.einsum_lookup,
-    dask.array.core.concatenate_lookup,
+    hash_object_dispatch,
+    make_meta,
+    make_scalar,
+    group_split_dispatch,
+    tensordot_lookup,
+    einsum_lookup,
+    concatenate_lookup,
 ):
     dispatch.register(ProxyObject, unproxify_input_wrapper(dispatch))
 

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -732,7 +732,7 @@ def unproxify_input_wrapper(func):
 # Register dispatch of ProxyObject on all known dispatch objects
 for dispatch in (
     dask.dataframe.core.hash_object_dispatch,
-    dask.dataframe.core.make_meta,
+    dask.dataframe.utils.make_meta,
     dask.dataframe.utils.make_scalar,
     dask.dataframe.core.group_split_dispatch,
     dask.array.core.tensordot_lookup,

--- a/dask_cuda/tests/test_ucx_options.py
+++ b/dask_cuda/tests/test_ucx_options.py
@@ -50,6 +50,7 @@ def _test_global_option(seg_size):
             assert conf["SEG_SIZE"] == seg_size
 
 
+@pytest.mark.xfail(reason="https://github.com/rapidsai/dask-cuda/issues/627")
 def test_global_option():
     for seg_size in ["2K", "1M", "2M"]:
         p = mp.Process(target=_test_global_option, args=(seg_size,))


### PR DESCRIPTION
Requires PR ( https://github.com/rapidsai/cudf/pull/8342 )

As these functions recently got relocated, handle `import`ing from the new location with a fallback to the old location.

xref: https://github.com/dask/dask/pull/7503
xref: https://github.com/dask/dask/pull/7505