### PR TITLE
Warn if CUDA context is created on incorrect device with `LocalCUDACluster`

### DIFF
--- a/dask_cuda/initialize.py
+++ b/dask_cuda/initialize.py
@@ -1,13 +1,46 @@
 import logging
+import os
+import warnings
 
 import click
 import numba.cuda
 
 import dask
 
-from .utils import get_ucx_config
+from .utils import get_ucx_config, has_cuda_context
 
 logger = logging.getLogger(__name__)
+
+
+def _create_cuda_context():
+    try:
+        cuda_visible_device = int(
+            os.environ.get("CUDA_VISIBLE_DEVICES", "0").split(",")[0]
+        )
+        ctx = has_cuda_context()
+        if ctx is not False:
+            warnings.warn(
+                f"A CUDA context for device {ctx} already exists on process ID "
+                f"{os.getpid()}. This is often the result of a CUDA-enabled library "
+                "calling a CUDA runtime function before Dask-CUDA can spawn worker "
+                "processes. Please make sure any such function calls don't happen at "
+                "happen at import time or in the global scope of a program."
+            )
+
+        numba.cuda.current_context()
+
+        ctx = has_cuda_context()
+        if ctx is not False and ctx != cuda_visible_device:
+            warnings.warn(
+                f"Worker with process ID {os.getpid()} should have a CUDA context "
+                f"assigned to device {cuda_visible_device}, but instead the CUDA "
+                f"context is on device {ctx}. This is often the result of a "
+                "CUDA-enabled library calling a CUDA runtime function before Dask-CUDA "
+                "can spawn worker processes. Please make sure any such function calls "
+                "don't happen at import time or in the global scope of a program."
+            )
+    except Exception:
+        logger.error("Unable to start CUDA Context", exc_info=True)
 
 
 def initialize(
@@ -79,10 +112,7 @@ def initialize(
     """
 
     if create_cuda_context:
-        try:
-            numba.cuda.current_context()
-        except Exception:
-            logger.error("Unable to start CUDA Context", exc_info=True)
+        _create_cuda_context()
 
     ucx_config = get_ucx_config(
         enable_tcp_over_ucx=enable_tcp_over_ucx,
@@ -138,7 +168,4 @@ def dask_setup(
     net_devices,
 ):
     if create_cuda_context:
-        try:
-            numba.cuda.current_context()
-        except Exception:
-            logger.error("Unable to start CUDA Context", exc_info=True)
+        _create_cuda_context()

--- a/dask_cuda/initialize.py
+++ b/dask_cuda/initialize.py
@@ -24,7 +24,7 @@ def _create_cuda_context():
                 f"{os.getpid()}. This is often the result of a CUDA-enabled library "
                 "calling a CUDA runtime function before Dask-CUDA can spawn worker "
                 "processes. Please make sure any such function calls don't happen at "
-                "happen at import time or in the global scope of a program."
+                "import time or in the global scope of a program."
             )
 
         numba.cuda.current_context()

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -166,6 +166,24 @@ def get_gpu_count_mig(return_uuids=False):
     return len(uuids)
 
 
+def has_cuda_context():
+    """Check whether the current process already has a CUDA context created.
+
+    Returns
+    -------
+    ``False`` if current process has no CUDA context created, otherwise returns the
+    index of the device for which there's a CUDA context.
+    """
+    pynvml.nvmlInit()
+    for index in range(get_gpu_count()):
+        handle = pynvml.nvmlDeviceGetHandleByIndex(index)
+        running_processes = pynvml.nvmlDeviceGetComputeRunningProcesses_v2(handle)
+        for proc in running_processes:
+            if os.getpid() == proc.pid:
+                return index
+    return False
+
+
 def get_cpu_affinity(device_index=None):
     """Get a list containing the CPU indices to which a GPU is directly connected.
     Use either the device index or the specified device identifier UUID.


### PR DESCRIPTION
Warns if for some reason the creation of CUDA context has already happened or occurs on the incorrect device in `LocalCUDACluster`. This can be a problem if something initializes the CUDA runtime library too early.

Because these things are related to the global Python context, it's difficult to test it with pytest. But below is a reproducer for both warnings:

<details><summary> gpu_assignment.py </summary>

```python
import create_context  # `create_context.py` file on running directory -- Triggers CUDA context has already been created

from dask.distributed import Client
from dask_cuda import LocalCUDACluster
from numba import cuda

cuda_ver = cuda.runtime.get_version()  # Doesn't create a context, but causes all workers to create context on device 0 when `numba.cuda.current_context()` is called


if __name__ == '__main__':
    cluster = LocalCUDACluster()
    client = Client(cluster)
```

</details>

<details><summary> create_context.py </summary>

```python
from numba import cuda
cuda.current_context()
```

</details>

Fixes #384 