### PR TITLE
Use cuDF Frame instead of Table

### DIFF
--- a/dask_cuda/_version.py
+++ b/dask_cuda/_version.py
@@ -51,7 +51,7 @@ class NotThisMethod(Exception):
     """Exception raised if a method is not valid for the current scenario."""
 
 
-LONG_VERSION_PY = {}
+LONG_VERSION_PY = {}  # type: ignore
 HANDLERS = {}
 
 

--- a/dask_cuda/explicit_comms/dataframe/shuffle.py
+++ b/dask_cuda/explicit_comms/dataframe/shuffle.py
@@ -192,9 +192,9 @@ async def local_shuffle(
         dfs = []
         for out_parts in out_parts_list:
             dfs.extend(out_parts[i])
-            out_parts[i] = None
+            out_parts[i] = None  # type: ignore
         dfs.extend(rank_to_out_parts_list[myrank][i])
-        rank_to_out_parts_list[myrank][i] = None
+        rank_to_out_parts_list[myrank][i] = None  # type: ignore
         if len(dfs) > 1:
             ret.append(concat(dfs, ignore_index=ignore_index))
         else:

--- a/dask_cuda/proxify_device_objects.py
+++ b/dask_cuda/proxify_device_objects.py
@@ -224,17 +224,22 @@ def proxify_device_object_python_dict(
 @dispatch.register_lazy("cudf")
 def _register_cudf():
     import cudf
-    import cudf._lib.table
+
+    try:
+        # In v21.12, cuDF removed Table in favor of Frame as base class
+        from cudf._lib.table import Table as Frame
+    except ImportError:
+        from cudf.core.frame import Frame
 
     # In order to support the cuDF API implemented in Cython, we inherit from
-    # `cudf._lib.table.Table`, which is the base class of Index, Series, and
+    # `cudf.core.frame.Frame`, which is the base class of Index, Series, and
     # Dataframes in cuDF.
     # Notice, the order of base classes matters. Since ProxyObject is the first
     # base class, ProxyObject.__init__() is called on creation, which doesn't
-    # define the Table._data and Table._index attributes. Thus, accessing
+    # define the Frame._data and Frame._index attributes. Thus, accessing
     # FrameProxyObject._data and FrameProxyObject._index is pass-through to
     # ProxyObejct.__getattr__(), which is what we want.
-    class FrameProxyObject(ProxyObject, cudf._lib.table.Table):
+    class FrameProxyObject(ProxyObject, Frame):
         pass
 
     @dispatch.register(cudf.DataFrame)

--- a/dask_cuda/tests/test_dgx.py
+++ b/dask_cuda/tests/test_dgx.py
@@ -16,7 +16,7 @@ from dask_cuda import LocalCUDACluster
 from dask_cuda.initialize import initialize
 from dask_cuda.utils import _ucx_110, wait_workers
 
-mp = mp.get_context("spawn")
+mp = mp.get_context("spawn")  # type: ignore
 psutil = pytest.importorskip("psutil")
 
 

--- a/dask_cuda/tests/test_explicit_comms.py
+++ b/dask_cuda/tests/test_explicit_comms.py
@@ -18,7 +18,7 @@ from dask_cuda.explicit_comms.dataframe.shuffle import shuffle as explicit_comms
 from dask_cuda.initialize import initialize
 from dask_cuda.utils import get_ucx_config
 
-mp = mp.get_context("spawn")
+mp = mp.get_context("spawn")  # type: ignore
 ucp = pytest.importorskip("ucp")
 
 # Notice, all of the following tests is executed in a new process such

--- a/dask_cuda/tests/test_initialize.py
+++ b/dask_cuda/tests/test_initialize.py
@@ -11,7 +11,7 @@ from distributed.deploy.local import LocalCluster
 from dask_cuda.initialize import initialize
 from dask_cuda.utils import _ucx_110, get_ucx_config
 
-mp = mp.get_context("spawn")
+mp = mp.get_context("spawn")  # type: ignore
 ucp = pytest.importorskip("ucp")
 
 # Notice, all of the following tests is executed in a new process such


### PR DESCRIPTION
In v21.12, [cuDF removed Table in favor of Frame as base class](https://github.com/rapidsai/cudf/pull/9315), which is now part of the office API. 

We now import `cudf.core.frame.Frame` if `cudf._lib.table.Table` isn't available. 
Also, this PR adds some `# type: ignore` to make `mypy` pass.