### PR TITLE
get_device_memory_objects(): dispatch on cudf.core.frame.Frame

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -111,13 +111,18 @@ else
     gpuci_logger "Running dask.distributed GPU tests"
     # Test downstream packages, which requires Python v3.7
     if [ $(python -c "import sys; print(sys.version_info[1])") -ge "7" ]; then
-        gpuci_logger "TEST OF DASK/UCX"
-        py.test --cache-clear -vs `python -c "import distributed.protocol.tests.test_cupy as m;print(m.__file__)"`
-        py.test --cache-clear -vs `python -c "import distributed.protocol.tests.test_numba as m;print(m.__file__)"`
-        py.test --cache-clear -vs `python -c "import distributed.protocol.tests.test_rmm as m;print(m.__file__)"`
-        py.test --cache-clear -vs `python -c "import distributed.protocol.tests.test_collection_cuda as m;print(m.__file__)"`
-        py.test --cache-clear -vs `python -c "import distributed.tests.test_nanny as m;print(m.__file__)"`
-        py.test --cache-clear -vs `python -c "import distributed.diagnostics.tests.test_nvml as m;print(m.__file__)"`
+        # Clone Distributed to avoid pytest cleanup fixture errors
+        # See https://github.com/dask/distributed/issues/4902
+        gpuci_logger "Clone Distributed"
+        git clone https://github.com/dask/distributed
+
+        gpuci_logger "Run Distributed Tests"
+        py.test --cache-clear -vs distributed/distributed/protocol/tests/test_cupy.py
+        py.test --cache-clear -vs distributed/distributed/protocol/tests/test_numba.py
+        py.test --cache-clear -vs distributed/distributed/protocol/tests/test_rmm.py
+        py.test --cache-clear -vs distributed/distributed/protocol/tests/test_collection_cuda.py
+        py.test --cache-clear -vs distributed/distributed/tests/test_nanny.py
+        py.test --cache-clear -vs distributed/distributed/diagnostics/tests/test_nvml.py
     fi
 
     logger "Run local benchmark..."

--- a/dask_cuda/get_device_memory_objects.py
+++ b/dask_cuda/get_device_memory_objects.py
@@ -1,12 +1,10 @@
-from typing import Any, Set
-
 from dask.sizeof import sizeof
 from dask.utils import Dispatch
 
 dispatch = Dispatch(name="get_device_memory_objects")
 
 
-def get_device_memory_objects(obj: Any) -> Set:
+def get_device_memory_objects(obj) -> set:
     """ Find all CUDA device objects in `obj`
 
     Search through `obj` and find all CUDA device objects, which are objects
@@ -73,14 +71,13 @@ def get_device_memory_objects_register_cupy():
 
 @dispatch.register_lazy("cudf")
 def get_device_memory_objects_register_cudf():
-    import cudf.core.dataframe
+    import cudf.core.frame
     import cudf.core.index
     import cudf.core.multiindex
     import cudf.core.series
 
-    @dispatch.register(cudf.core.dataframe.DataFrame)
-    def get_device_memory_objects_cudf_dataframe(obj):
-
+    @dispatch.register(cudf.core.frame.Frame)
+    def get_device_memory_objects_cudf_frame(obj):
         ret = dispatch(obj._index)
         for col in obj._data.columns:
             ret += dispatch(col)


### PR DESCRIPTION
`get_device_memory_objects()` now dispatch on `cudf.core.frame.Frame` instead of `cudf.core.dataframe.DataFrame` only.

This includes the CI fix, closes https://github.com/rapidsai/dask-cuda/pull/659