### PR TITLE
Handle UCX-Py FutureWarning on UCX < 1.11.1 deprecation

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,4 @@ filterwarnings =
     error::DeprecationWarning
     error::FutureWarning
     ignore::DeprecationWarning:pkg_resources
+    ignore:Support for UCX 1.9.0 is deprecated.*:FutureWarning:ucp


### PR DESCRIPTION
After https://github.com/rapidsai/ucx-py/pull/779 , this is required to run pytests when using UCX 1.9. To be removed in a future release.