### PR TITLE
Avoid creating CUDA context in LocalCUDACluster parent process

### DIFF
--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -327,6 +327,7 @@ class LocalCUDACluster(LocalCluster):
         self.host = kwargs.get("host", None)
 
         initialize(
+            create_cuda_context=False,
             enable_tcp_over_ucx=enable_tcp_over_ucx,
             enable_nvlink=enable_nvlink,
             enable_infiniband=enable_infiniband,


### PR DESCRIPTION
This is helpful for preventing an extra, unnecessary, CUDA context. However, this is only helpful if `Client` is not created in the same process as `LocalCUDACluster`, as otherwise it will anyway create a CUDA context.