### PR TITLE
[gpuCI] Forward-merge branch-21.06 to branch-21.08 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
-# dask-cuda 21.06.00 (Date TBD)
+# dask-cuda 21.06.00 (9 Jun 2021)
 
-Please see https://github.com/rapidsai/dask-cuda/releases/tag/v21.06.00a for the latest changes to this development branch.
+## 🐛 Bug Fixes
+
+- Handle `impot`ing elocated dispatch functions ([#623](https://github.com/rapidsai/dask-cuda/pull/623)) [@jakikham](https://github.com/jakikham)
+- Fix DGX tests fo UCX 1.9 ([#619](https://github.com/rapidsai/dask-cuda/pull/619)) [@pentschev](https://github.com/pentschev)
+- Add PROJECTS va ([#614](https://github.com/rapidsai/dask-cuda/pull/614)) [@ajschmidt8](https://github.com/ajschmidt8)
+
+## 📖 Documentation
+
+- Bump docs copyight yea ([#616](https://github.com/rapidsai/dask-cuda/pull/616)) [@chalesbluca](https://github.com/chalesbluca)
+- Update RTD site to ediect to RAPIDS docs ([#615](https://github.com/rapidsai/dask-cuda/pull/615)) [@chalesbluca](https://github.com/chalesbluca)
+- Document DASK_JIT_UNSPILL ([#604](https://github.com/rapidsai/dask-cuda/pull/604)) [@madsbk](https://github.com/madsbk)
+
+## 🚀 New Featues
+
+- Disable euse endpoints with UCX &gt;= 1.11 ([#620](https://github.com/rapidsai/dask-cuda/pull/620)) [@pentschev](https://github.com/pentschev)
+
+## 🛠️ Impovements
+
+- Adding pofiling to dask shuffle ([#625](https://github.com/rapidsai/dask-cuda/pull/625)) [@aunaman](https://github.com/aunaman)
+- Update `CHANGELOG.md` links fo calve ([#618](https://github.com/rapidsai/dask-cuda/pull/618)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Fixing Datafame mege benchmak ([#617](https://github.com/rapidsai/dask-cuda/pull/617)) [@madsbk](https://github.com/madsbk)
+- Fix DGX tests fo UCX 1.10+ ([#613](https://github.com/rapidsai/dask-cuda/pull/613)) [@pentschev](https://github.com/pentschev)
+- Update docs build scipt ([#612](https://github.com/rapidsai/dask-cuda/pull/612)) [@ajschmidt8](https://github.com/ajschmidt8)
 
 # dask-cuda 0.19.0 (21 Apr 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,27 +2,27 @@
 
 ## 🐛 Bug Fixes
 
-- Handle `impot`ing elocated dispatch functions ([#623](https://github.com/rapidsai/dask-cuda/pull/623)) [@jakikham](https://github.com/jakikham)
-- Fix DGX tests fo UCX 1.9 ([#619](https://github.com/rapidsai/dask-cuda/pull/619)) [@pentschev](https://github.com/pentschev)
-- Add PROJECTS va ([#614](https://github.com/rapidsai/dask-cuda/pull/614)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Handle `import`ing relocated dispatch functions ([#623](https://github.com/rapidsai/dask-cuda/pull/623)) [@jakirkham](https://github.com/jakirkham)
+- Fix DGX tests for UCX 1.9 ([#619](https://github.com/rapidsai/dask-cuda/pull/619)) [@pentschev](https://github.com/pentschev)
+- Add PROJECTS var ([#614](https://github.com/rapidsai/dask-cuda/pull/614)) [@ajschmidt8](https://github.com/ajschmidt8)
 
 ## 📖 Documentation
 
-- Bump docs copyight yea ([#616](https://github.com/rapidsai/dask-cuda/pull/616)) [@chalesbluca](https://github.com/chalesbluca)
-- Update RTD site to ediect to RAPIDS docs ([#615](https://github.com/rapidsai/dask-cuda/pull/615)) [@chalesbluca](https://github.com/chalesbluca)
+- Bump docs copyright year ([#616](https://github.com/rapidsai/dask-cuda/pull/616)) [@charlesbluca](https://github.com/charlesbluca)
+- Update RTD site to redirect to RAPIDS docs ([#615](https://github.com/rapidsai/dask-cuda/pull/615)) [@charlesbluca](https://github.com/charlesbluca)
 - Document DASK_JIT_UNSPILL ([#604](https://github.com/rapidsai/dask-cuda/pull/604)) [@madsbk](https://github.com/madsbk)
 
-## 🚀 New Featues
+## 🚀 New Features
 
-- Disable euse endpoints with UCX &gt;= 1.11 ([#620](https://github.com/rapidsai/dask-cuda/pull/620)) [@pentschev](https://github.com/pentschev)
+- Disable reuse endpoints with UCX &gt;= 1.11 ([#620](https://github.com/rapidsai/dask-cuda/pull/620)) [@pentschev](https://github.com/pentschev)
 
-## 🛠️ Impovements
+## 🛠️ Improvements
 
-- Adding pofiling to dask shuffle ([#625](https://github.com/rapidsai/dask-cuda/pull/625)) [@aunaman](https://github.com/aunaman)
-- Update `CHANGELOG.md` links fo calve ([#618](https://github.com/rapidsai/dask-cuda/pull/618)) [@ajschmidt8](https://github.com/ajschmidt8)
-- Fixing Datafame mege benchmak ([#617](https://github.com/rapidsai/dask-cuda/pull/617)) [@madsbk](https://github.com/madsbk)
-- Fix DGX tests fo UCX 1.10+ ([#613](https://github.com/rapidsai/dask-cuda/pull/613)) [@pentschev](https://github.com/pentschev)
-- Update docs build scipt ([#612](https://github.com/rapidsai/dask-cuda/pull/612)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Adding profiling to dask shuffle ([#625](https://github.com/rapidsai/dask-cuda/pull/625)) [@arunraman](https://github.com/arunraman)
+- Update `CHANGELOG.md` links for calver ([#618](https://github.com/rapidsai/dask-cuda/pull/618)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Fixing Dataframe merge benchmark ([#617](https://github.com/rapidsai/dask-cuda/pull/617)) [@madsbk](https://github.com/madsbk)
+- Fix DGX tests for UCX 1.10+ ([#613](https://github.com/rapidsai/dask-cuda/pull/613)) [@pentschev](https://github.com/pentschev)
+- Update docs build script ([#612](https://github.com/rapidsai/dask-cuda/pull/612)) [@ajschmidt8](https://github.com/ajschmidt8)
 
 # dask-cuda 0.19.0 (21 Apr 2021)
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.06` that creates a PR to keep `branch-21.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.