### PR TITLE
Fix parsing of device by UUID

### DIFF
--- a/dask_cuda/initialize.py
+++ b/dask_cuda/initialize.py
@@ -9,7 +9,7 @@ import dask
 import distributed.comm.ucx
 from distributed.diagnostics.nvml import has_cuda_context
 
-from .utils import get_ucx_config
+from .utils import get_ucx_config, parse_cuda_visible_device
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ def _create_cuda_context():
             # Therefore if ``import ucp`` fails we can just continue here.
             pass
 
-        cuda_visible_device = int(
+        cuda_visible_device = parse_cuda_visible_device(
             os.environ.get("CUDA_VISIBLE_DEVICES", "0").split(",")[0]
         )
         ctx = has_cuda_context()

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import subprocess
+from unittest.mock import patch
 
 import pytest
 
@@ -245,8 +246,8 @@ def test_cuda_mig_visible_devices_and_memory_limit_and_nthreads(loop):  # noqa: 
 
 def test_cuda_visible_devices_uuid(loop):  # noqa: F811
     gpu_uuid = get_gpu_uuid_from_index(0)
-    os.environ["CUDA_VISIBLE_DEVICES"] = gpu_uuid
-    try:
+
+    with patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": gpu_uuid}):
         with popen(["dask-scheduler", "--port", "9359", "--no-dashboard"]):
             with popen(
                 [
@@ -264,5 +265,3 @@ def test_cuda_visible_devices_uuid(loop):  # noqa: F811
 
                     result = client.run(lambda: os.environ["CUDA_VISIBLE_DEVICES"])
                     assert list(result.values())[0] == gpu_uuid
-    finally:
-        del os.environ["CUDA_VISIBLE_DEVICES"]

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -249,11 +249,14 @@ async def test_available_mig_workers():
 
 @gen_test(timeout=20)
 async def test_gpu_uuid():
+    gpu_uuid = get_gpu_uuid_from_index(0)
+
     async with LocalCUDACluster(
-        CUDA_VISIBLE_DEVICES=get_gpu_uuid_from_index(0),
-        scheduler_port=0,
-        asynchronous=True,
+        CUDA_VISIBLE_DEVICES=gpu_uuid, scheduler_port=0, asynchronous=True,
     ) as cluster:
         assert len(cluster.workers) == 1
         async with Client(cluster, asynchronous=True) as client:
             await client.wait_for_workers(1)
+
+            result = await client.run(lambda: os.environ["CUDA_VISIBLE_DEVICES"])
+            assert list(result.values())[0] == gpu_uuid

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -653,3 +653,26 @@ class MockWorker(Worker):
     @staticmethod
     def device_get_count():
         return 0
+
+
+def get_gpu_uuid_from_index(device_index=0):
+    """Get GPU UUID from CUDA device index.
+
+    Parameters
+    ----------
+    device_index: int or str
+        The index of the device from which to obtain the UUID. Default: 0.
+
+    Examples
+    --------
+    >>> get_gpu_uuid_from_index()
+    'GPU-9baca7f5-0f2f-01ac-6b05-8da14d6e9005'
+
+    >>> get_gpu_uuid_from_index(3)
+    'GPU-9fb42d6f-7d6b-368f-f79c-3c3e784c93f6'
+    """
+    import pynvml
+
+    pynvml.nvmlInit()
+    handle = pynvml.nvmlDeviceGetHandleByIndex(device_index)
+    return pynvml.nvmlDeviceGetUUID(handle).decode("utf-8")


### PR DESCRIPTION
With this change, specifying GPUs via their UUIDs in `CUDA_VISIBLE_DEVICES` should work again. Add tests for `LocalCUDACluster`/`dask-cuda-worker`.