### PR TITLE
Update parse_bytes imports to resolve deprecation warnings

### DIFF
--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -9,6 +9,7 @@ from toolz import valmap
 from tornado.ioloop import IOLoop
 
 import dask
+from dask.utils import parse_bytes
 from distributed import Nanny
 from distributed.core import Server
 from distributed.deploy.cluster import Cluster
@@ -16,7 +17,6 @@ from distributed.proctitle import (
     enable_proctitle_on_children,
     enable_proctitle_on_current,
 )
-from distributed.utils import parse_bytes
 from distributed.worker import parse_memory_limit
 
 from .device_host_file import DeviceHostFile

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -3,8 +3,8 @@ import os
 import warnings
 
 import dask
-from dask.distributed import LocalCluster, Nanny, Worker
-from distributed.utils import parse_bytes
+from dask.utils import parse_bytes
+from distributed import LocalCluster, Nanny, Worker
 from distributed.worker import parse_memory_limit
 
 from .device_host_file import DeviceHostFile

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -9,8 +9,8 @@ import numpy as np
 import pynvml
 import toolz
 
+from dask.utils import parse_bytes
 from distributed import Worker, wait
-from distributed.utils import parse_bytes
 
 try:
     from nvtx import annotate as nvtx_annotate


### PR DESCRIPTION
Resolves deprecation warnings such as the one below:

```python
FutureWarning: parse_bytes is deprecated and will be removed in a future release. Please use dask.utils.parse_bytes instead.
    from distributed.utils import parse_bytes
```