### PR TITLE
Tally IDs instead of device buffers directly

### DIFF
--- a/dask_cuda/get_device_memory_objects.py
+++ b/dask_cuda/get_device_memory_objects.py
@@ -10,7 +10,7 @@ class DeviceMemoryId:
     """ID and size of device memory objects
 
     Instead of keeping a reference to device memory objects this class
-    only save the id and size in order to avoid delayed freeing.
+    only saves the id and size in order to avoid delayed freeing.
     """
 
     def __init__(self, obj: object):

--- a/dask_cuda/get_device_memory_objects.py
+++ b/dask_cuda/get_device_memory_objects.py
@@ -10,7 +10,7 @@ class DeviceMemoryId:
     """ID and size of device memory objects
 
     Instead of keeping a reference to device memory objects this class
-    only save the id and size in order to avoid delaying freeing of object.
+    only save the id and size in order to avoid delayed freeing.
     """
 
     def __init__(self, obj: object):

--- a/dask_cuda/get_device_memory_objects.py
+++ b/dask_cuda/get_device_memory_objects.py
@@ -1,16 +1,34 @@
+from typing import Set
+
 from dask.sizeof import sizeof
 from dask.utils import Dispatch
 
 dispatch = Dispatch(name="get_device_memory_objects")
 
 
-def get_device_memory_objects(obj) -> set:
-    """ Find all CUDA device objects in `obj`
+class DeviceMemoryId:
+    """ID and size of device memory objects
+
+    Instead of keeping a reference to device memory objects this class
+    only save the id and size in order to avoid delaying freeing of object.
+    """
+
+    def __init__(self, obj: object):
+        self.id = id(obj)
+        self.nbytes = sizeof(obj)
+
+    def __hash__(self) -> int:
+        return self.id
+
+    def __eq__(self, o) -> bool:
+        return self.id == hash(o)
+
+
+def get_device_memory_ids(obj) -> Set[DeviceMemoryId]:
+    """Find all CUDA device objects in `obj`
 
     Search through `obj` and find all CUDA device objects, which are objects
     that either are known to `dispatch` or implement `__cuda_array_interface__`.
-
-    Notice, the CUDA device objects must be hashable.
 
     Parameters
     ----------
@@ -19,10 +37,10 @@ def get_device_memory_objects(obj) -> set:
 
     Returns
     -------
-    ret: set
-        Set of CUDA device memory objects
+    ret: Set[DeviceMemoryId]
+        Set of CUDA device memory IDs
     """
-    return set(dispatch(obj))
+    return {DeviceMemoryId(o) for o in dispatch(obj)}
 
 
 @dispatch.register(object)

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -14,6 +14,7 @@ from typing import (
     DefaultDict,
     Dict,
     Hashable,
+    Iterable,
     List,
     MutableMapping,
     Optional,
@@ -63,6 +64,14 @@ class Proxies(abc.ABC):
     def mem_usage_remove(self, proxy: ProxyObject) -> None:
         """Removal of proxy, update `self._mem_usage`"""
 
+    @abc.abstractmethod
+    def buffer_info(self) -> List[Tuple[float, int, List[ProxyObject]]]:
+        """Return a list of buffer information
+
+        The returned format is:
+            `[(<access-time>, <size-of-buffer>, <list-of-proxies>), ...]
+        """
+
     def add(self, proxy: ProxyObject) -> None:
         """Add a proxy for tracking, calls `self.mem_usage_add`"""
         assert not self.contains_proxy_id(id(proxy))
@@ -94,6 +103,17 @@ class Proxies(abc.ABC):
                     ret.append(proxy)
             return ret
 
+    def get_proxies_by_ids(self, proxy_ids: Iterable[int]) -> List[ProxyObject]:
+        """Return a list of proxies"""
+        ret = []
+        for proxy_id in proxy_ids:
+            weakref_proxy = self._proxy_id_to_proxy.get(proxy_id)
+            if weakref_proxy is not None:
+                proxy = weakref_proxy()
+                if proxy is not None:
+                    ret.append(proxy)
+        return ret
+
     def contains_proxy_id(self, proxy_id: int) -> bool:
         return proxy_id in self._proxy_id_to_proxy
 
@@ -113,6 +133,13 @@ class ProxiesOnHost(Proxies):
     def mem_usage_remove(self, proxy: ProxyObject) -> None:
         self._mem_usage -= sizeof(proxy)
 
+    def buffer_info(self) -> List[Tuple[float, int, List[ProxyObject]]]:
+        ret = []
+        for p in self.get_proxies():
+            size = sizeof(p)
+            ret.append((p._pxy_get().last_access, size, [p]))
+        return ret
+
 
 class ProxiesOnDisk(ProxiesOnHost):
     """Implement tracking of proxies on the Disk"""
@@ -125,6 +152,10 @@ class ProxiesOnDevice(Proxies):
     handle that multiple proxy objects can refer to the same underlying
     device memory object. Thus, we have to track aliasing and make sure
     we don't count down the memory usage prematurely.
+
+    Notice, we only track direct aliasing thus multiple proxy objects can
+    point to different non-overlapping parts of the same device buffer.
+    In this case the tally of the total device memory usage is incorrect.
     """
 
     def __init__(self):
@@ -152,6 +183,14 @@ class ProxiesOnDevice(Proxies):
             if len(self.dev_mem_to_proxy_ids[dev_mem]) == 0:
                 del self.dev_mem_to_proxy_ids[dev_mem]
                 self._mem_usage -= dev_mem.nbytes
+
+    def buffer_info(self) -> List[Tuple[float, int, List[ProxyObject]]]:
+        ret = []
+        for dev_mem, proxy_ids in self.dev_mem_to_proxy_ids.items():
+            proxies = self.get_proxies_by_ids(proxy_ids)
+            last_access = max(p._pxy_get().last_access for p in proxies)
+            ret.append((last_access, dev_mem.nbytes, proxies))
+        return ret
 
 
 class ProxyManager:
@@ -297,35 +336,6 @@ class ProxyManager:
         self.maybe_evict()
         return ret
 
-    def get_dev_access_info(self) -> List[Tuple[float, int, List[ProxyObject]]]:
-        """Return a list of device buffers packed with associated info like:
-            `[(<access-time>, <size-of-buffer>, <list-of-proxies>), ...]
-        """
-        with self.lock:
-            # Map device buffers to proxy objects. Note, multiple proxy object can
-            # point to different non-overlapping parts of the same device buffer.
-            buffer_to_proxies = defaultdict(list)
-            for proxy in self._dev.get_proxies():
-                for buffer in get_device_memory_ids(proxy._pxy_get().obj):
-                    buffer_to_proxies[buffer].append(proxy)
-
-            ret = []
-            for dev_buf, proxies in buffer_to_proxies.items():
-                last_access = max(p._pxy_get().last_access for p in proxies)
-                ret.append((last_access, dev_buf.nbytes, proxies))
-            return ret
-
-    def get_host_access_info(self) -> List[Tuple[float, int, List[ProxyObject]]]:
-        """Return a list of device buffers packed with associated info like:
-            `[(<access-time>, <size-of-buffer>, <list-of-proxies>), ...]
-        """
-        with self.lock:
-            ret = []
-            for p in self._host.get_proxies():
-                size = sizeof(p)
-                ret.append((p._pxy_get().last_access, size, [p]))
-            return ret
-
     def evict(
         self,
         nbytes: int,
@@ -384,7 +394,7 @@ class ProxyManager:
         if mem_over_usage > 0:
             self.evict(
                 nbytes=mem_over_usage,
-                proxies_access=self.get_dev_access_info,
+                proxies_access=self._dev.buffer_info,
                 serializer=lambda p: p._pxy_serialize(serializers=("dask", "pickle")),
             )
 
@@ -400,7 +410,7 @@ class ProxyManager:
         if mem_over_usage > 0:
             self.evict(
                 nbytes=mem_over_usage,
-                proxies_access=self.get_host_access_info,
+                proxies_access=self._host.buffer_info,
                 serializer=ProxifyHostFile.serialize_proxy_to_disk_inplace,
             )
 
@@ -527,7 +537,7 @@ class ProxifyHostFile(MutableMapping):
                     """Try to handle an out-of-memory error by spilling"""
                     memory_freed = self.manager.evict(
                         nbytes=nbytes,
-                        proxies_access=self.manager.get_dev_access_info,
+                        proxies_access=self.manager._dev.buffer_info,
                         serializer=lambda p: p._pxy_serialize(
                             serializers=("dask", "pickle")
                         ),

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -34,7 +34,7 @@ try:
 except ImportError:
     from dask.dataframe.utils import make_meta as make_meta_dispatch
 
-from .get_device_memory_objects import get_device_memory_objects
+
 from .is_device_object import is_device_object
 
 if TYPE_CHECKING:
@@ -167,7 +167,7 @@ class ProxyManagerDummy:
 
 
 class ProxyDetail:
-    """ Details of a ProxyObject
+    """Details of a ProxyObject
 
     In order to avoid having to use thread locks, a ProxyObject maintains
     its state in a ProxyDetail object. The idea is to first make a copy
@@ -434,17 +434,6 @@ class ProxyObject:
         ret = pxy.deserialize(maybe_evict=maybe_evict, nbytes=self.__sizeof__())
         self._pxy_set(pxy)
         return ret
-
-    @_pxy_cache_wrapper("device_memory_objects")
-    def _pxy_get_device_memory_objects(self) -> set:
-        """Return all device memory objects within the proxied object.
-
-        Returns
-        -------
-        ret : set
-            Set of device memory objects
-        """
-        return get_device_memory_objects(self._pxy_get().obj)
 
     def __reduce__(self):
         """Serialization of ProxyObject that uses pickle"""

--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -14,7 +14,7 @@ from distributed.worker import get_worker
 
 import dask_cuda
 import dask_cuda.proxify_device_objects
-from dask_cuda.get_device_memory_objects import get_device_memory_objects
+from dask_cuda.get_device_memory_objects import get_device_memory_ids
 from dask_cuda.proxify_host_file import ProxifyHostFile
 from dask_cuda.proxy_object import ProxyObject, asproxy, unproxy
 from dask_cuda.utils import get_device_total_memory
@@ -264,7 +264,7 @@ def test_cudf_get_device_memory_objects():
             levels=[[1, 2], ["blue", "red"]], codes=[[0, 0, 1, 1], [1, 0, 1, 0]]
         ),
     ]
-    res = get_device_memory_objects(objects)
+    res = get_device_memory_ids(objects)
     assert len(res) == 4, "We expect four buffer objects"
 
 


### PR DESCRIPTION
Instead of keeping a reference to device memory objects when tallying the device memory usage, we now use IDs and sizes in order to avoid delaying freeing.