### PR TITLE
[REVIEW] Fix `assert_eq` related imports

### DIFF
--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -24,9 +24,7 @@ except ImportError:
     from dask.dataframe.methods import concat_pandas
 
 try:
-    from dask.dataframe.dispatch import (
-        make_meta_dispatch as make_meta_dispatch,
-    )
+    from dask.dataframe.dispatch import make_meta_dispatch as make_meta_dispatch
 except ImportError:
     from dask.dataframe.utils import make_meta as make_meta_dispatch
 

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -23,6 +23,13 @@ try:
 except ImportError:
     from dask.dataframe.methods import concat_pandas
 
+try:
+    from dask.dataframe.dispatch import (
+        make_meta_dispatch as make_meta_dispatch,
+    )
+except ImportError:
+    from dask.dataframe.utils import make_meta as make_meta_dispatch
+
 from .get_device_memory_objects import get_device_memory_objects
 from .is_device_object import is_device_object
 
@@ -732,7 +739,7 @@ def unproxify_input_wrapper(func):
 # Register dispatch of ProxyObject on all known dispatch objects
 for dispatch in (
     dask.dataframe.core.hash_object_dispatch,
-    dask.dataframe.utils.make_meta,
+    make_meta_dispatch,
     dask.dataframe.utils.make_scalar,
     dask.dataframe.core.group_split_dispatch,
     dask.array.core.tensordot_lookup,

--- a/dask_cuda/tests/test_explicit_comms.py
+++ b/dask_cuda/tests/test_explicit_comms.py
@@ -96,7 +96,7 @@ def check_partitions(df, npartitions):
 def _test_dataframe_shuffle(backend, protocol, n_workers):
     if backend == "cudf":
         cudf = pytest.importorskip("cudf")
-        from cudf.tests.utils import assert_eq
+        from cudf.testing._utils import assert_eq
 
         initialize(enable_tcp_over_ucx=True)
     else:
@@ -201,7 +201,7 @@ def test_dask_use_explicit_comms():
 def _test_dataframe_shuffle_merge(backend, protocol, n_workers):
     if backend == "cudf":
         cudf = pytest.importorskip("cudf")
-        from cudf.tests.utils import assert_eq
+        from cudf.testing._utils import assert_eq
 
         initialize(enable_tcp_over_ucx=True)
     else:
@@ -264,7 +264,7 @@ def test_dataframe_shuffle_merge(backend, protocol, nworkers):
 
 def _test_jit_unspill(protocol):
     import cudf
-    from cudf.tests.utils import assert_eq
+    from cudf.testing._utils import assert_eq
 
     with dask_cuda.LocalCUDACluster(
         protocol=protocol,


### PR DESCRIPTION
Recently there has been a change of location of where the testing utils of `cudf` reside. This PR is adapting to those changes.