### PR TITLE
Fix deadlock and simplify proxy tracking

### DIFF
--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -175,14 +175,12 @@ class DeviceHostFile(ZictBase):
         local_directory=None,
         log_spilling=False,
     ):
-        if local_directory is None:
-            local_directory = dask.config.get("temporary-directory") or os.getcwd()
-
-        if local_directory and not os.path.exists(local_directory):
-            os.makedirs(local_directory, exist_ok=True)
-        local_directory = os.path.join(local_directory, "dask-worker-space")
-
-        self.disk_func_path = os.path.join(local_directory, "storage")
+        self.disk_func_path = os.path.join(
+            local_directory or dask.config.get("temporary-directory") or os.getcwd(),
+            "dask-worker-space",
+            "storage",
+        )
+        os.makedirs(self.disk_func_path, exist_ok=True)
 
         self.host_func = dict()
         self.disk_func = Func(

--- a/dask_cuda/explicit_comms/dataframe/shuffle.py
+++ b/dask_cuda/explicit_comms/dataframe/shuffle.py
@@ -148,9 +148,7 @@ async def local_shuffle(
     eps = s["eps"]
 
     try:
-        manager = first(iter(in_parts[0].values()))._obj_pxy.get(
-            "manager", lambda: None
-        )()
+        manager = first(iter(in_parts[0].values()))._obj_pxy.get("manager", None)
     except AttributeError:
         manager = None
 

--- a/dask_cuda/explicit_comms/dataframe/shuffle.py
+++ b/dask_cuda/explicit_comms/dataframe/shuffle.py
@@ -18,7 +18,7 @@ from dask.delayed import delayed
 from distributed import wait
 from distributed.protocol import nested_deserialize, to_serialize
 
-from ...proxify_host_file import ProxifyHostFile
+from ...proxify_host_file import ProxyManager
 from .. import comms
 
 
@@ -148,19 +148,19 @@ async def local_shuffle(
     eps = s["eps"]
 
     try:
-        hostfile = first(iter(in_parts[0].values()))._obj_pxy.get(
-            "hostfile", lambda: None
+        manager = first(iter(in_parts[0].values()))._obj_pxy.get(
+            "manager", lambda: None
         )()
     except AttributeError:
-        hostfile = None
+        manager = None
 
-    if isinstance(hostfile, ProxifyHostFile):
+    if isinstance(manager, ProxyManager):
 
         def concat(args, ignore_index=False):
             if len(args) < 2:
                 return args[0]
 
-            return hostfile.add_external(dd_concat(args, ignore_index=ignore_index))
+            return manager.proxify(dd_concat(args, ignore_index=ignore_index))
 
     else:
         concat = dd_concat

--- a/dask_cuda/get_device_memory_objects.py
+++ b/dask_cuda/get_device_memory_objects.py
@@ -28,7 +28,7 @@ def get_device_memory_objects(obj) -> set:
 @dispatch.register(object)
 def get_device_memory_objects_default(obj):
     if hasattr(obj, "_obj_pxy"):
-        if obj._obj_pxy["serializers"] is None:
+        if not obj._obj_pxy_is_serialized():
             return dispatch(obj._obj_pxy["obj"])
         else:
             return []

--- a/dask_cuda/get_device_memory_objects.py
+++ b/dask_cuda/get_device_memory_objects.py
@@ -28,10 +28,7 @@ def get_device_memory_objects(obj) -> set:
 @dispatch.register(object)
 def get_device_memory_objects_default(obj):
     if hasattr(obj, "_obj_pxy"):
-        if not obj._obj_pxy_is_serialized():
-            return dispatch(obj._obj_pxy["obj"])
-        else:
-            return []
+        return dispatch(obj._obj_pxy["obj"])
     if hasattr(obj, "data"):
         return dispatch(obj.data)
     if hasattr(obj, "_owner") and obj._owner is not None:

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -273,9 +273,7 @@ class LocalCUDACluster(LocalCluster):
                     {
                         "device_memory_limit": self.device_memory_limit,
                         "memory_limit": self.host_memory_limit,
-                        "local_directory": local_directory
-                        or dask.config.get("temporary-directory")
-                        or os.getcwd(),
+                        "local_directory": local_directory,
                         "log_spilling": log_spilling,
                     },
                 )

--- a/dask_cuda/proxify_device_objects.py
+++ b/dask_cuda/proxify_device_objects.py
@@ -192,7 +192,7 @@ def proxify_device_object_proxy_object(
 ):
     # We deserialize CUDA-serialized objects since it is very cheap and
     # makes it easy to administrate device memory usage
-    if obj._obj_pxy_is_serialized() and "cuda" in obj._obj_pxy["serializers"]:
+    if obj._obj_pxy_is_serialized() and obj._obj_pxy["serializer"] != "cuda":
         obj._obj_pxy_deserialize()
 
     # Check if `obj` is already known

--- a/dask_cuda/proxify_device_objects.py
+++ b/dask_cuda/proxify_device_objects.py
@@ -190,25 +190,12 @@ def proxify_device_object_default(
 def proxify_device_object_proxy_object(
     obj, proxied_id_to_proxy, found_proxies, excl_proxies
 ):
-    # We deserialize CUDA-serialized objects since it is very cheap and
-    # makes it easy to administrate device memory usage
-    if obj._obj_pxy_is_serialized() and obj._obj_pxy["serializer"] != "cuda":
-        obj._obj_pxy_deserialize()
-
     # Check if `obj` is already known
     if not obj._obj_pxy_is_serialized():
         _id = id(obj._obj_pxy["obj"])
         if _id in proxied_id_to_proxy:
             obj = proxied_id_to_proxy[_id]
         else:
-            proxied_id_to_proxy[_id] = obj
-
-    finalize = obj._obj_pxy.get("external_finalize", None)
-    if finalize:
-        finalize()
-        obj = obj._obj_pxy_copy()
-        if not obj._obj_pxy_is_serialized():
-            _id = id(obj._obj_pxy["obj"])
             proxied_id_to_proxy[_id] = obj
 
     if not excl_proxies:

--- a/dask_cuda/proxify_device_objects.py
+++ b/dask_cuda/proxify_device_objects.py
@@ -165,14 +165,10 @@ def unproxify_decorator(func):
 
 def proxify(obj, proxied_id_to_proxy, found_proxies, subclass=None):
     _id = id(obj)
-    if _id in proxied_id_to_proxy:
-        ret = proxied_id_to_proxy[_id]
-        finalize = ret._obj_pxy.get("external_finalize", None)
-        if finalize:
-            finalize()
-            proxied_id_to_proxy[_id] = ret = asproxy(obj, subclass=subclass)
-    else:
+    if _id not in proxied_id_to_proxy:
         proxied_id_to_proxy[_id] = ret = asproxy(obj, subclass=subclass)
+    else:
+        ret = proxied_id_to_proxy[_id]
     found_proxies.append(ret)
     return ret
 

--- a/dask_cuda/proxify_device_objects.py
+++ b/dask_cuda/proxify_device_objects.py
@@ -166,9 +166,8 @@ def unproxify_decorator(func):
 def proxify(obj, proxied_id_to_proxy, found_proxies, subclass=None):
     _id = id(obj)
     if _id not in proxied_id_to_proxy:
-        proxied_id_to_proxy[_id] = ret = asproxy(obj, subclass=subclass)
-    else:
-        ret = proxied_id_to_proxy[_id]
+        proxied_id_to_proxy[_id] = asproxy(obj, subclass=subclass)
+    ret = proxied_id_to_proxy[_id]
     found_proxies.append(ret)
     return ret
 

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -218,8 +218,9 @@ class ProxyManager:
             for p in found_proxies:
                 p._obj_pxy["last_access"] = last_access
                 if not self.contains(id(p)):
-                    p._obj_pxy_register_manager(self)
-                    p._obj_pxy["finalizer"] = weakref.finalize(p, self.remove, id(p))
+                    p._obj_pxy_register_manager(
+                        self, weakref.finalize(p, self.remove, id(p))
+                    )
                     self.add(p)
             self.maybe_evict()
             return ret

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -44,7 +44,7 @@ class Proxies(abc.ABC):
         """Given a new proxy, update `self._mem_usage`"""
 
     @abc.abstractmethod
-    def mem_usage_sub(self, proxy: ProxyObject) -> None:
+    def mem_usage_remove(self, proxy: ProxyObject) -> None:
         """Removal of proxy, update `self._mem_usage`"""
 
     def add(self, proxy: ProxyObject) -> None:
@@ -54,9 +54,9 @@ class Proxies(abc.ABC):
         self.mem_usage_add(proxy)
 
     def remove(self, proxy: ProxyObject) -> None:
-        """Remove proxy from tracking, calls `self.mem_usage_sub`"""
+        """Remove proxy from tracking, calls `self.mem_usage_remove`"""
         del self._proxy_id_to_proxy[id(proxy)]
-        self.mem_usage_sub(proxy)
+        self.mem_usage_remove(proxy)
         if len(self._proxy_id_to_proxy) == 0:
             if self._mem_usage != 0:
                 warnings.warn(
@@ -88,7 +88,7 @@ class ProxiesOnHost(Proxies):
     def mem_usage_add(self, proxy: ProxyObject):
         self._mem_usage += sizeof(proxy)
 
-    def mem_usage_sub(self, proxy: ProxyObject):
+    def mem_usage_remove(self, proxy: ProxyObject):
         self._mem_usage -= sizeof(proxy)
 
 
@@ -117,7 +117,7 @@ class ProxiesOnDevice(Proxies):
                 self._mem_usage += sizeof(dev_mem)
             ps.add(proxy_id)
 
-    def mem_usage_sub(self, proxy: ProxyObject):
+    def mem_usage_remove(self, proxy: ProxyObject):
         proxy_id = id(proxy)
         for dev_mem in self.proxy_id_to_dev_mems.pop(proxy_id):
             self.dev_mem_to_proxy_ids[dev_mem].remove(proxy_id)

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -73,13 +73,13 @@ class ProxiesOnHost(Proxies):
         self._mem_usage += sizeof(proxy)
 
     def mem_usage_sub(self, proxy: ProxyObject):
-        self._mem_usage = sizeof(proxy)
+        self._mem_usage -= sizeof(proxy)
 
 
 class ProxiesOnDevice(Proxies):
     """Implement tracking of proxies on the GPU
 
-    This is a bit more complicated than ProxiesOnHost because we has to
+    This is a bit more complicated than ProxiesOnHost because we have to
     handle that multiple proxy objects can refer to the same underlying
     device memory object. Thus, we have to track aliasing and make sure
     we don't count down the memory usage prematurely.

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -133,7 +133,7 @@ class ProxyManager:
     memory usage. It turns out having to re-calculate memory usage continuously
     is too expensive.
 
-    The idea is to have the ProxifyHostFile or the proxies themself update
+    The idea is to have the ProxifyHostFile or the proxies themselves update
     their location (device or host). The manager then tallies the total memory usage.
 
     Notice, the manager only keeps weak references to the proxies.

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -97,12 +97,13 @@ class ProxiesOnDevice(Proxies):
 
     def __init__(self):
         super().__init__()
-        self.proxy_id_to_dev_mems: DefaultDict[int, Set[Hashable]] = defaultdict(set)
+        self.proxy_id_to_dev_mems: Dict[int, Set[Hashable]] = {}
         self.dev_mem_to_proxy_ids: DefaultDict[Hashable, Set[int]] = defaultdict(set)
 
     def mem_usage_add(self, proxy: ProxyObject):
         proxy_id = id(proxy)
         assert proxy_id not in self.proxy_id_to_dev_mems
+        self.proxy_id_to_dev_mems[proxy_id] = set()
         for dev_mem in proxy._obj_pxy_get_device_memory_objects():
             self.proxy_id_to_dev_mems[proxy_id].add(dev_mem)
             ps = self.dev_mem_to_proxy_ids[dev_mem]
@@ -112,7 +113,6 @@ class ProxiesOnDevice(Proxies):
 
     def mem_usage_sub(self, proxy: ProxyObject):
         proxy_id = id(proxy)
-        assert proxy_id in self.proxy_id_to_dev_mems
         for dev_mem in self.proxy_id_to_dev_mems.pop(proxy_id):
             self.dev_mem_to_proxy_ids[dev_mem].remove(proxy_id)
             if len(self.dev_mem_to_proxy_ids[dev_mem]) == 0:

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -4,6 +4,7 @@ import time
 import weakref
 from collections import defaultdict
 from typing import (
+    Any,
     DefaultDict,
     Dict,
     Hashable,
@@ -155,7 +156,7 @@ class ProxifyHostFile(MutableMapping):
 
     def __init__(self, device_memory_limit: int, compatibility_mode: bool = None):
         self.device_memory_limit = device_memory_limit
-        self.store = {}
+        self.store: Dict[Hashable, Any] = {}
         self.lock = threading.RLock()
         self.proxies_tally = ProxiesTally()
         if compatibility_mode is None:

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -184,7 +184,7 @@ class ProxyManager:
     def remove(self, proxy_id: int) -> None:
         with self.lock:
             # Find where the proxy is located and remove it
-            proxies = None
+            proxies: Optional[Proxies] = None
             if self._host.contains_proxy_id(proxy_id):
                 proxies = self._host
             if self._dev.contains_proxy_id(proxy_id):
@@ -215,11 +215,10 @@ class ProxyManager:
             proxied_id_to_proxy: Dict[int, ProxyObject] = {}
             ret = proxify_device_objects(obj, proxied_id_to_proxy, found_proxies)
             last_access = time.monotonic()
-            self_weakref = weakref.ref(self)
             for p in found_proxies:
                 p._obj_pxy["last_access"] = last_access
                 if not self.contains(id(p)):
-                    p._obj_pxy["manager"] = self_weakref
+                    p._obj_pxy_register_manager(self)
                     p._obj_pxy["finalizer"] = weakref.finalize(p, self.remove, id(p))
                     self.add(p)
             self.maybe_evict()

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -2,6 +2,7 @@ import abc
 import logging
 import threading
 import time
+import warnings
 import weakref
 from collections import defaultdict
 from typing import (
@@ -58,7 +59,13 @@ class Proxies(abc.ABC):
         assert proxy is not None
         self.mem_usage_sub(proxy)
         if len(self._proxy_id_to_proxy) == 0:
-            assert self._mem_usage == 0, self._mem_usage
+            if self._mem_usage != 0:
+                warnings.warn(
+                    "ProxyManager is empty but the tally of "
+                    f"{self} is {self._mem_usage} bytes. "
+                    "Resetting the tally."
+                )
+                self._mem_usage = 0
 
     def __iter__(self) -> Iterator[ProxyObject]:
         for p in self._proxy_id_to_proxy.values():

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -333,7 +333,7 @@ class ProxyObject:
                 # to evict because of the increased device memory usage.
                 if manager and maybe_evict and serializer != "cuda":
                     # In order to avoid a potential deadlock, we skip the
-                    # `maybe_evict()` call if another thread is also accessing
+                    # evict call if another thread is also accessing
                     # the hostfile.
                     if manager.lock.acquire(blocking=False):
                         try:

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -5,7 +5,7 @@ import pickle
 import threading
 import time
 from collections import OrderedDict
-from typing import Any, Dict, Iterable, List, Optional, Set, Type
+from typing import Any, Dict, Iterable, Optional, Set, Type
 
 import pandas
 
@@ -55,9 +55,10 @@ def asproxy(
     -------
     The ProxyObject proxying `obj`
     """
-
     if hasattr(obj, "_obj_pxy"):  # Already a proxy object
         ret = obj
+    elif isinstance(obj, (list, set, tuple, dict)):
+        raise ValueError(f"Cannot wrap a collection ({type(obj)}) in a proxy object")
     else:
         fixed_attr = {}
         for attr in _FIXED_ATTRS:

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -450,7 +450,7 @@ class ProxyObject:
             return ret
 
     @property  # type: ignore  # mypy doesn't support decorated property
-    @_obj_pxy_cache_wrapper("type_serialized")  #
+    @_obj_pxy_cache_wrapper("type_serialized")
     def __class__(self):
         return pickle.loads(self._obj_pxy["type_serialized"])
 

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -221,10 +221,8 @@ class ProxyObject:
         self._obj_pxy_cache: Dict[str, Any] = {}
 
     def __del__(self):
-        """In order to call `external_finalize()` ASAP, we call it here"""
-        external_finalize = self._obj_pxy.get("external_finalize", None)
-        if external_finalize is not None:
-            external_finalize()
+        """In order to call `finalizer()` ASAP, we call it here"""
+        self._obj_pxy.get("finalizer", lambda: None)()
 
     def _obj_pxy_get_init_args(self, include_obj=True):
         """Return the attributes needed to initialize a ProxyObject

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -374,9 +374,6 @@ class ProxyObject:
     def _obj_pxy_get_device_memory_objects(self) -> Set:
         """Return all device memory objects within the proxied object.
 
-        Calling this when the proxied object is serialized returns the
-        empty list.
-
         Returns
         -------
         ret : set

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -303,7 +303,7 @@ class ProxyObject:
                 org_ser, new_ser = self._obj_pxy["serializer"], header["serializer"]
                 self._obj_pxy["serializer"] = new_ser
 
-                # Tell the manager (if any) that this proxy has change serializer
+                # Tell the manager (if any) that this proxy has changed serializer
                 if manager:
                     manager.move(self, from_serializer=org_ser, to_serializer=new_ser)
 
@@ -317,7 +317,7 @@ class ProxyObject:
         Parameters
         ----------
         maybe_evict: bool
-            Before deserializing, call associated hostfile.maybe_evict()
+            Before deserializing, maybe evict managered proxy objects
 
         Returns
         -------
@@ -365,8 +365,7 @@ class ProxyObject:
         ret : boolean
             Is the proxied object a CUDA object?
         """
-        with self._obj_pxy_lock:
-            return self._obj_pxy["is_cuda_object"]
+        return self._obj_pxy["is_cuda_object"]
 
     @_obj_pxy_cache_wrapper("device_memory_objects")
     def _obj_pxy_get_device_memory_objects(self) -> Set:

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -112,7 +112,7 @@ def unproxy(obj):
     return obj
 
 
-def _obj_pxy_cache_wrapper(attr_name):
+def _obj_pxy_cache_wrapper(attr_name: str):
     """Caching the access of attr_name in ProxyObject._obj_pxy_cache"""
 
     def wrapper1(func):
@@ -213,7 +213,7 @@ class ProxyObject:
             "explicit_proxy": explicit_proxy,
         }
         self._obj_pxy_lock = threading.RLock()
-        self._obj_pxy_cache = {}
+        self._obj_pxy_cache: Dict[str, Any] = {}
 
     def __del__(self):
         """In order to call `external_finalize()` ASAP, we call it here"""
@@ -420,8 +420,8 @@ class ProxyObject:
                 ret += f" at {hex(id(self._obj_pxy['obj']))}>"
             return ret
 
-    @property
-    @_obj_pxy_cache_wrapper("type_serialized")
+    @property  # type: ignore  # mypy doesn't support decorated property
+    @_obj_pxy_cache_wrapper("type_serialized")  #
     def __class__(self):
         return pickle.loads(self._obj_pxy["type_serialized"])
 
@@ -513,8 +513,8 @@ class ProxyObject:
     def __divmod__(self, other):
         return divmod(self._obj_pxy_deserialize(), other)
 
-    def __pow__(self, other, *args):
-        return pow(self._obj_pxy_deserialize(), other, *args)
+    def __pow__(self, other):
+        return pow(self._obj_pxy_deserialize(), other)
 
     def __lshift__(self, other):
         return self._obj_pxy_deserialize() << other

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -284,7 +284,7 @@ class ProxyObject:
         serializers = tuple(serializers)
 
         with self._obj_pxy_lock:
-            if self._obj_pxy["serializers"] is not None:
+            if self._obj_pxy_is_serialized():
                 if self._obj_pxy["serializers"] == serializers:
                     return self._obj_pxy["obj"]  # Nothing to be done
                 else:
@@ -318,7 +318,7 @@ class ProxyObject:
             The proxied object (deserialized)
         """
         with self._obj_pxy_lock:
-            if self._obj_pxy["serializers"] is not None:
+            if self._obj_pxy_is_serialized():
                 hostfile = self._obj_pxy.get("hostfile", lambda: None)()
                 # When not deserializing a CUDA-serialized proxied, we might have
                 # to evict because of the increased device memory usage.
@@ -413,7 +413,7 @@ class ProxyObject:
         with self._obj_pxy_lock:
             typename = self._obj_pxy["typename"]
             ret = f"<{dask.utils.typename(type(self))} at {hex(id(self))} of {typename}"
-            if self._obj_pxy["serializers"] is not None:
+            if self._obj_pxy_is_serialized():
                 ret += f" (serialized={repr(self._obj_pxy['serializers'])})>"
             else:
                 ret += f" at {hex(id(self._obj_pxy['obj']))}>"
@@ -684,7 +684,7 @@ def obj_pxy_cuda_serialize(obj: ProxyObject):
     or another CUDA friendly communication library. As serializers, it uses "cuda",
     which means that proxied CUDA objects are _not_ spilled to main memory.
     """
-    if obj._obj_pxy["serializers"] is not None:  # Already serialized
+    if obj._obj_pxy_is_serialized():  # Already serialized
         header, frames = obj._obj_pxy["obj"]
     else:
         # Notice, since obj._obj_pxy_serialize() is a inplace operation, we make a

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -291,15 +291,14 @@ class ProxyObject:
                     # The proxied object is serialized with other serializers
                     self._obj_pxy_deserialize()
 
-            if self._obj_pxy["serializers"] is None:
-                self._obj_pxy["obj"] = distributed.protocol.serialize(
-                    self._obj_pxy["obj"], serializers, on_error="raise"
-                )
-                self._obj_pxy["serializers"] = serializers
-                hostfile = self._obj_pxy.get("hostfile", lambda: None)()
-                if hostfile is not None:
-                    external = self._obj_pxy.get("external", self)
-                    hostfile.proxies_tally.spill_proxy(external)
+            self._obj_pxy["obj"] = distributed.protocol.serialize(
+                self._obj_pxy["obj"], serializers, on_error="raise"
+            )
+            self._obj_pxy["serializers"] = serializers
+            hostfile = self._obj_pxy.get("hostfile", lambda: None)()
+            if hostfile is not None:
+                external = self._obj_pxy.get("external", self)
+                hostfile.proxies_tally.spill_proxy(external)
 
             # Invalidate the (possible) cached "device_memory_objects"
             self._obj_pxy_cache.pop("device_memory_objects", None)

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -5,7 +5,7 @@ import pickle
 import threading
 import time
 from collections import OrderedDict
-from typing import Any, Dict, Iterable, List, Optional, Set
+from typing import Any, Dict, Iterable, List, Optional, Set, Type
 
 import pandas
 
@@ -36,16 +36,17 @@ from .is_device_object import is_device_object
 _FIXED_ATTRS = ["name", "__len__"]
 
 
-def asproxy(obj, serializers=None, subclass=None) -> "ProxyObject":
+def asproxy(
+    obj: object, serializers: Iterable[str] = None, subclass: Type["ProxyObject"] = None
+) -> "ProxyObject":
     """Wrap `obj` in a ProxyObject object if it isn't already.
 
     Parameters
     ----------
     obj: object
         Object to wrap in a ProxyObject object.
-    serializers: list(str), optional
-        List of serializers to use to serialize `obj`. If None,
-        no serialization is done.
+    serializers: Iterable[str], optional
+        Serializers to use to serialize `obj`. If None, no serialization is done.
     subclass: class, optional
         Specify a subclass of ProxyObject to create instead of ProxyObject.
         `subclass` must be pickable.
@@ -183,9 +184,8 @@ class ProxyObject:
     subclass: bytes
         Pickled type to use instead of ProxyObject when deserializing. The type
         must inherit from ProxyObject.
-    serializers: list(str), optional
-        List of serializers to use to serialize `obj`. If None, `obj`
-        isn't serialized.
+    serializers: Iterable[str], optional
+        Serializers to use to serialize `obj`. If None, no serialization is done.
     explicit_proxy: bool
         Mark the proxy object as "explicit", which means that the user allows it
         as input argument to dask tasks even in compatibility-mode.
@@ -199,7 +199,7 @@ class ProxyObject:
         typename: str,
         is_cuda_object: bool,
         subclass: bytes,
-        serializers: Optional[List[str]],
+        serializers: Optional[Iterable[str]],
         explicit_proxy: bool,
     ):
         self._obj_pxy = {

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -5,7 +5,7 @@ import pickle
 import threading
 import time
 from collections import OrderedDict
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, Iterable, List, Optional, Set
 
 import pandas
 
@@ -264,12 +264,12 @@ class ProxyObject:
         """Return whether the proxied object is serialized or not"""
         return self._obj_pxy["serializers"] is not None
 
-    def _obj_pxy_serialize(self, serializers):
+    def _obj_pxy_serialize(self, serializers: Iterable[str]):
         """Inplace serialization of the proxied object using the `serializers`
 
         Parameters
         ----------
-        serializers: tuple[str]
+        serializers: Iterable[str]
             Tuple of serializers to use to serialize the proxied object.
 
         Returns
@@ -281,9 +281,7 @@ class ProxyObject:
         """
         if not serializers:
             raise ValueError("Please specify a list of serializers")
-
-        if type(serializers) is not tuple:
-            serializers = tuple(serializers)
+        serializers = tuple(serializers)
 
         with self._obj_pxy_lock:
             if self._obj_pxy["serializers"] is not None:

--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -195,23 +195,27 @@ def test_externals():
     assert not k2._obj_pxy_is_serialized()
     assert is_proxies_equal(dhf.manager._host, [k1])
     assert is_proxies_equal(dhf.manager._dev, [k2])
+    assert dhf.manager._dev._mem_usage == one_item_nbytes
 
     k1[0]  # Trigger spilling of `k2`
     assert not k1._obj_pxy_is_serialized()
     assert k2._obj_pxy_is_serialized()
     assert is_proxies_equal(dhf.manager._host, [k2])
     assert is_proxies_equal(dhf.manager._dev, [k1])
+    assert dhf.manager._dev._mem_usage == one_item_nbytes
 
     k2[0]  # Trigger spilling of `k1`
     assert k1._obj_pxy_is_serialized()
     assert not k2._obj_pxy_is_serialized()
     assert is_proxies_equal(dhf.manager._host, [k1])
     assert is_proxies_equal(dhf.manager._dev, [k2])
+    assert dhf.manager._dev._mem_usage == one_item_nbytes
 
     # Removing `k2` also removes it from the tally
     del k2
     assert is_proxies_equal(dhf.manager._host, [k1])
     assert is_proxies_equal(dhf.manager._dev, [])
+    assert dhf.manager._dev._mem_usage == 0
 
 
 def test_proxify_device_objects_of_cupy_array():

--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -1,3 +1,5 @@
+from typing import Iterable
+
 import numpy as np
 import pandas
 import pytest
@@ -12,9 +14,9 @@ from distributed.worker import get_worker
 
 import dask_cuda
 import dask_cuda.proxify_device_objects
-import dask_cuda.proxy_object
 from dask_cuda.get_device_memory_objects import get_device_memory_objects
 from dask_cuda.proxify_host_file import ProxifyHostFile
+from dask_cuda.proxy_object import ProxyObject
 
 cupy = pytest.importorskip("cupy")
 cupy.cuda.set_allocator(None)
@@ -27,53 +29,80 @@ dask_cuda.proxify_device_objects.dispatch.dispatch(cupy.ndarray)
 dask_cuda.proxify_device_objects.ignore_types = ()
 
 
+def is_proxies_equal(p1: Iterable[ProxyObject], p2: Iterable[ProxyObject]):
+    """Check that two collections of proxies contains the same proxies (unordered)
+
+    In order to avoid deserializing proxy objects when comparing them,
+    this funcntion compares object IDs.
+    """
+
+    ids1 = sorted([id(p) for p in p1])
+    ids2 = sorted([id(p) for p in p2])
+    return ids1 == ids2
+
+
 def test_one_item_limit():
     dhf = ProxifyHostFile(device_memory_limit=one_item_nbytes)
-    dhf["k1"] = one_item_array() + 42
-    dhf["k2"] = one_item_array()
+
+    a1 = one_item_array() + 42
+    a2 = one_item_array()
+    dhf["k1"] = a1
+    dhf["k2"] = a2
 
     # Check k1 is spilled because of the newer k2
     k1 = dhf["k1"]
     k2 = dhf["k2"]
     assert k1._obj_pxy_is_serialized()
     assert not k2._obj_pxy_is_serialized()
+    assert is_proxies_equal(dhf.manager._host, [k1])
+    assert is_proxies_equal(dhf.manager._dev, [k2])
 
     # Accessing k1 spills k2 and unspill k1
     k1_val = k1[0]
     assert k1_val == 42
     assert k2._obj_pxy_is_serialized()
+    assert is_proxies_equal(dhf.manager._host, [k2])
+    assert is_proxies_equal(dhf.manager._dev, [k1])
 
     # Duplicate arrays changes nothing
     dhf["k3"] = [k1, k2]
     assert not k1._obj_pxy_is_serialized()
     assert k2._obj_pxy_is_serialized()
+    assert is_proxies_equal(dhf.manager._host, [k2])
+    assert is_proxies_equal(dhf.manager._dev, [k1])
 
     # Adding a new array spills k1 and k2
     dhf["k4"] = one_item_array()
+    k4 = dhf["k4"]
     assert k1._obj_pxy_is_serialized()
     assert k2._obj_pxy_is_serialized()
     assert not dhf["k4"]._obj_pxy_is_serialized()
+    assert is_proxies_equal(dhf.manager._host, [k1, k2])
+    assert is_proxies_equal(dhf.manager._dev, [k4])
 
     # Accessing k2 spills k1 and k4
     k2[0]
     assert k1._obj_pxy_is_serialized()
     assert dhf["k4"]._obj_pxy_is_serialized()
     assert not k2._obj_pxy_is_serialized()
+    assert is_proxies_equal(dhf.manager._host, [k1, k4])
+    assert is_proxies_equal(dhf.manager._dev, [k2])
 
     # Deleting k2 does not change anything since k3 still holds a
     # reference to the underlying proxy object
-    assert dhf.proxies_tally.get_dev_mem_usage() == one_item_nbytes
-    p1 = list(dhf.proxies_tally.get_unspilled_proxies())
-    assert len(p1) == 1
+    assert dhf.manager.get_dev_access_info()[0] == one_item_nbytes
+    assert is_proxies_equal(dhf.manager._host, [k1, k4])
+    assert is_proxies_equal(dhf.manager._dev, [k2])
     del dhf["k2"]
-    assert dhf.proxies_tally.get_dev_mem_usage() == one_item_nbytes
-    p2 = list(dhf.proxies_tally.get_unspilled_proxies())
-    assert len(p2) == 1
-    assert p1[0] is p2[0]
+    assert is_proxies_equal(dhf.manager._host, [k1, k4])
+    assert is_proxies_equal(dhf.manager._dev, [k2])
 
-    # Overwriting "k3" with a non-cuda object, should be noticed
+    # Overwriting "k3" with a non-cuda object and deleting `k2`
+    # should empty the device
     dhf["k3"] = "non-cuda-object"
-    assert dhf.proxies_tally.get_dev_mem_usage() == 0
+    del k2
+    assert is_proxies_equal(dhf.manager._host, [k1, k4])
+    assert is_proxies_equal(dhf.manager._dev, [])
 
 
 @pytest.mark.parametrize("jit_unspill", [True, False])
@@ -144,59 +173,45 @@ def test_cudf_get_device_memory_objects():
 
 
 def test_externals():
+    """Test adding objects directly to the manager
+
+    Add an object directly to the manager makes it count against the
+    device_memory_limit but isn't part of the store.
+
+    Normally, we use __setitem__ to store objects in the hostfile and make it
+    count against the device_memory_limit with the inherent consequence that
+    the objects are not freeable before subsequential calls to __delitem__.
+    This is a problem for long running tasks that want objects to count against
+    the device_memory_limit while freeing them ASAP without explicit calls to
+    __delitem__.
+    """
     dhf = ProxifyHostFile(device_memory_limit=one_item_nbytes)
     dhf["k1"] = one_item_array()
     k1 = dhf["k1"]
-    k2 = dhf.add_external(one_item_array())
+    k2 = dhf.manager.proxify(one_item_array())
     # `k2` isn't part of the store but still triggers spilling of `k1`
     assert len(dhf) == 1
     assert k1._obj_pxy_is_serialized()
     assert not k2._obj_pxy_is_serialized()
+    assert is_proxies_equal(dhf.manager._host, [k1])
+    assert is_proxies_equal(dhf.manager._dev, [k2])
+
     k1[0]  # Trigger spilling of `k2`
     assert not k1._obj_pxy_is_serialized()
     assert k2._obj_pxy_is_serialized()
+    assert is_proxies_equal(dhf.manager._host, [k2])
+    assert is_proxies_equal(dhf.manager._dev, [k1])
+
     k2[0]  # Trigger spilling of `k1`
     assert k1._obj_pxy_is_serialized()
     assert not k2._obj_pxy_is_serialized()
-    assert dhf.proxies_tally.get_dev_mem_usage() == one_item_nbytes
+    assert is_proxies_equal(dhf.manager._host, [k1])
+    assert is_proxies_equal(dhf.manager._dev, [k2])
+
     # Removing `k2` also removes it from the tally
     del k2
-    assert dhf.proxies_tally.get_dev_mem_usage() == 0
-    assert len(list(dhf.proxies_tally.get_unspilled_proxies())) == 0
-
-
-def test_externals_setitem():
-    dhf = ProxifyHostFile(device_memory_limit=one_item_nbytes)
-    k1 = dhf.add_external(one_item_array())
-    assert type(k1) is dask_cuda.proxy_object.ProxyObject
-    assert len(dhf) == 0
-    assert "external" in k1._obj_pxy
-    assert "external_finalize" in k1._obj_pxy
-    dhf["k1"] = k1
-    k1 = dhf["k1"]
-    assert type(k1) is dask_cuda.proxy_object.ProxyObject
-    assert len(dhf) == 1
-    assert "external" not in k1._obj_pxy
-    assert "external_finalize" not in k1._obj_pxy
-
-    k1 = dhf.add_external(one_item_array())
-    k1._obj_pxy_serialize(serializers=("dask", "pickle"))
-    dhf["k1"] = k1
-    k1 = dhf["k1"]
-    assert type(k1) is dask_cuda.proxy_object.ProxyObject
-    assert len(dhf) == 1
-    assert "external" not in k1._obj_pxy
-    assert "external_finalize" not in k1._obj_pxy
-
-    dhf["k1"] = one_item_array()
-    assert len(dhf.proxies_tally.proxy_id_to_proxy) == 1
-    assert dhf.proxies_tally.get_dev_mem_usage() == one_item_nbytes
-    k1 = dhf.add_external(k1)
-    assert len(dhf.proxies_tally.proxy_id_to_proxy) == 1
-    assert dhf.proxies_tally.get_dev_mem_usage() == one_item_nbytes
-    k1 = dhf.add_external(dhf["k1"])
-    assert len(dhf.proxies_tally.proxy_id_to_proxy) == 1
-    assert dhf.proxies_tally.get_dev_mem_usage() == one_item_nbytes
+    assert is_proxies_equal(dhf.manager._host, [k1])
+    assert is_proxies_equal(dhf.manager._dev, [])
 
 
 def test_proxify_device_objects_of_cupy_array():

--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -87,7 +87,7 @@ def test_local_cuda_cluster(jit_unspill):
         if jit_unspill:
             # Check that `x` is a proxy object and the proxied DataFrame is serialized
             assert "FrameProxyObject" in str(type(x))
-            assert x._obj_pxy["serializers"] == ("dask", "pickle")
+            assert x._obj_pxy["serializer"] == "dask"
         else:
             assert type(x) == cudf.DataFrame
         assert len(x) == 10  # Trigger deserialization

--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -23,20 +23,20 @@ from dask_cuda.proxify_device_objects import proxify_device_objects
 def test_proxy_object(serializers):
     """Check "transparency" of the proxy object"""
 
-    org = list(range(10))
+    org = bytearray(range(10))
     pxy = proxy_object.asproxy(org, serializers=serializers)
 
     assert len(org) == len(pxy)
     assert org[0] == pxy[0]
     assert 1 in pxy
-    assert -1 not in pxy
+    assert 10 not in pxy
     assert str(org) == str(pxy)
     assert "dask_cuda.proxy_object.ProxyObject at " in repr(pxy)
-    assert "list at " in repr(pxy)
+    assert "bytearray at " in repr(pxy)
 
     pxy._obj_pxy_serialize(serializers=("dask", "pickle"))
     assert "dask_cuda.proxy_object.ProxyObject at " in repr(pxy)
-    assert "list (serialized=('dask', 'pickle'))" in repr(pxy)
+    assert "bytearray (serialized=('dask', 'pickle'))" in repr(pxy)
 
     assert org == proxy_object.unproxy(pxy)
     assert org == proxy_object.unproxy(org)
@@ -46,7 +46,7 @@ def test_proxy_object(serializers):
 @pytest.mark.parametrize("serializers_second", [None, ("dask", "pickle")])
 def test_double_proxy_object(serializers_first, serializers_second):
     """Check asproxy() when creating a proxy object of a proxy object"""
-    org = list(range(10))
+    org = bytearray(range(10))
     pxy1 = proxy_object.asproxy(org, serializers=serializers_first)
     assert pxy1._obj_pxy["serializers"] == serializers_first
     pxy2 = proxy_object.asproxy(pxy1, serializers=serializers_second)

--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -36,25 +36,45 @@ def test_proxy_object(serializers):
 
     pxy._obj_pxy_serialize(serializers=("dask", "pickle"))
     assert "dask_cuda.proxy_object.ProxyObject at " in repr(pxy)
-    assert "bytearray (serialized=('dask', 'pickle'))" in repr(pxy)
+    assert "bytearray (serialized='dask')" in repr(pxy)
 
     assert org == proxy_object.unproxy(pxy)
     assert org == proxy_object.unproxy(org)
+
+
+class DummyObj:
+    """Class that only "pickle" can serialize"""
+
+    def __reduce__(self):
+        return (DummyObj, ())
+
+
+def test_proxy_object_serializer():
+    """Check the serializers argument"""
+    pxy = proxy_object.asproxy(DummyObj(), serializers=("dask", "pickle"))
+    assert pxy._obj_pxy["serializer"] == "pickle"
+    assert "DummyObj (serialized='pickle')" in repr(pxy)
+
+    with pytest.raises(ValueError) as excinfo:
+        pxy = proxy_object.asproxy([42], serializers=("dask", "pickle"))
+        assert "Cannot wrap a collection" in str(excinfo.value)
 
 
 @pytest.mark.parametrize("serializers_first", [None, ("dask", "pickle")])
 @pytest.mark.parametrize("serializers_second", [None, ("dask", "pickle")])
 def test_double_proxy_object(serializers_first, serializers_second):
     """Check asproxy() when creating a proxy object of a proxy object"""
+    serializer1 = serializers_first[0] if serializers_first else None
+    serializer2 = serializers_second[0] if serializers_second else None
     org = bytearray(range(10))
     pxy1 = proxy_object.asproxy(org, serializers=serializers_first)
-    assert pxy1._obj_pxy["serializers"] == serializers_first
+    assert pxy1._obj_pxy["serializer"] == serializer1
     pxy2 = proxy_object.asproxy(pxy1, serializers=serializers_second)
     if serializers_second is None:
         # Check that `serializers=None` doesn't change the initial serializers
-        assert pxy2._obj_pxy["serializers"] == serializers_first
+        assert pxy2._obj_pxy["serializer"] == serializer1
     else:
-        assert pxy2._obj_pxy["serializers"] == serializers_second
+        assert pxy2._obj_pxy["serializer"] == serializer2
     assert pxy1 is pxy2
 
 
@@ -257,7 +277,7 @@ def test_spilling_local_cuda_cluster(jit_unspill):
         if jit_unspill:
             # Check that `x` is a proxy object and the proxied DataFrame is serialized
             assert "FrameProxyObject" in str(type(x))
-            assert x._obj_pxy["serializers"] == ("dask", "pickle")
+            assert x._obj_pxy["serializer"] == "dask"
         else:
             assert type(x) == cudf.DataFrame
         assert len(x) == 10  # Trigger deserialization
@@ -292,7 +312,7 @@ class _PxyObjTest(proxy_object.ProxyObject):
 
     def _obj_pxy_deserialize(self):
         if self._obj_pxy["assert_on_deserializing"]:
-            assert self._obj_pxy["serializers"] is None
+            assert self._obj_pxy["serializer"] is None
         return super()._obj_pxy_deserialize()
 
 
@@ -305,16 +325,16 @@ def test_communicating_proxy_objects(protocol, send_serializers):
     def task(x):
         # Check that the subclass survives the trip from client to worker
         assert isinstance(x, _PxyObjTest)
-        serializers_used = x._obj_pxy["serializers"]
+        serializers_used = x._obj_pxy["serializer"]
 
         # Check that `x` is serialized with the expected serializers
         if protocol == "ucx":
             if send_serializers is None:
-                assert serializers_used == ("cuda",)
+                assert serializers_used == "cuda"
             else:
-                assert serializers_used == send_serializers
+                assert serializers_used == send_serializers[0]
         else:
-            assert serializers_used == ("dask", "pickle")
+            assert serializers_used == "dask"
 
     with dask_cuda.LocalCUDACluster(
         n_workers=1, protocol=protocol, enable_tcp_over_ucx=protocol == "ucx"

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -594,7 +594,6 @@ def nvml_device_index(i, CUDA_VISIBLE_DEVICES):
 def parse_device_memory_limit(device_memory_limit, device_index=0):
     """Parse memory limit to be used by a CUDA device.
 
-
     Parameters
     ----------
     device_memory_limit: float, int, str or None


### PR DESCRIPTION
This PR introduce a `ProxyManager` that replaces the current implementation of proxy tracking:
```python
class ProxyManager:
    """
    This class together with Proxies, ProxiesOnHost, and ProxiesOnDevice
    implements the tracking of all known proxies and their total host/device
    memory usage. It turns out having to re-calculate memory usage continuously
    is too expensive.

    The idea is to have the ProxifyHostFile or the proxies themself update
    their location (device or host). The manager then tallies the total memory usage.

    Notice, the manager only keeps weak references to the proxies.
    """
```
Additionally, this PR fixes a rare deadlock by having all proxies and the `ProxyManager` use the same lock. Finally, this PR will make it much easier to implement spilling to disk: https://github.com/rapidsai/dask-cuda/pull/708.

Notice, from the user's perspective, this PR shouldn't change anything.

