### PR TITLE
Check if CUDA context was created in distributed.comm.ucx

### DIFF
--- a/dask_cuda/initialize.py
+++ b/dask_cuda/initialize.py
@@ -118,10 +118,6 @@ def initialize(
         it is callable. Can be an integer or ``None`` if ``net_devices`` is not
         callable.
     """
-
-    if create_cuda_context:
-        _create_cuda_context()
-
     ucx_config = get_ucx_config(
         enable_tcp_over_ucx=enable_tcp_over_ucx,
         enable_infiniband=enable_infiniband,
@@ -131,6 +127,9 @@ def initialize(
         cuda_device_index=cuda_device_index,
     )
     dask.config.set({"distributed.comm.ucx": ucx_config})
+
+    if create_cuda_context:
+        _create_cuda_context()
 
 
 @click.command()

--- a/dask_cuda/initialize.py
+++ b/dask_cuda/initialize.py
@@ -7,9 +7,8 @@ import numba.cuda
 
 import dask
 import distributed.comm.ucx
-from distributed.diagnostics.nvml import has_cuda_context
 
-from .utils import get_ucx_config
+from .utils import get_ucx_config, has_cuda_context
 
 logger = logging.getLogger(__name__)
 

--- a/dask_cuda/initialize.py
+++ b/dask_cuda/initialize.py
@@ -16,7 +16,10 @@ logger = logging.getLogger(__name__)
 
 def _create_cuda_context():
     try:
+        # Added here to ensure the parent `LocalCUDACluster` process creates the CUDA
+        # context directly from the UCX module, thus avoiding a similar warning there.
         distributed.comm.ucx.init_once()
+
         cuda_visible_device = int(
             os.environ.get("CUDA_VISIBLE_DEVICES", "0").split(",")[0]
         )

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -166,6 +166,24 @@ def get_gpu_count_mig(return_uuids=False):
     return len(uuids)
 
 
+def has_cuda_context():
+    """Check whether the current process already has a CUDA context created.
+
+    Returns
+    -------
+    ``False`` if current process has no CUDA context created, otherwise returns the
+    index of the device for which there's a CUDA context.
+    """
+    pynvml.nvmlInit()
+    for index in range(get_gpu_count()):
+        handle = pynvml.nvmlDeviceGetHandleByIndex(index)
+        running_processes = pynvml.nvmlDeviceGetComputeRunningProcesses_v2(handle)
+        for proc in running_processes:
+            if os.getpid() == proc.pid:
+                return index
+    return False
+
+
 def get_cpu_affinity(device_index=None):
     """Get a list containing the CPU indices to which a GPU is directly connected.
     Use either the device index or the specified device identifier UUID.

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -166,24 +166,6 @@ def get_gpu_count_mig(return_uuids=False):
     return len(uuids)
 
 
-def has_cuda_context():
-    """Check whether the current process already has a CUDA context created.
-
-    Returns
-    -------
-    ``False`` if current process has no CUDA context created, otherwise returns the
-    index of the device for which there's a CUDA context.
-    """
-    pynvml.nvmlInit()
-    for index in range(get_gpu_count()):
-        handle = pynvml.nvmlDeviceGetHandleByIndex(index)
-        running_processes = pynvml.nvmlDeviceGetComputeRunningProcesses_v2(handle)
-        for proc in running_processes:
-            if os.getpid() == proc.pid:
-                return index
-    return False
-
-
 def get_cpu_affinity(device_index=None):
     """Get a list containing the CPU indices to which a GPU is directly connected.
     Use either the device index or the specified device identifier UUID.


### PR DESCRIPTION
Because communications in `Nanny` are initialized before Dask preload plugins, and UCX creates the context directly within its own initializer in Distributed, Dask-CUDA will always think the CUDA context has already been incorrectly initialized when using UCX, which isn't true, with the globals added here Dask-CUDA can verify the CUDA contexts are indeed valid.

Depends on https://github.com/dask/distributed/pull/5308 .

Fixes #721 .