### PR TITLE
Spilling on demand

### DIFF
--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -473,7 +473,7 @@ class ProxifyHostFile(MutableMapping):
         else:
             self.compatibility_mode = compatibility_mode
         if spill_on_demand is None:
-            spill_on_demand = dask.config.get("spill-on-demand", default=False)
+            spill_on_demand = dask.config.get("spill-on-demand", default=True)
         # `None` in this context means: never initialize
         self.spill_on_demand_initialized = False if spill_on_demand else None
 

--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -175,7 +175,7 @@ def test_one_item_host_limit():
 def test_spill_on_demand():
     """
     Test spilling on demand by disabling the device_memory_limit
-    and allocating two large buffers that will fail if not because
+    and allocating two large buffers that will otherwise fail because
     of spilling on demand.
     """
     rmm = pytest.importorskip("rmm")

--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -183,7 +183,9 @@ def test_spill_on_demand():
         pytest.skip("RMM doesn't implement FailureCallbackResourceAdaptor")
 
     dhf = ProxifyHostFile(
-        device_memory_limit=1e11, memory_limit=1e11, spill_on_demand=True
+        device_memory_limit=2 * get_device_total_memory(),
+        memory_limit=2 * get_device_total_memory(),
+        spill_on_demand=True,
     )
     total_mem = get_device_total_memory()
     for i in range(2):

--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -182,12 +182,12 @@ def test_spill_on_demand():
     if not hasattr(rmm.mr, "FailureCallbackResourceAdaptor"):
         pytest.skip("RMM doesn't implement FailureCallbackResourceAdaptor")
 
+    total_mem = get_device_total_memory()
     dhf = ProxifyHostFile(
-        device_memory_limit=2 * get_device_total_memory(),
-        memory_limit=2 * get_device_total_memory(),
+        device_memory_limit=2 * total_mem,
+        memory_limit=2 * total_mem,
         spill_on_demand=True,
     )
-    total_mem = get_device_total_memory()
     for i in range(2):
         dhf[i] = rmm.DeviceBuffer(size=total_mem // 2 + 1)
 


### PR DESCRIPTION
Use https://github.com/rapidsai/rmm/pull/892 to implement spilling on demand. Requires use of [RMM](https://github.com/rapidsai/rmm) and JIT-unspill enabled.

The `device_memory_limit` still works as usual -- when known allocations gets to `device_memory_limit`, Dask-CUDA starts spilling preemptively. However, with this PR it is should be possible to increase `device_memory_limit` significantly since memory spikes will be handled by spilling on demand.

Closes #755 