### PR TITLE
Increase CUDAWorker close timeout

### DIFF
--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -270,5 +270,5 @@ class CUDAWorker(Server):
     async def finished(self):
         await asyncio.gather(*[n.finished() for n in self.nannies])
 
-    async def close(self, timeout=2):
+    async def close(self, timeout=5):
         await asyncio.gather(*[n.close(timeout=timeout) for n in self.nannies])


### PR DESCRIPTION
Current timeout=2 is too short for UCX and frequently causes unclean
exit in workers, such as below:

```
distributed.nanny - WARNING - Worker process still alive after 1 seconds, killing
```

By increasing it a bit less errors and warnings are raised for 32
workers, but if there it's possible that if there are many more workers
the default timeout should be increased to prevent that.