### PR TITLE
Standardize Distributed config separator in get_ucx_config

### DIFF
--- a/dask_cuda/tests/test_utils.py
+++ b/dask_cuda/tests/test_utils.py
@@ -176,30 +176,30 @@ def test_get_ucx_config(enable_tcp_over_ucx, enable_infiniband, net_devices):
     else:
         ucx_config = get_ucx_config(**kwargs)
 
-    if enable_tcp_over_ucx is True:
-        assert ucx_config["tcp"] is True
-        assert ucx_config["cuda_copy"] is True
-    else:
-        assert ucx_config["tcp"] is None
+    assert ucx_config["tcp"] is enable_tcp_over_ucx
+    assert ucx_config["infiniband"] is enable_infiniband
 
-    if enable_infiniband is True:
-        assert ucx_config["infiniband"] is True
-        assert ucx_config["cuda_copy"] is True
-    else:
-        assert ucx_config["infiniband"] is None
+    if enable_tcp_over_ucx is True or enable_infiniband is True:
+        if "cuda-copy" in ucx_config:
+            assert ucx_config["cuda-copy"] is True
+        else:
+            assert ucx_config["cuda_copy"] is True
 
     if enable_tcp_over_ucx is False and enable_infiniband is False:
-        assert ucx_config["cuda_copy"] is None
+        if "cuda-copy" in ucx_config:
+            assert ucx_config["cuda-copy"] is None
+        else:
+            assert ucx_config["cuda_copy"] is None
 
-    if net_devices == "eth0":
-        assert ucx_config["net-devices"] == "eth0"
-    elif net_devices == "auto":
+    if net_devices == "auto":
         # Since the actual device is system-dependent, we don't do any
         # checks at the moment. If any InfiniBand devices are available,
         # that will be the value of "net-devices", otherwise an empty string.
         pass
-    elif net_devices == "":
-        assert "net-device" not in ucx_config
+    elif net_devices == "eth0":
+        assert ucx_config["net-devices"] == "eth0"
+    else:
+        assert ucx_config["net-devices"] is None
 
 
 def test_parse_visible_devices():

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -11,6 +11,7 @@ import toolz
 
 import dask
 import distributed  # noqa: required for dask.config.get("distributed.comm.ucx")
+from dask.config import canonical_name
 from dask.utils import parse_bytes
 from distributed import Worker, wait
 
@@ -300,28 +301,23 @@ def get_ucx_config(
 
     ucx_config = dask.config.get("distributed.comm.ucx")
 
-    ucx_config["create-cuda-context"] = True
-    ucx_config["reuse-endpoints"] = not _ucx_111
+    ucx_config[canonical_name("create-cuda-context", ucx_config)] = True
+    ucx_config[canonical_name("reuse-endpoints", ucx_config)] = not _ucx_111
 
-    ucx_config["tcp"] = enable_tcp_over_ucx
-    ucx_config["infiniband"] = enable_infiniband
-    ucx_config["nvlink"] = enable_nvlink
-    ucx_config["rdmacm"] = enable_rdmacm
+    ucx_config[canonical_name("tcp", ucx_config)] = enable_tcp_over_ucx
+    ucx_config[canonical_name("infiniband", ucx_config)] = enable_infiniband
+    ucx_config[canonical_name("nvlink", ucx_config)] = enable_nvlink
+    ucx_config[canonical_name("rdmacm", ucx_config)] = enable_rdmacm
 
     if enable_tcp_over_ucx or enable_infiniband or enable_nvlink:
-        cuda_copy = True
+        ucx_config[canonical_name("cuda-copy", ucx_config)] = True
     else:
-        cuda_copy = None
-
-    # For backwards compatibility with https://github.com/dask/distributed/pull/5539
-    # May be removed once support for Distributed <= 2021.11.2 is dropped
-    if "cuda-copy" in ucx_config:
-        ucx_config["cuda-copy"] = cuda_copy
-    elif "cuda_copy" in ucx_config:
-        ucx_config["cuda_copy"] = cuda_copy
+        ucx_config[canonical_name("cuda-copy", ucx_config)] = None
 
     if net_devices is not None and net_devices != "":
-        ucx_config["net-devices"] = get_ucx_net_devices(cuda_device_index, net_devices)
+        ucx_config[canonical_name("net-devices", ucx_config)] = get_ucx_net_devices(
+            cuda_device_index, net_devices
+        )
     return ucx_config
 
 

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -285,10 +285,10 @@ def get_ucx_net_devices(
 
 
 def get_ucx_config(
-    enable_tcp_over_ucx=False,
-    enable_infiniband=False,
-    enable_nvlink=False,
-    enable_rdmacm=False,
+    enable_tcp_over_ucx=None,
+    enable_infiniband=None,
+    enable_nvlink=None,
+    enable_rdmacm=None,
     net_devices="",
     cuda_device_index=None,
 ):
@@ -303,21 +303,22 @@ def get_ucx_config(
     ucx_config["create-cuda-context"] = True
     ucx_config["reuse-endpoints"] = not _ucx_111
 
+    ucx_config["tcp"] = enable_tcp_over_ucx
+    ucx_config["infiniband"] = enable_infiniband
+    ucx_config["nvlink"] = enable_nvlink
+    ucx_config["rdmacm"] = enable_rdmacm
+
     if enable_tcp_over_ucx or enable_infiniband or enable_nvlink:
-        # For backwards compatibility with https://github.com/dask/distributed/pull/5539
-        # May be removed once support for Distributed <= 2021.11.2 is dropped
-        if "cuda-copy" in ucx_config:
-            ucx_config["cuda-copy"] = True
-        elif "cuda_copy" in ucx_config:
-            ucx_config["cuda_copy"] = True
-    if enable_tcp_over_ucx:
-        ucx_config["tcp"] = True
-    if enable_infiniband:
-        ucx_config["infiniband"] = True
-    if enable_nvlink:
-        ucx_config["nvlink"] = True
-    if enable_rdmacm:
-        ucx_config["rdmacm"] = True
+        cuda_copy = True
+    else:
+        cuda_copy = None
+
+    # For backwards compatibility with https://github.com/dask/distributed/pull/5539
+    # May be removed once support for Distributed <= 2021.11.2 is dropped
+    if "cuda-copy" in ucx_config:
+        ucx_config["cuda-copy"] = cuda_copy
+    elif "cuda_copy" in ucx_config:
+        ucx_config["cuda_copy"] = cuda_copy
 
     if net_devices is not None and net_devices != "":
         ucx_config["net-devices"] = get_ucx_net_devices(cuda_device_index, net_devices)


### PR DESCRIPTION
Some of the UCX configurations used `_` whereas others used `-` as a separator. This has been standardized in https://github.com/dask/distributed/pull/5539, and this updates Dask-CUDA to the new standard.