### PR TITLE
Add device memory limit argument to benchmarks

### DIFF
--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -35,6 +35,16 @@ def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]
         help="Write dask profile report (E.g. dask-report.html)",
     )
     parser.add_argument(
+        "--device-memory-limit",
+        default=None,
+        type=parse_bytes,
+        help="Size of the CUDA device LRU cache, which is used to determine when the "
+        "worker starts spilling to host memory. Can be an integer (bytes), float "
+        "(fraction of total device memory), string (like ``'5GB'`` or ``'5000M'``), or "
+        "``'auto'``, 0, or ``None`` to disable spilling to host (i.e. allow full "
+        "device memory usage).",
+    )
+    parser.add_argument(
         "--rmm-pool-size",
         default=None,
         type=parse_bytes,
@@ -211,6 +221,7 @@ def get_cluster_options(args):
             "scheduler_options": {"protocol": args.protocol},
             "worker_module": "dask_cuda.dask_cuda_worker",
             "worker_options": worker_options,
+            "device_memory_limit": args.device_memory_limit,
             # "n_workers": len(args.devs.split(",")),
             # "CUDA_VISIBLE_DEVICES": args.devs,
         }
@@ -229,6 +240,7 @@ def get_cluster_options(args):
             "enable_nvlink": args.enable_nvlink,
             "enable_rdmacm": args.enable_rdmacm,
             "interface": args.interface,
+            "device_memory_limit": args.device_memory_limit,
         }
         if args.no_silence_logs:
             cluster_kwargs["silence_logs"] = False

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -212,6 +212,8 @@ def get_cluster_options(args):
             worker_options["enable_infiniband"] = ""
         if args.enable_rdmacm:
             worker_options["enable_rdmacm"] = ""
+        if args.device_memory_limit:
+            worker_options["device_memory_limit"] = ""
 
         if args.ucx_net_devices:
             worker_options["ucx_net_devices"] = args.ucx_net_devices
@@ -221,7 +223,6 @@ def get_cluster_options(args):
             "scheduler_options": {"protocol": args.protocol},
             "worker_module": "dask_cuda.dask_cuda_worker",
             "worker_options": worker_options,
-            "device_memory_limit": args.device_memory_limit,
             # "n_workers": len(args.devs.split(",")),
             # "CUDA_VISIBLE_DEVICES": args.devs,
         }

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -212,9 +212,9 @@ def get_cluster_options(args):
             worker_options["enable_infiniband"] = ""
         if args.enable_rdmacm:
             worker_options["enable_rdmacm"] = ""
-        if args.device_memory_limit:
-            worker_options["device_memory_limit"] = ""
 
+        if args.device_memory_limit:
+            worker_options["device_memory_limit"] = args.device_memory_limit
         if args.ucx_net_devices:
             worker_options["ucx_net_devices"] = args.ucx_net_devices
 


### PR DESCRIPTION
Adds a `--device-memory-limit` argument to the benchmark utils, to set a device memory limit on the instantiated `LocalCUDACluster`. This can be helpful when we want to force spilling to host (for context, I am doing this while benchmarking pack/unpack serialization).