### PR TITLE
Remove automatic `doc` labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,9 +5,6 @@
 python:
  - 'dask_cuda/**'
 
-doc:
- - 'docs/**'
-
 gpuCI:
   - 'ci/**'
 


### PR DESCRIPTION
If there's another category label in a PR, everytime a new commit is pushed GitHub Actions will add a new `doc` category that will cause the label checker to fail. Therefore, we remove the `doc` automatic labeler.