### PR TITLE
[gpuCI] Forward-merge branch-21.06 to branch-21.08 [skip ci]

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -56,7 +56,7 @@ conda list --show-channel-urls
 # indicate binary incompatibility. Expected 192 from C header, got 216 from PyObject
 gpuci_conda_retry install "cudatoolkit=$CUDA_REL" \
               "cudf=${MINOR_VERSION}" "dask-cudf=${MINOR_VERSION}" \
-              "ucx-py=$MINOR_VERSION.*" "ucx-proc=*=gpu" \
+              "ucx-py=0.20.*" "ucx-proc=*=gpu" \
               "rapids-build-env=$MINOR_VERSION.*"
 
 # Pin pytest-asyncio because latest versions modify the default asyncio


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.06` that creates a PR to keep `branch-21.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.