### PR TITLE
Drop xfail from `test_global_option`

### DIFF
--- a/dask_cuda/tests/test_ucx_options.py
+++ b/dask_cuda/tests/test_ucx_options.py
@@ -50,7 +50,6 @@ def _test_global_option(seg_size):
             assert conf["SEG_SIZE"] == seg_size
 
 
-@pytest.mark.xfail(reason="https://github.com/rapidsai/dask-cuda/issues/627")
 def test_global_option():
     for seg_size in ["2K", "1M", "2M"]:
         p = mp.Process(target=_test_global_option, args=(seg_size,))


### PR DESCRIPTION
This test was marked as `xfail` as it started failing recently. Try re-enabling to see if we can get this passing again.

xref: https://github.com/rapidsai/dask-cuda/issues/627

cc @pentschev