### PR TITLE
Simplify JIT-unspill and writing docs

### DIFF
--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -541,12 +541,12 @@ class ProxifyHostFile(MutableMapping):
             @staticmethod
             def evict():
                 # We don't know how much we need to spill but Dask will call evict()
-                # repeatedly until enough is spilled. We ask for 100MB each time.
+                # repeatedly until enough is spilled. We ask for 1% each time.
                 return (
                     None,
                     None,
                     self.manager.evict(
-                        nbytes=2 ** 27,
+                        nbytes=int(self.manager._host_memory_limit * 0.01),
                         proxies_access=self.manager.get_host_access_info,
                         serializer=ProxifyHostFile.serialize_proxy_to_disk_inplace,
                     ),

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -78,6 +78,7 @@ class Proxies(abc.ABC):
                 self._mem_usage = 0
 
     def get_proxies(self) -> List[ProxyObject]:
+        """Return a list of all proxies"""
         with self._lock:
             ret = []
             for p in self._proxy_id_to_proxy.values():
@@ -193,6 +194,7 @@ class ProxyManager:
             return ret[:-1]  # Strip last newline
 
     def get_proxies_by_serializer(self, serializer: Optional[str]) -> Proxies:
+        """Get Proxies collection by serializer"""
         if serializer == "disk":
             return self._disk
         elif serializer in ("dask", "pickle"):
@@ -201,6 +203,7 @@ class ProxyManager:
             return self._dev
 
     def get_proxies_by_proxy_object(self, proxy: ProxyObject) -> Optional[Proxies]:
+        """Get Proxies collection by proxy object"""
         proxy_id = id(proxy)
         if self._dev.contains_proxy_id(proxy_id):
             return self._dev
@@ -211,6 +214,7 @@ class ProxyManager:
         return None
 
     def contains(self, proxy_id: int) -> bool:
+        """Is the proxy in any of the Proxies collection?"""
         with self.lock:
             return (
                 self._disk.contains_proxy_id(proxy_id)
@@ -219,6 +223,7 @@ class ProxyManager:
             )
 
     def add(self, proxy: ProxyObject, serializer: Optional[str]) -> None:
+        """Add the proxy to the Proxies collection by that match the serializer"""
         with self.lock:
             old_proxies = self.get_proxies_by_proxy_object(proxy)
             new_proxies = self.get_proxies_by_serializer(serializer)
@@ -228,6 +233,7 @@ class ProxyManager:
                 new_proxies.add(proxy)
 
     def remove(self, proxy: ProxyObject) -> None:
+        """Remove the proxy from the Proxies collection it is in"""
         with self.lock:
             # Find where the proxy is located (if found) and remove it
             proxies: Optional[Proxies] = None
@@ -243,6 +249,7 @@ class ProxyManager:
             proxies.remove(proxy)
 
     def validate(self):
+        """Validate the state of the manager"""
         with self.lock:
             for serializer in ("disk", "dask", "cuda"):
                 proxies = self.get_proxies_by_serializer(serializer)
@@ -262,6 +269,7 @@ class ProxyManager:
                         assert header["serializer"] == pxy.serializer
 
     def proxify(self, obj: object) -> object:
+        """Proxify `obj` and add found proxies to the Proxies collections"""
         with self.lock:
             found_proxies: List[ProxyObject] = []
             proxied_id_to_proxy: Dict[int, ProxyObject] = {}

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -158,9 +158,6 @@ class ProxyManagerDummy:
     def remove(self, *args, **kwargs):
         pass
 
-    def move(self, *args, **kwargs):
-        pass
-
     def maybe_evict(self, *args, **kwargs):
         pass
 

--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -97,7 +97,7 @@ def test_one_dev_item_limit():
 
     # Deleting k2 does not change anything since k3 still holds a
     # reference to the underlying proxy object
-    assert dhf.manager.get_dev_access_info()[0] == one_item_nbytes
+    assert dhf.manager._dev.mem_usage() == one_item_nbytes
     dhf.manager.validate()
     assert is_proxies_equal(dhf.manager._host.get_proxies(), [k1, k4])
     assert is_proxies_equal(dhf.manager._dev.get_proxies(), [k2])


### PR DESCRIPTION
Simplify and clean up of JIT-unspill. Particularly, the evict functions are now sharing common code.
Also adding function docs.