### PR TITLE
Avoid proxy object aliasing 

### DIFF
--- a/dask_cuda/proxify_device_objects.py
+++ b/dask_cuda/proxify_device_objects.py
@@ -93,9 +93,8 @@ def proxify_device_objects(
     if found_proxies is None:
         found_proxies = []
     ret = dispatch(obj, proxied_id_to_proxy, found_proxies, excl_proxies)
-    if mark_as_explicit_proxies:
-        for p in found_proxies:
-            p._pxy_get().explicit_proxy = True
+    for p in found_proxies:
+        p._pxy_get().explicit_proxy = mark_as_explicit_proxies
     return ret
 
 
@@ -167,9 +166,10 @@ def unproxify_decorator(func):
 
 def proxify(obj, proxied_id_to_proxy, found_proxies, subclass=None):
     _id = id(obj)
-    if _id not in proxied_id_to_proxy:
-        proxied_id_to_proxy[_id] = asproxy(obj, subclass=subclass)
-    ret = proxied_id_to_proxy[_id]
+    if _id in proxied_id_to_proxy:
+        ret = proxied_id_to_proxy[_id]
+    else:
+        ret = proxied_id_to_proxy[_id] = asproxy(obj, subclass=subclass)
     found_proxies.append(ret)
     return ret
 

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -277,7 +277,11 @@ class ProxyManager:
         """Proxify `obj` and add found proxies to the Proxies collections"""
         with self.lock:
             found_proxies: List[ProxyObject] = []
-            proxied_id_to_proxy: Dict[int, ProxyObject] = {}
+            # In order detect already proxied object, proxify_device_objects()
+            # needs a mapping from proxied objects to their proxy objects.
+            proxied_id_to_proxy = {
+                id(p._pxy_get().obj): p for p in self._dev.get_proxies()
+            }
             ret = proxify_device_objects(obj, proxied_id_to_proxy, found_proxies)
             last_access = time.monotonic()
             for p in found_proxies:


### PR DESCRIPTION
In order detect already proxied object, `proxify_device_objects()` now gets a mapping from proxied objects to their proxy objects.