### PR TITLE
Small tweaks to make compatible with dask-mpi

### DIFF
--- a/dask_cuda/__init__.py
+++ b/dask_cuda/__init__.py
@@ -5,8 +5,8 @@ import dask.dataframe.shuffle
 from ._version import get_versions
 from .cuda_worker import CUDAWorker
 from .explicit_comms.dataframe.shuffle import get_rearrange_by_column_tasks_wrapper
-from .proxify_device_objects import proxify_decorator, unproxify_decorator
 from .local_cuda_cluster import LocalCUDACluster
+from .proxify_device_objects import proxify_decorator, unproxify_decorator
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -221,10 +221,7 @@ class CUDAWorker(Server):
                 plugins={
                     CPUAffinity(get_cpu_affinity(i)),
                     RMMSetup(
-                        rmm_pool_size,
-                        rmm_managed_memory,
-                        rmm_async,
-                        rmm_log_directory,
+                        rmm_pool_size, rmm_managed_memory, rmm_async, rmm_log_directory,
                     ),
                 },
                 name=name if nprocs == 1 or not name else str(name) + "-" + str(i),

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -10,6 +10,7 @@ from tornado.ioloop import IOLoop
 
 import dask
 from distributed import Nanny
+from distributed.core import Server
 from distributed.deploy.cluster import Cluster
 from distributed.proctitle import (
     enable_proctitle_on_children,
@@ -45,7 +46,7 @@ def _get_interface(interface, host, cuda_device_index, ucx_net_devices):
         )
 
 
-class CUDAWorker:
+class CUDAWorker(Server):
     def __init__(
         self,
         scheduler=None,
@@ -220,10 +221,13 @@ class CUDAWorker:
                 plugins={
                     CPUAffinity(get_cpu_affinity(i)),
                     RMMSetup(
-                        rmm_pool_size, rmm_managed_memory, rmm_async, rmm_log_directory,
+                        rmm_pool_size,
+                        rmm_managed_memory,
+                        rmm_async,
+                        rmm_log_directory,
                     ),
                 },
-                name=name if nprocs == 1 or not name else name + "-" + str(i),
+                name=name if nprocs == 1 or not name else str(name) + "-" + str(i),
                 local_directory=local_directory,
                 config={
                     "ucx": get_ucx_config(

--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -178,7 +178,7 @@ class DeviceHostFile(ZictBase):
         if local_directory is None:
             local_directory = dask.config.get("temporary-directory") or os.getcwd()
 
-        if not os.path.exists(local_directory):
+        if local_directory and not os.path.exists(local_directory):
             os.makedirs(local_directory, exist_ok=True)
         local_directory = os.path.join(local_directory, "dask-worker-space")
 

--- a/rtd/conf.py
+++ b/rtd/conf.py
@@ -193,7 +193,10 @@ pages = [
 ]
 html_additional_pages = {page: "redirect.html" for page in pages}
 html_context = {
-    "redirects": {page: f"https://docs.rapids.ai/api/dask-cuda/nightly/{page}" for page in pages}}
+    "redirects": {
+        page: f"https://docs.rapids.ai/api/dask-cuda/nightly/{page}" for page in pages
+    }
+}
 
 
 def add_404(app, docname):


### PR DESCRIPTION
While working on GPU support in [dask-mpi](https://github.com/dask/dask-mpi) I ran into a few issues with `CUDAWorker`. This PR makes a few tweaks to ensure things are compatible.

1. A valid option for `local_directory` is an empty string representing the current directory. So added a check before trying to create the directory.

2. Integers are valid options for `name` so added an explicit cast to string when concatenating with GPU index.

3. In `dask-mpi` it uses `async with` for creating `Worker` and `Nanny` objects. This broke with `CUDAWorker` because `__aenter__` and `__aexit__` have not been implemented. Looking at distributed those methods are implemented in the base `Server` class, so I've updated `CUDAWorker` here to also use `Server` as a base. 

   I was surprised this wasn't the case already, but perhaps that was an intentional decision? If so it would be quick to implement the async context manager methods directly here instead.