### PR TITLE
Ignore `DeprecationWarning` from `distutils.Version` classes

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ filterwarnings =
     error::FutureWarning
     ignore::DeprecationWarning:pkg_resources
     ignore:Support for UCX 1.9.0 is deprecated.*:FutureWarning:ucp
+    ignore:distutils Version classes are deprecated.*:DeprecationWarning:


### PR DESCRIPTION
Ignore `DeprecationWarning`s being raised in `fsspec`:

```python
dask_cuda/tests/test_dask_cuda_worker.py:11: in <module>
    from distributed.utils_test import loop  # noqa: F401
<frozen importlib._bootstrap>:991: in _find_and_load
    ???
<frozen importlib._bootstrap>:975: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:671: in _load_unlocked
    ???
../../miniconda3/envs/rn-115-22.02.220103/lib/python3.8/site-packages/_pytest/assertion/rewrite.py:170: in exec_module
    exec(co, module.__dict__)
../../miniconda3/envs/rn-115-22.02.220103/lib/python3.8/site-packages/distributed/utils_test.py:80: in <module>
    import dask.array  # register config
../../miniconda3/envs/rn-115-22.02.220103/lib/python3.8/site-packages/dask/array/__init__.py:3: in <module>
    from . import backends, fft, lib, linalg, ma, overlap, random
../../miniconda3/envs/rn-115-22.02.220103/lib/python3.8/site-packages/dask/array/backends.py:13: in <module>
    from .percentile import _percentile
../../miniconda3/envs/rn-115-22.02.220103/lib/python3.8/site-packages/dask/array/percentile.py:10: in <module>
    from .core import Array
../../miniconda3/envs/rn-115-22.02.220103/lib/python3.8/site-packages/dask/array/core.py:30: in <module>
    from fsspec import get_mapper
../../miniconda3/envs/rn-115-22.02.220103/lib/python3.8/site-packages/fsspec/__init__.py:12: in <module>
    from .core import get_fs_token_paths, open, open_files, open_local
../../miniconda3/envs/rn-115-22.02.220103/lib/python3.8/site-packages/fsspec/core.py:18: in <module>
    from .compression import compr
../../miniconda3/envs/rn-115-22.02.220103/lib/python3.8/site-packages/fsspec/compression.py:6: in <module>
    from fsspec.spec import AbstractBufferedFile
../../miniconda3/envs/rn-115-22.02.220103/lib/python3.8/site-packages/fsspec/spec.py:92: in <module>
    if pa_version and LooseVersion(pa_version) < LooseVersion("2.0"):
../../miniconda3/envs/rn-115-22.02.220103/lib/python3.8/site-packages/setuptools/_distutils/version.py:53: in __init__
    warnings.warn(
E   DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
```