### PR TITLE
Set shuffle config default to "tasks"

### DIFF
--- a/dask_cuda/initialize.py
+++ b/dask_cuda/initialize.py
@@ -94,6 +94,13 @@ def initialize(
     )
     dask.config.set({"distributed.comm.ucx": ucx_config})
 
+    # partd is used by default for disk-based shuffling, but unsupported by
+    # cuDF/Dask-cuDF. Therefore, we set task-based shuffling instead.
+    try:
+        dask.config.get("shuffle")
+    except KeyError:
+        dask.config.set({"shuffle": "tasks"})
+
 
 @click.command()
 @click.option(

--- a/dask_cuda/initialize.py
+++ b/dask_cuda/initialize.py
@@ -96,10 +96,7 @@ def initialize(
 
     # partd is used by default for disk-based shuffling, but unsupported by
     # cuDF/Dask-cuDF. Therefore, we set task-based shuffling instead.
-    try:
-        dask.config.get("shuffle")
-    except KeyError:
-        dask.config.set({"shuffle": "tasks"})
+    dask.config.update_defaults({"shuffle": "tasks"})
 
 
 @click.command()


### PR DESCRIPTION
By default Dask uses partd ("disk") for shuffling, which is unsupported by cuDF/Dask-cuDF. To avoid forcing users to set it on their own, this changes the default to "tasks", unless the explicitly set by the user.