### PR TITLE
[gpuCI] Forward-merge branch-21.12 to branch-22.02 [skip gpuci]

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,9 +5,6 @@
 python:
  - 'dask_cuda/**'
 
-doc:
- - 'docs/**'
-
 gpuCI:
   - 'ci/**'
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.12` that creates a PR to keep `branch-22.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.