### PR TITLE
Bump isort hook version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
-      - repo: https://github.com/timothycrosley/isort
-        rev: 5.0.7
+      - repo: https://github.com/pycqa/isort
+        rev: 5.6.4
         hooks:
               - id: isort
       - repo: https://github.com/ambv/black


### PR DESCRIPTION
Bumps the `isort` pre-commit hook to 5.6.4 to correspond with the version bump in gpuCI.