### PR TITLE
Add create_cuda_context UCX config from Distributed

### DIFF
--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -303,6 +303,7 @@ def get_ucx_config(
         "rdmacm": None,
         "net-devices": None,
         "cuda_copy": None,
+        "create_cuda_context": None,
         "reuse-endpoints": not _ucx_111,
     }
     if enable_tcp_over_ucx or enable_infiniband or enable_nvlink:


### PR DESCRIPTION
This is necessary to fill the missing create_cuda_context configuration option recently added in Distributed. In
https://github.com/rapidsai/dask-cuda/pull/792 it will be used to simplify UCX configuration.