### PR TITLE
Leave interface unset when ucx_net_devices unset in LocalCUDACluster

### DIFF
--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -309,7 +309,7 @@ class LocalCUDACluster(LocalCluster):
         elif ucx_net_devices == "":
             raise ValueError("ucx_net_devices can not be an empty string")
         self.ucx_net_devices = ucx_net_devices
-        self.set_ucx_net_devices = enable_infiniband
+        self.set_ucx_net_devices = enable_infiniband and ucx_net_devices is not None
         self.host = kwargs.get("host", None)
 
         initialize(


### PR DESCRIPTION
Setting `interface` when `ucx_net_devices=None` causes failures with RDMACM, as the `interface` defined by the user to handle connections is overwritten.