### PR TITLE
Ignore known but expected test warnings

### DIFF
--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -50,6 +50,7 @@ async def test_local_cuda_cluster():
 
 # Notice, this test might raise errors when the number of available GPUs is less
 # than 8 but as long as the test passes the errors can be ignored.
+@pytest.mark.filterwarnings("ignore:Cannot get CPU affinity")
 @gen_test(timeout=20)
 async def test_with_subset_of_cuda_visible_devices():
     os.environ["CUDA_VISIBLE_DEVICES"] = "0,3,6,8"
@@ -96,6 +97,7 @@ async def test_ucx_protocol(protocol):
 
 
 @pytest.mark.asyncio
+@pytest.mark.filterwarnings("ignore:Exception ignored in")
 async def test_ucx_protocol_type_error():
     pytest.importorskip("ucp")
 

--- a/dask_cuda/tests/test_worker_spec.py
+++ b/dask_cuda/tests/test_worker_spec.py
@@ -24,6 +24,7 @@ def _check_env_value(spec, k, v):
         assert all([i in set(s["options"]["env"][k].split(",")) for s in spec.values()])
 
 
+@pytest.mark.filterwarnings("ignore:Cannot get CPU affinity")
 @pytest.mark.parametrize("num_devices", [1, 4])
 @pytest.mark.parametrize("cls", [Nanny])
 @pytest.mark.parametrize("interface", [None, "eth0", "enp1s0f0"])


### PR DESCRIPTION
Some warnings get raised during tests, they are known, expected and harmless, so it's safe to filter them out.