### PR TITLE
[gpuCI] Forward-merge branch-21.06 to branch-21.08 [skip ci]

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -33,7 +33,7 @@ export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1
 
 # Install dask and distributed from master branch. Usually needed during
 # development time and disabled before a new dask-cuda release.
-export INSTALL_DASK_MASTER=1
+export INSTALL_DASK_MASTER=0
 
 ################################################################################
 # SETUP - Check environment

--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -27,11 +27,11 @@ requirements:
     - setuptools
   run:
     - python
-    - dask >=2.22.0
-    - distributed >=2.22.0
+    - dask >=2.22.0,<=2021.5.1
+    - distributed >=2.22.0,<2021.5.1
     - pynvml >=8.0.3
     - numpy >=1.16.0
-    - numba >=0.50.0,!=0.51.0
+    - numba >=0.53.1
 
 test:
   imports:

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -107,7 +107,7 @@ def test_rmm_managed(loop):  # noqa: F811
 
 
 @pytest.mark.skipif(
-    ((_driver_version, _runtime_version) < (11020, 11020)),
+    _driver_version < 11020 or _runtime_version < 11020,
     reason="cudaMallocAsync not supported",
 )
 def test_rmm_async(loop):  # noqa: F811

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -160,7 +160,7 @@ async def test_rmm_managed():
 
 
 @pytest.mark.skipif(
-    ((_driver_version, _runtime_version) < (11020, 11020)),
+    _driver_version < 11020 or _runtime_version < 11020,
     reason="cudaMallocAsync not supported",
 )
 @gen_test(timeout=20)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-dask>=2.22.0
-distributed>=2.22.0
+dask>=2.22.0,<=2021.5.1
+distributed>=2.22.0,<=2021.5.1
 pynvml>=8.0.3
 numpy>=1.16.0
-numba>=0.50.0,!=0.51.0
+numba>=0.53.1


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.06` that creates a PR to keep `branch-21.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.