### PR TITLE
Pin max `dask` and `distributed` versions to `2021.09.1`

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -33,7 +33,7 @@ export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1
 
 # Install dask and distributed from master branch. Usually needed during
 # development time and disabled before a new dask-cuda release.
-export INSTALL_DASK_MASTER=1
+export INSTALL_DASK_MASTER=0
 
 ################################################################################
 # SETUP - Check environment

--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -27,8 +27,8 @@ requirements:
     - setuptools
   run:
     - python
-    - dask >=2.22.0,<=2021.09.1
-    - distributed >=2.22.0,<=2021.09.1
+    - dask=2021.09.1
+    - distributed=2021.09.1
     - pynvml >=8.0.3
     - numpy >=1.16.0
     - numba >=0.53.1

--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -27,8 +27,8 @@ requirements:
     - setuptools
   run:
     - python
-    - dask >=2.22.0
-    - distributed >=2.22.0
+    - dask >=2.22.0,<=2021.09.1
+    - distributed >=2.22.0,<=2021.09.1
     - pynvml >=8.0.3
     - numpy >=1.16.0
     - numba >=0.53.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-dask>=2.22.0,<=2021.09.1
-distributed>=2.22.0,<=2021.09.1
+dask==2021.09.1
+distributed==2021.09.1
 pynvml>=11.0.0
 numpy>=1.16.0
 numba>=0.53.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-dask>=2.22.0
-distributed>=2.22.0
+dask>=2.22.0,<=2021.09.1
+distributed>=2.22.0,<=2021.09.1
 pynvml>=11.0.0
 numpy>=1.16.0
 numba>=0.53.1


### PR DESCRIPTION
Changes to be in-line with: https://github.com/rapidsai/cudf/pull/9286