### PR TITLE
Fix skipping GDS test if cucim is not installed

### DIFF
--- a/dask_cuda/tests/test_gds.py
+++ b/dask_cuda/tests/test_gds.py
@@ -23,8 +23,8 @@ def test_gds(gds_enabled, cuda_lib):
         ProxifyHostFile.register_disk_spilling()
         if gds_enabled and not ProxifyHostFile._gds_enabled:
             pytest.importorskip("cucim.clara.filesystem")
-            # In this case, we know that cucim and for testing we
-            # force enabling cucim even if GDS is unavailable.
+            # In this case, we know that cucim is available and for testing
+            # we enable cucim explicitly even if GDS is unavailable.
             ProxifyHostFile._gds_enabled = True
 
         a = data_create()

--- a/dask_cuda/tests/test_gds.py
+++ b/dask_cuda/tests/test_gds.py
@@ -23,9 +23,8 @@ def test_gds(gds_enabled, cuda_lib):
         ProxifyHostFile.register_disk_spilling()
         if gds_enabled and not ProxifyHostFile._gds_enabled:
             pytest.importorskip("cucim.clara.filesystem")
-            # In this case, we know that cucim is available but GDS
-            # isn't installed on the system. For testing, we enable
-            # the use of the cucim anyways.
+            # In this case, we know that cucim and for testing we
+            # force enabling cucim even if GDS is unavailable.
             ProxifyHostFile._gds_enabled = True
 
         a = data_create()

--- a/dask_cuda/tests/test_gds.py
+++ b/dask_cuda/tests/test_gds.py
@@ -20,7 +20,7 @@ def test_gds(gds_enabled, cuda_lib):
         data_compare = lambda x, y: all(x.copy_to_host() == y.copy_to_host())
 
     try:
-        ProxifyHostFile.register_disk_spilling(gds=gds_enabled)
+        ProxifyHostFile.register_disk_spilling()
         if gds_enabled and not ProxifyHostFile._gds_enabled:
             pytest.importorskip("cucim.clara.filesystem")
             # In this case, we know that cucim is available but GDS


### PR DESCRIPTION
When `ProxifyHostFile.register_disk_spilling()` is configured with `gds=True` an `ImportError` is raised and the test fails. To fix that we force enabling cucim (if available) after disk spilling is configured, or skip the test if cucim is unavailable.