### PR TITLE
Fix regex pattern to match to in test_on_demand_debug_info

### DIFF
--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -429,7 +429,7 @@ def test_on_demand_debug_info():
 
             # Submit too large RMM buffer
             with pytest.raises(
-                MemoryError, match=r".*std::bad_alloc: CUDA error at:.*"
+                MemoryError, match=r".*std::bad_alloc:.*CUDA error at:.*"
             ):
                 client.submit(task).result()
 


### PR DESCRIPTION
The string for bad allocation from RMM has changed from to include the type of error, now `std::bad_alloc: out_of_memory: CUDA error a`, previously `std::bad_alloc: CUDA error at`, the regex change included here matches both cases now.