### PR TITLE
[gpuCI] Forward-merge branch-21.08 to branch-21.10 [skip ci]

### DIFF
--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -27,8 +27,8 @@ requirements:
     - setuptools
   run:
     - python
-    - dask >=2.22.0
-    - distributed >=2.22.0
+    - dask >=2.22.0,<=2021.07.1
+    - distributed >=2.22.0,<=2021.07.1
     - pynvml >=8.0.3
     - numpy >=1.16.0
     - numba >=0.53.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-dask>=2.22.0
-distributed>=2.22.0
+dask>=2.22.0,<=2021.07.1
+distributed>=2.22.0,<=2021.07.1
 pynvml>=8.0.3
 numpy>=1.16.0
 numba>=0.53.1


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.08` that creates a PR to keep `branch-21.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.