### PR TITLE
Remove support for UCX < 1.11.1

### DIFF
--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -117,13 +117,6 @@ def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]
         help="Disable RDMACM with UCX.",
     )
     parser.add_argument(
-        "--ucx-net-devices",
-        default=None,
-        type=str,
-        help="The device to be used for UCX communication, or 'auto'. "
-        "Ignored if protocol is 'tcp'",
-    )
-    parser.add_argument(
         "--interface",
         default=None,
         type=str,
@@ -195,7 +188,6 @@ def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]
 
 def get_cluster_options(args):
     ucx_options = {
-        "ucx_net_devices": args.ucx_net_devices,
         "enable_tcp_over_ucx": args.enable_tcp_over_ucx,
         "enable_infiniband": args.enable_infiniband,
         "enable_nvlink": args.enable_nvlink,

--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -249,21 +249,6 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     requires ``--enable-infiniband``.""",
 )
 @click.option(
-    "--net-devices",
-    type=str,
-    default=None,
-    help="""Interface(s) used by workers for UCX communication. Can be a string (like
-    ``"eth0"`` for NVLink or ``"mlx5_0:1"``/``"ib0"`` for InfiniBand), ``"auto"``
-    (requires ``--enable-infiniband``) to pick the optimal interface per-worker based on
-    the system's topology, or ``None`` to stay with the default value of ``"all"`` (use
-    all available interfaces).
-
-    .. warning::
-        ``"auto"`` requires UCX-Py to be installed and compiled with hwloc support.
-        Unexpected errors can occur when using ``"auto"`` if any interfaces are
-        disconnected or improperly configured.""",
-)
-@click.option(
     "--enable-jit-unspill/--disable-jit-unspill",
     default=None,
     help="""Enable just-in-time unspilling. Can be a boolean or ``None`` to fall back on
@@ -310,7 +295,6 @@ def main(
     enable_infiniband,
     enable_nvlink,
     enable_rdmacm,
-    net_devices,
     enable_jit_unspill,
     worker_class,
     **kwargs,
@@ -359,7 +343,6 @@ def main(
         enable_infiniband,
         enable_nvlink,
         enable_rdmacm,
-        net_devices,
         enable_jit_unspill,
         worker_class,
         **kwargs,

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -163,7 +163,6 @@ class CUDAWorker(Server):
             enable_infiniband=enable_infiniband,
             enable_nvlink=enable_nvlink,
             enable_rdmacm=enable_rdmacm,
-            cuda_device_index=0,
         )
 
         if jit_unspill is None:
@@ -232,7 +231,6 @@ class CUDAWorker(Server):
                         enable_infiniband=enable_infiniband,
                         enable_nvlink=enable_nvlink,
                         enable_rdmacm=enable_rdmacm,
-                        cuda_device_index=i,
                     )
                 },
                 data=data(nvml_device_index(i, cuda_visible_devices(i))),

--- a/dask_cuda/initialize.py
+++ b/dask_cuda/initialize.py
@@ -73,8 +73,6 @@ def initialize(
     enable_infiniband=None,
     enable_nvlink=None,
     enable_rdmacm=None,
-    net_devices="",
-    cuda_device_index=None,
 ):
     """Create CUDA context and initialize UCX-Py, depending on user parameters.
 
@@ -119,28 +117,12 @@ def initialize(
     enable_rdmacm : bool, default None
         Set environment variables to enable UCX RDMA connection manager support,
         requires ``enable_infiniband=True``.
-    net_devices : str or callable, default ""
-        Interface(s) used by workers for UCX communication. Can be a string (like
-        ``"eth0"`` for NVLink, ``"mlx5_0:1"``/``"ib0"`` for InfiniBand, or ``""`` to use
-        all available devices), or a callable function that takes the index of the
-        current GPU to return an interface name (like
-        ``lambda dev: "mlx5_%d:1" % (dev // 2)``).
-
-        .. note::
-            If ``net_devices`` is callable, a GPU index must be supplied through
-            ``cuda_device_index``.
-    cuda_device_index : int or None, default None
-        Index of the current GPU, which must be specified for ``net_devices`` if
-        it is callable. Can be an integer or ``None`` if ``net_devices`` is not
-        callable.
     """
     ucx_config = get_ucx_config(
         enable_tcp_over_ucx=enable_tcp_over_ucx,
         enable_infiniband=enable_infiniband,
         enable_nvlink=enable_nvlink,
         enable_rdmacm=enable_rdmacm,
-        net_devices=net_devices,
-        cuda_device_index=cuda_device_index,
     )
     dask.config.set({"distributed.comm.ucx": ucx_config})
 
@@ -174,13 +156,6 @@ def initialize(
     default=False,
     help="Enable RDMA connection manager, currently requires InfiniBand enabled.",
 )
-@click.option(
-    "--net-devices",
-    type=str,
-    default=None,
-    help="Network interface to establish UCX connection, "
-    "usually the Ethernet interface, like 'eth0' or 'enp1s0f0'",
-)
 def dask_setup(
     service,
     create_cuda_context,
@@ -188,7 +163,6 @@ def dask_setup(
     enable_infiniband,
     enable_nvlink,
     enable_rdmacm,
-    net_devices,
 ):
     if create_cuda_context:
         _create_cuda_context()

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -13,11 +13,9 @@ from .proxify_host_file import ProxifyHostFile
 from .utils import (
     CPUAffinity,
     RMMSetup,
-    _ucx_111,
     cuda_visible_devices,
     get_cpu_affinity,
     get_ucx_config,
-    get_ucx_net_devices,
     nvml_device_index,
     parse_cuda_visible_device,
     parse_device_memory_limit,
@@ -100,19 +98,6 @@ class LocalCUDACluster(LocalCluster):
     enable_rdmacm : bool, default None
         Set environment variables to enable UCX RDMA connection manager support,
         requires ``protocol="ucx"`` and ``enable_infiniband=True``.
-    ucx_net_devices : str, callable, or None, default None
-        Interface(s) used by workers for UCX communication. Can be a string (like
-        ``"eth0"`` for NVLink or ``"mlx5_0:1"``/``"ib0"`` for InfiniBand), a callable
-        function that takes the index of the current GPU to return an interface name
-        (like ``lambda dev: "mlx5_%d:1" % (dev // 2)``), ``"auto"`` (requires
-        ``enable_infiniband=True``) to pick the optimal interface per-worker
-        based on the system's topology, or ``None`` to stay with the default value of
-        ``"all"`` (use all available interfaces).
-
-        .. warning::
-            ``"auto"`` requires UCX-Py to be installed and compiled with hwloc support.
-            Unexpected errors can occur when using ``"auto"`` if any interfaces are
-            disconnected or improperly configured.
     rmm_pool_size : int, str or None, default None
         RMM pool size to initialize each worker with. Can be an integer (bytes), string
         (like ``"5GB"`` or ``"5000M"``), or ``None`` to disable RMM pools.
@@ -177,12 +162,8 @@ class LocalCUDACluster(LocalCluster):
     TypeError
         If InfiniBand or NVLink are enabled and ``protocol!="ucx"``.
     ValueError
-        If ``ucx_net_devices=""``, if NVLink and RMM managed memory are
-        both enabled, if RMM pools / managed memory and asynchronous allocator are both
-        enabled, or if ``ucx_net_devices="auto"`` and:
-
-            - UCX-Py is not installed or wasn't compiled with hwloc support; or
-            - ``enable_infiniband=False``
+        If NVLink and RMM managed memory are both enabled, or if RMM pools / managed
+        memory and asynchronous allocator are both enabled.
 
     See Also
     --------
@@ -204,7 +185,6 @@ class LocalCUDACluster(LocalCluster):
         enable_infiniband=None,
         enable_nvlink=None,
         enable_rdmacm=None,
-        ucx_net_devices=None,
         rmm_pool_size=None,
         rmm_maximum_pool_size=None,
         rmm_managed_memory=False,
@@ -316,30 +296,6 @@ class LocalCUDACluster(LocalCluster):
             elif protocol != "ucx":
                 raise TypeError("Enabling InfiniBand or NVLink requires protocol='ucx'")
 
-        if ucx_net_devices == "auto":
-            if _ucx_111:
-                warnings.warn(
-                    "Starting with UCX 1.11, `ucx_net_devices='auto' is deprecated, "
-                    "it should now be left unspecified for the same behavior. "
-                    "Please make sure to read the updated UCX Configuration section in "
-                    "https://docs.rapids.ai/api/dask-cuda/nightly/ucx.html, "
-                    "where significant performance considerations for InfiniBand with "
-                    "UCX 1.11 and above is documented.",
-                )
-            else:
-                try:
-                    from ucp._libs.topological_distance import (  # NOQA
-                        TopologicalDistance,
-                    )
-                except ImportError:
-                    raise ValueError(
-                        "ucx_net_devices set to 'auto' but UCX-Py is not "
-                        "installed or it's compiled without hwloc support"
-                    )
-        elif ucx_net_devices == "":
-            raise ValueError("ucx_net_devices can not be an empty string")
-        self.ucx_net_devices = ucx_net_devices
-        self.set_ucx_net_devices = enable_infiniband and ucx_net_devices is not None
         self.host = kwargs.get("host", None)
 
         initialize(
@@ -348,7 +304,6 @@ class LocalCUDACluster(LocalCluster):
             enable_nvlink=enable_nvlink,
             enable_infiniband=enable_infiniband,
             enable_rdmacm=enable_rdmacm,
-            net_devices=ucx_net_devices,
             cuda_device_index=0,
         )
 
@@ -419,22 +374,5 @@ class LocalCUDACluster(LocalCluster):
                 },
             }
         )
-
-        if self.set_ucx_net_devices:
-            cuda_device_index = visible_devices.split(",")[0]
-
-            net_dev = get_ucx_net_devices(cuda_device_index, self.ucx_net_devices)
-            if net_dev is not None:
-                spec["options"]["env"]["UCX_NET_DEVICES"] = net_dev
-                spec["options"]["config"]["distributed.comm.ucx"][
-                    "net-devices"
-                ] = net_dev
-
-            spec["options"]["interface"] = get_ucx_net_devices(
-                cuda_device_index,
-                self.ucx_net_devices,
-                get_openfabrics=False,
-                get_network=True,
-            )
 
         return {name: spec}

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -304,7 +304,6 @@ class LocalCUDACluster(LocalCluster):
             enable_nvlink=enable_nvlink,
             enable_infiniband=enable_infiniband,
             enable_rdmacm=enable_rdmacm,
-            cuda_device_index=0,
         )
 
         if worker_class is not None:

--- a/dask_cuda/tests/test_dgx.py
+++ b/dask_cuda/tests/test_dgx.py
@@ -1,20 +1,15 @@
 import multiprocessing as mp
 import os
-import subprocess
 from enum import Enum, auto
-from time import sleep
 
 import numpy
 import pytest
-from tornado.ioloop import IOLoop
 
 from dask import array as da
 from distributed import Client
-from distributed.utils import get_ip_interface
 
 from dask_cuda import LocalCUDACluster
 from dask_cuda.initialize import initialize
-from dask_cuda.utils import _ucx_110, _ucx_111, wait_workers
 
 mp = mp.get_context("spawn")  # type: ignore
 psutil = pytest.importorskip("psutil")
@@ -51,41 +46,6 @@ def _get_dgx_version():
         return DGXVersion.DGX_2
     elif "DGXA100" in dgx_name:
         return DGXVersion.DGX_A100
-
-
-def _get_dgx_net_devices():
-    if _get_dgx_version() == DGXVersion.DGX_1:
-        return [
-            "mlx5_0:1,ib0",
-            "mlx5_0:1,ib0",
-            "mlx5_1:1,ib1",
-            "mlx5_1:1,ib1",
-            "mlx5_2:1,ib2",
-            "mlx5_2:1,ib2",
-            "mlx5_3:1,ib3",
-            "mlx5_3:1,ib3",
-        ]
-    elif _get_dgx_version() == DGXVersion.DGX_2:
-        return [
-            "mlx5_0:1,ib0",
-            "mlx5_0:1,ib0",
-            "mlx5_1:1,ib1",
-            "mlx5_1:1,ib1",
-            "mlx5_2:1,ib2",
-            "mlx5_2:1,ib2",
-            "mlx5_3:1,ib3",
-            "mlx5_3:1,ib3",
-            "mlx5_6:1,ib4",
-            "mlx5_6:1,ib4",
-            "mlx5_7:1,ib5",
-            "mlx5_7:1,ib5",
-            "mlx5_8:1,ib6",
-            "mlx5_8:1,ib6",
-            "mlx5_9:1,ib7",
-            "mlx5_9:1,ib7",
-        ]
-    else:
-        return None
 
 
 if _get_dgx_version() is None:
@@ -127,11 +87,7 @@ def _test_tcp_over_ucx():
                 assert "TLS" in conf
                 assert "tcp" in conf["TLS"]
                 assert "cuda_copy" in conf["TLS"]
-                if _ucx_110:
-                    assert "tcp" in conf["SOCKADDR_TLS_PRIORITY"]
-                else:
-                    assert "sockcm" in conf["TLS"]
-                    assert "sockcm" in conf["SOCKADDR_TLS_PRIORITY"]
+                assert "tcp" in conf["SOCKADDR_TLS_PRIORITY"]
                 return True
 
             assert all(client.run(check_ucx_options).values())
@@ -165,39 +121,18 @@ def _test_ucx_infiniband_nvlink(enable_infiniband, enable_nvlink, enable_rdmacm)
     cupy = pytest.importorskip("cupy")
     ucp = pytest.importorskip("ucp")
 
-    net_devices = _get_dgx_net_devices()
-    openfabrics_devices = [d.split(",")[0] for d in net_devices]
-    ucx_net_devices = None
-
     if enable_infiniband is None and enable_nvlink is None and enable_rdmacm is None:
-        if _ucx_110 is False:
-            pytest.skip(
-                "Specifying transports is required on UCX < 1.10",
-                allow_module_level=True,
-            )
         enable_tcp_over_ucx = None
         cm_tls = ["all"]
         cm_tls_priority = ["rdmacm", "tcp", "sockcm"]
     else:
-        if enable_infiniband and not _ucx_110:
-            ucx_net_devices = "auto"
-
         enable_tcp_over_ucx = True
 
-        if _ucx_110 is True:
-            cm_tls = ["tcp"]
-            if enable_rdmacm is True:
-                cm_tls_priority = ["rdmacm"]
-            else:
-                cm_tls_priority = ["tcp"]
+        cm_tls = ["tcp"]
+        if enable_rdmacm is True:
+            cm_tls_priority = ["rdmacm"]
         else:
-            cm_tls = ["tcp"]
-            if enable_rdmacm is True:
-                cm_tls.append("rdmacm")
-                cm_tls_priority = ["rdmacm"]
-            else:
-                cm_tls.append("sockcm")
-                cm_tls_priority = ["sockcm"]
+            cm_tls_priority = ["tcp"]
 
     initialize(
         enable_tcp_over_ucx=enable_tcp_over_ucx,
@@ -212,7 +147,6 @@ def _test_ucx_infiniband_nvlink(enable_infiniband, enable_nvlink, enable_rdmacm)
         enable_infiniband=enable_infiniband,
         enable_nvlink=enable_nvlink,
         enable_rdmacm=enable_rdmacm,
-        ucx_net_devices=ucx_net_devices,
         rmm_pool_size="1 GiB",
     ) as cluster:
         with Client(cluster) as client:
@@ -234,15 +168,6 @@ def _test_ucx_infiniband_nvlink(enable_infiniband, enable_nvlink, enable_rdmacm)
                         assert "rc" in conf["TLS"]
                 return True
 
-            if ucx_net_devices == "auto":
-                assert all(
-                    [
-                        cluster.worker_spec[k]["options"]["env"]["UCX_NET_DEVICES"]
-                        == openfabrics_devices[k].split(",")[0]
-                        for k in cluster.worker_spec.keys()
-                    ]
-                )
-
             assert all(client.run(check_ucx_options).values())
 
 
@@ -263,14 +188,6 @@ def _test_ucx_infiniband_nvlink(enable_infiniband, enable_nvlink, enable_rdmacm)
 def test_ucx_infiniband_nvlink(params):
     ucp = pytest.importorskip("ucp")  # NOQA: F841
 
-    if (
-        not _ucx_111
-        and params["enable_infiniband"] is None
-        and params["enable_nvlink"] is None
-        and params["enable_rdmacm"] is None
-    ):
-        pytest.skip("Automatic configuration not supported in UCX < 1.11")
-
     if params["enable_infiniband"]:
         if not any([at.startswith("rc") for at in ucp.get_active_transports()]):
             pytest.skip("No support available for 'rc' transport in UCX")
@@ -290,129 +207,5 @@ def test_ucx_infiniband_nvlink(params):
     # has been used may cause UCX-Py to complain about being already initialized.
     if params["enable_rdmacm"] is True:
         ucp.reset()
-
-    assert not p.exitcode
-
-
-def _test_dask_cuda_worker_ucx_net_devices(enable_rdmacm):
-    loop = IOLoop.current()
-    ucp = pytest.importorskip("ucp")
-
-    cm_protocol = "rdmacm" if enable_rdmacm else "sockcm"
-    net_devices = _get_dgx_net_devices()
-    openfabrics_devices = [d.split(",")[0] for d in net_devices]
-
-    sched_addr = "127.0.0.1"
-
-    # Enable proper variables for scheduler
-    sched_env = os.environ.copy()
-    sched_env["DASK_DISTRIBUTED__COMM__UCX__INFINIBAND"] = "True"
-    sched_env["DASK_DISTRIBUTED__COMM__UCX__TCP"] = "True"
-    sched_env["DASK_DISTRIBUTED__COMM__UCX__CUDA_COPY"] = "True"
-    sched_env["DASK_DISTRIBUTED__COMM__UCX__NET_DEVICES"] = openfabrics_devices[0]
-
-    if enable_rdmacm:
-        sched_env["DASK_DISTRIBUTED__COMM__UCX__RDMACM"] = "True"
-        sched_addr = get_ip_interface("ib0")
-
-    sched_url = "ucx://" + sched_addr + ":9379"
-
-    # Enable proper variables for workers
-    worker_ucx_opts = [
-        "--enable-infiniband",
-        "--net-devices",
-        "auto",
-    ]
-    if enable_rdmacm:
-        worker_ucx_opts.append("--enable-rdmacm")
-
-    # Enable proper variables for client
-    initialize(
-        enable_tcp_over_ucx=True,
-        enable_infiniband=True,
-        enable_rdmacm=enable_rdmacm,
-        net_devices=openfabrics_devices[0],
-    )
-
-    with subprocess.Popen(
-        [
-            "dask-scheduler",
-            "--protocol",
-            "ucx",
-            "--host",
-            sched_addr,
-            "--port",
-            "9379",
-            "--no-dashboard",
-        ],
-        env=sched_env,
-    ) as sched_proc:
-        # Scheduler with UCX will take a few seconds to fully start
-        sleep(5)
-
-        with subprocess.Popen(
-            ["dask-cuda-worker", sched_url, "--no-dashboard",] + worker_ucx_opts
-        ) as worker_proc:
-            with Client(sched_url, loop=loop) as client:
-
-                def _timeout_callback():
-                    # We must ensure processes are terminated to avoid hangs
-                    # if a timeout occurs
-                    worker_proc.kill()
-                    sched_proc.kill()
-
-                assert wait_workers(client, timeout_callback=_timeout_callback)
-
-                workers_tls = client.run(lambda: ucp.get_config()["TLS"])
-                workers_tls_priority = client.run(
-                    lambda: ucp.get_config()["SOCKADDR_TLS_PRIORITY"]
-                )
-                for tls, tls_priority in zip(
-                    workers_tls.values(), workers_tls_priority.values()
-                ):
-                    assert cm_protocol in tls
-                    assert cm_protocol in tls_priority
-                worker_net_devices = client.run(lambda: ucp.get_config()["NET_DEVICES"])
-                cuda_visible_devices = client.run(
-                    lambda: os.environ["CUDA_VISIBLE_DEVICES"]
-                )
-
-                for i, v in enumerate(
-                    zip(worker_net_devices.values(), cuda_visible_devices.values())
-                ):
-                    net_dev = v[0]
-                    dev_idx = int(v[1].split(",")[0])
-                    assert net_dev == openfabrics_devices[dev_idx]
-
-            # A dask-worker with UCX protocol will not close until some work
-            # is dispatched, therefore we kill the worker and scheduler to
-            # ensure timely closing.
-            worker_proc.kill()
-            sched_proc.kill()
-
-
-@pytest.mark.parametrize("enable_rdmacm", [False, True])
-@pytest.mark.skipif(
-    _get_dgx_version() == DGXVersion.DGX_A100,
-    reason="Automatic InfiniBand device detection Unsupported for %s" % _get_dgx_name(),
-)
-def test_dask_cuda_worker_ucx_net_devices(enable_rdmacm):
-    ucp = pytest.importorskip("ucp")  # NOQA: F841
-
-    if _ucx_110:
-        pytest.skip("UCX 1.10 and higher should rely on default UCX_NET_DEVICES")
-
-    if not any([at.startswith("rc") for at in ucp.get_active_transports()]):
-        pytest.skip("No support available for 'rc' transport in UCX")
-
-    p = mp.Process(
-        target=_test_dask_cuda_worker_ucx_net_devices, args=(enable_rdmacm,),
-    )
-    p.start()
-    p.join()
-
-    # The processes may be killed in the test, preventing UCX-Py from cleaning
-    # up all objects. Reset to prevent issues on tests running after.
-    ucp.reset()
 
     assert not p.exitcode

--- a/dask_cuda/tests/test_utils.py
+++ b/dask_cuda/tests/test_utils.py
@@ -7,7 +7,6 @@ from numba import cuda
 from dask.config import canonical_name
 
 from dask_cuda.utils import (
-    _ucx_111,
     cuda_visible_devices,
     get_cpu_affinity,
     get_device_total_memory,
@@ -15,7 +14,6 @@ from dask_cuda.utils import (
     get_n_gpus,
     get_preload_options,
     get_ucx_config,
-    get_ucx_net_devices,
     nvml_device_index,
     parse_cuda_visible_device,
     parse_device_memory_limit,
@@ -93,15 +91,10 @@ def test_get_preload_options_default():
 
 
 @pytest.mark.parametrize("enable_tcp", [True, False])
-@pytest.mark.parametrize(
-    "enable_infiniband_netdev",
-    [(True, lambda i: "mlx5_%d:1" % (i // 2)), (True, "eth0"), (True, ""), (False, "")],
-)
+@pytest.mark.parametrize("enable_infiniband", [True, False])
 @pytest.mark.parametrize("enable_nvlink", [True, False])
-def test_get_preload_options(enable_tcp, enable_infiniband_netdev, enable_nvlink):
+def test_get_preload_options(enable_tcp, enable_infiniband, enable_nvlink):
     pytest.importorskip("ucp")
-
-    enable_infiniband, net_devices = enable_infiniband_netdev
 
     opts = get_preload_options(
         protocol="ucx",
@@ -109,8 +102,6 @@ def test_get_preload_options(enable_tcp, enable_infiniband_netdev, enable_nvlink
         enable_tcp_over_ucx=enable_tcp,
         enable_infiniband=enable_infiniband,
         enable_nvlink=enable_nvlink,
-        ucx_net_devices=net_devices,
-        cuda_device_index=5,
     )
 
     assert "preload" in opts
@@ -122,76 +113,22 @@ def test_get_preload_options(enable_tcp, enable_infiniband_netdev, enable_nvlink
         assert "--enable-tcp-over-ucx" in opts["preload_argv"]
     if enable_infiniband:
         assert "--enable-infiniband" in opts["preload_argv"]
-        if callable(net_devices):
-            dev = net_devices(5)
-            assert str("--net-devices=" + dev) in opts["preload_argv"]
-        elif isinstance(net_devices, str) and net_devices != "":
-            assert str("--net-devices=" + net_devices) in opts["preload_argv"]
     if enable_nvlink:
         assert "--enable-nvlink" in opts["preload_argv"]
-
-
-@pytest.mark.skipif(
-    _ucx_111, reason="`ucx_net_devices='auto'` is deprecated for UCX >= 1.11.0",
-)
-def test_get_ucx_net_devices_raises():
-    pytest.importorskip("ucp")
-
-    with pytest.raises(ValueError):
-        get_ucx_net_devices(None, "auto")
-
-
-def test_get_ucx_net_devices_callable():
-    pytest.importorskip("ucp")
-
-    net_devices = [
-        "mlx5_0:1",
-        "mlx5_0:1",
-        "mlx5_1:1",
-        "mlx5_1:1",
-        "mlx5_2:1",
-        "mlx5_2:1",
-        "mlx5_3:1",
-        "mlx5_3:1",
-    ]
-
-    for idx in range(8):
-        dev = get_ucx_net_devices(idx, lambda i: "mlx5_%d:1" % (i // 2))
-        assert dev == net_devices[idx]
-
-
-def test_get_ucx_net_devices_auto():
-    pytest.importorskip("ucp")
-
-    for idx in range(get_n_gpus()):
-        # Since the actual device is system-dependent, we just check that
-        # this function call doesn't fail. If any InfiniBand devices are
-        # available, it will return that, otherwise an empty string.
-        get_ucx_net_devices(idx, "auto")
 
 
 @pytest.mark.parametrize("enable_tcp_over_ucx", [True, False, None])
 @pytest.mark.parametrize("enable_nvlink", [True, False, None])
 @pytest.mark.parametrize("enable_infiniband", [True, False, None])
-@pytest.mark.parametrize("net_devices", ["eth0", "auto", ""])
-def test_get_ucx_config(
-    enable_tcp_over_ucx, enable_infiniband, enable_nvlink, net_devices
-):
+def test_get_ucx_config(enable_tcp_over_ucx, enable_infiniband, enable_nvlink):
     pytest.importorskip("ucp")
 
     kwargs = {
         "enable_tcp_over_ucx": enable_tcp_over_ucx,
         "enable_infiniband": enable_infiniband,
         "enable_nvlink": enable_nvlink,
-        "net_devices": net_devices,
-        "cuda_device_index": 0,
     }
-    if net_devices == "auto" and enable_infiniband is False:
-        with pytest.raises(ValueError):
-            get_ucx_config(**kwargs)
-        return
-    else:
-        ucx_config = get_ucx_config(**kwargs)
+    ucx_config = get_ucx_config(**kwargs)
 
     assert ucx_config[canonical_name("create_cuda_context", ucx_config)] is True
 
@@ -240,16 +177,6 @@ def test_get_ucx_config(
         assert ucx_config[canonical_name("cuda-copy", ucx_config)] is True
     else:
         assert ucx_config[canonical_name("cuda-copy", ucx_config)] is None
-
-    if net_devices == "auto":
-        # Since the actual device is system-dependent, we don't do any
-        # checks at the moment. If any InfiniBand devices are available,
-        # that will be the value of "net-devices", otherwise an empty string.
-        pass
-    elif net_devices == "eth0":
-        assert ucx_config[canonical_name("net-devices", ucx_config)] == "eth0"
-    else:
-        assert ucx_config[canonical_name("net-devices", ucx_config)] is None
 
 
 def test_parse_visible_devices():

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -26,16 +26,6 @@ except ImportError:
         yield
 
 
-try:
-    import ucp
-
-    _ucx_110 = ucp.get_ucx_version() >= (1, 10, 0)
-    _ucx_111 = ucp.get_ucx_version() >= (1, 11, 0)
-except ImportError:
-    _ucx_110 = False
-    _ucx_111 = False
-
-
 class CPUAffinity:
     def __init__(self, cores):
         self.cores = cores
@@ -258,66 +248,16 @@ def get_device_total_memory(index=0):
     return pynvml.nvmlDeviceGetMemoryInfo(handle).total
 
 
-def get_ucx_net_devices(
-    cuda_device_index, ucx_net_devices, get_openfabrics=True, get_network=False
-):
-    if _ucx_111 and ucx_net_devices == "auto":
-        return None
-
-    if cuda_device_index is None and (
-        callable(ucx_net_devices) or ucx_net_devices == "auto"
-    ):
-        raise ValueError(
-            "A CUDA device index must be specified if the "
-            "ucx_net_devices variable is either callable or 'auto'"
-        )
-    elif cuda_device_index is not None:
-        dev = int(cuda_device_index)
-
-    net_dev = None
-    if callable(ucx_net_devices):
-        net_dev = ucx_net_devices(int(cuda_device_index))
-    elif isinstance(ucx_net_devices, str):
-        if ucx_net_devices == "auto":
-            # If TopologicalDistance from ucp is available, we set the UCX
-            # net device to the closest network device explicitly.
-            from ucp._libs.topological_distance import TopologicalDistance
-
-            net_dev = ""
-            td = TopologicalDistance()
-            if get_openfabrics:
-                ibs = td.get_cuda_distances_from_device_index(dev, "openfabrics")
-                if len(ibs) > 0:
-                    net_dev += ibs[0]["name"] + ":1"
-            if get_network:
-                ifnames = td.get_cuda_distances_from_device_index(dev, "network")
-                if len(ifnames) > 0:
-                    if len(net_dev) > 0:
-                        net_dev += ","
-                    net_dev += ifnames[0]["name"]
-        else:
-            net_dev = ucx_net_devices
-    return net_dev
-
-
 def get_ucx_config(
     enable_tcp_over_ucx=None,
     enable_infiniband=None,
     enable_nvlink=None,
     enable_rdmacm=None,
-    net_devices=None,
-    cuda_device_index=None,
 ):
-    if net_devices == "auto" and enable_infiniband is False:
-        raise ValueError(
-            "Using ucx_net_devices='auto' is currently only "
-            "supported when enable_infiniband=True."
-        )
-
     ucx_config = dask.config.get("distributed.comm.ucx")
 
     ucx_config[canonical_name("create-cuda-context", ucx_config)] = True
-    ucx_config[canonical_name("reuse-endpoints", ucx_config)] = not _ucx_111
+    ucx_config[canonical_name("reuse-endpoints", ucx_config)] = False
 
     # If any transport is explicitly disabled (`False`) by the user, others that
     # are not specified should be enabled (`True`). If transports are explicitly
@@ -346,10 +286,6 @@ def get_ucx_config(
     else:
         ucx_config[canonical_name("cuda-copy", ucx_config)] = None
 
-    if net_devices is not None and net_devices != "":
-        ucx_config[canonical_name("net-devices", ucx_config)] = get_ucx_net_devices(
-            cuda_device_index, net_devices
-        )
     return ucx_config
 
 
@@ -360,8 +296,6 @@ def get_preload_options(
     enable_infiniband=None,
     enable_nvlink=None,
     enable_rdmacm=None,
-    ucx_net_devices="",
-    cuda_device_index=0,
 ):
     """
     Return a dictionary with the preload and preload_argv options required to
@@ -371,7 +305,7 @@ def get_preload_options(
     ----------
     protocol: None or str, default None
         If "ucx", options related to UCX (enable_tcp_over_ucx, enable_infiniband,
-        enable_nvlink and ucx_net_devices) are added to preload_argv.
+        enable_nvlink) are added to preload_argv.
     create_cuda_context: bool, default None
         Ensure the CUDA context gets created at initialization, generally
         needed by Dask workers.
@@ -387,26 +321,18 @@ def get_preload_options(
     enable_nvlink: bool, default None
         Set environment variables to enable UCX NVLink support. Implies
         enable_tcp=True.
-    ucx_net_devices: str or callable, default ""
-        A string with the interface name to be used for all devices (empty
-        string means use default), or a callable function taking an integer
-        identifying the GPU index.
-    cuda_device_index: int, default 0
-        The index identifying the CUDA device used by this worker, only used
-        when ucx_net_devices is callable.
 
     Example
     -------
     >>> from dask_cuda.utils import get_preload_options
     >>> get_preload_options()
     {'preload': ['dask_cuda.initialize'], 'preload_argv': []}
-    >>> get_preload_options(protocol="ucx", create_cuda_context=True,
-    ...                     enable_infiniband=True, cuda_device_index=5,
-    ...                     ucx_net_devices=lambda i: "mlx5_%d:1" % (i // 2))
+    >>> get_preload_options(protocol="ucx",
+    ...                     create_cuda_context=True,
+    ...                     enable_infiniband=True)
     {'preload': ['dask_cuda.initialize'],
      'preload_argv': ['--create-cuda-context',
-      '--enable-infiniband',
-      '--net-devices=mlx5_2:1']}
+      '--enable-infiniband']}
     """
     preload_options = {"preload": ["dask_cuda.initialize"], "preload_argv": []}
 
@@ -423,9 +349,6 @@ def get_preload_options(
             initialize_ucx_argv.append("--enable-rdmacm")
         if enable_nvlink:
             initialize_ucx_argv.append("--enable-nvlink")
-        if ucx_net_devices is not None and ucx_net_devices != "":
-            net_dev = get_ucx_net_devices(cuda_device_index, ucx_net_devices)
-            initialize_ucx_argv.append("--net-devices=%s" % net_dev)
 
         preload_options["preload_argv"].extend(initialize_ucx_argv)
 

--- a/dask_cuda/worker_spec.py
+++ b/dask_cuda/worker_spec.py
@@ -17,7 +17,6 @@ def worker_spec(
     CUDA_VISIBLE_DEVICES=None,
     enable_tcp_over_ucx=False,
     enable_infiniband=False,
-    ucx_net_devices="",
     enable_nvlink=False,
     **kwargs
 ):
@@ -47,10 +46,6 @@ def worker_spec(
     enable_infiniband: bool
         Set environment variables to enable UCX InfiniBand support. Implies
         enable_tcp_over_ucx=True.
-    ucx_net_device: str or callable
-        A string with the interface name to be used for all devices (empty
-        string means use default), or a callable function taking an integer
-        identifying the GPU index.
     enable_nvlink: bool
         Set environment variables to enable UCX NVLink support. Implies
         enable_tcp_over_ucx=True.
@@ -58,8 +53,7 @@ def worker_spec(
     Examples
     --------
     >>> from dask_cuda.worker_spec import worker_spec
-    >>> worker_spec(interface="enp1s0f0", CUDA_VISIBLE_DEVICES=[0, 2],
-                    ucx_net_devices=lambda i: "mlx5_%d:1" % (i //2))
+    >>> worker_spec(interface="enp1s0f0", CUDA_VISIBLE_DEVICES=[0, 2])
     {0: {'cls': distributed.nanny.Nanny,
       'options': {'env': {'CUDA_VISIBLE_DEVICES': '0,2'},
        'interface': 'enp1s0f0',
@@ -128,9 +122,4 @@ def worker_spec(
                 "preload_argv": "--create-cuda-context",
             },
         }
-        if ucx_net_devices is not None or ucx_net_devices != "":
-            if callable(ucx_net_devices):
-                spec[dev]["options"]["env"]["UCX_NET_DEVICES"] = ucx_net_devices(dev)
-            else:
-                spec[dev]["options"]["env"]["UCX_NET_DEVICES"] = ucx_net_devices
     return spec

--- a/docs/source/examples/ucx.rst
+++ b/docs/source/examples/ucx.rst
@@ -48,9 +48,6 @@ To connect a client to a cluster with all supported transports and an RMM pool:
     )
     client = Client(cluster)
 
-.. note::
-    For UCX 1.9 (deprecated) and older, it's necessary to pass ``ucx_net_devices="auto"`` to ``LocalCUDACluster``. UCX 1.11 and above is capable of selecting InfiniBand devices automatically.
-
 dask-cuda-worker with Automatic Configuration
 ------------------------------------------
 
@@ -148,9 +145,6 @@ To start a Dask scheduler using UCX with all supported transports and an gigabyt
 
 We communicate to the scheduler that we will be using UCX with the ``--protocol`` option, and that we will be using InfiniBand with the ``--interface`` option.
 
-.. note::
-    For UCX 1.9 (deprecated) and older it's also necessary to set ``DASK_DISTRIBUTED__COMM__UCX__NET_DEVICES=mlx5_0:1``, where ``"mlx5_0:1"`` is our UCX net device; because the scheduler does not rely upon Dask-CUDA, it cannot automatically detect InfiniBand interfaces, so we must specify one explicitly. UCX 1.11 and above is capable of selecting InfiniBand devices automatically.
-
 Workers
 ^^^^^^^
 
@@ -165,9 +159,6 @@ To start a cluster with all supported transports and an RMM pool:
     > --enable-infiniband \
     > --enable-rdmacm \
     > --rmm-pool-size="1GB"
-
-.. note::
-    For UCX 1.9 (deprecated) and older it's also necessary to set ``--net-devices="auto"``. UCX 1.11 and above is capable of selecting InfiniBand devices automatically.
 
 Client
 ^^^^^^
@@ -187,6 +178,3 @@ To connect a client to the cluster we have made:
         enable_rdmacm=True,
     )
     client = Client("ucx://<scheduler_address>:8786")
-
-.. note::
-    For UCX 1.9 (deprecated) and older it's also necessary to set ``net_devices="mlx5_0:1"``, where ``"mlx5_0:1"`` is our UCX net device; because the client does not rely upon Dask-CUDA, it cannot automatically detect InfiniBand interfaces, so we must specify one explicitly. UCX 1.11 and above is capable of selecting InfiniBand devices automatically.

--- a/docs/source/ucx.rst
+++ b/docs/source/ucx.rst
@@ -62,21 +62,6 @@ However, some will affect related libraries, such as RMM:
   Replaces ``sockcm`` with ``rdmacm`` in ``UCX_SOCKADDR_TLS_PRIORITY``, enabling remote direct memory access (RDMA) for InfiniBand transfers.
   This is recommended by UCX for use with InfiniBand, and will not work if InfiniBand is disabled.
 
-- ``distributed.comm.ucx.net-devices: <str>`` -- **recommended for UCX 1.9 and older.**
-
-  Explicitly sets ``UCX_NET_DEVICES`` instead of defaulting to ``"all"``, which can result in suboptimal performance.
-  If using InfiniBand, set to ``"auto"`` to automatically detect the InfiniBand interface closest to each GPU on UCX 1.9 and below.
-  If InfiniBand is disabled, set to a UCX-compatible ethernet interface, e.g. ``"enp1s0f0"`` on a DGX-1.
-  All available UCX-compatible interfaces can be listed by running ``ucx_info -d``.
-
-  UCX 1.11 and above is capable of identifying closest interfaces without setting ``"auto"`` (**deprecated for UCX 1.11 and above**), it is recommended not to set ``ucx.net-devices`` in most cases. However, some recommendations for optimal performance apply, see the documentation on ``ucx.infiniband`` above fore details.
-
-  .. warning::
-      Setting ``ucx.net-devices: "auto"`` assumes that all InfiniBand interfaces on the system are connected and properly configured; undefined behavior may occur otherwise.
-      **``ucx.net-devices: "auto"`` is *DEPRECATED* for UCX 1.11 and above.**
-
-
-
 - ``distributed.rmm.pool-size: <str|int>`` -- **recommended.**
 
   Allocates an RMM pool of the specified size for the process; size can be provided with an integer number of bytes or in human readable format, e.g. ``"4GB"``.

--- a/examples/ucx/client_initialize.py
+++ b/examples/ucx/client_initialize.py
@@ -21,16 +21,14 @@ from dask_cuda.initialize import initialize
     default=False,
     help="Enable InfiniBand communication with RDMA",
 )
+@click.option(
+    "--enable-rdmacm/--disable-rdmacm",
+    default=False,
+    help="Enable RDMA connection manager, requires --enable-infiniband",
+)
 def main(
-    address, enable_nvlink, enable_infiniband,
+    address, enable_nvlink, enable_infiniband, enable_rdmacm,
 ):
-
-    enable_rdmacm = False
-    ucx_net_devices = None
-
-    if enable_infiniband:
-        # enable_rdmacm = True  # RDMACM not working right now
-        ucx_net_devices = "mlx5_0:1"
 
     # set up environment
     initialize(
@@ -38,7 +36,6 @@ def main(
         enable_nvlink=enable_nvlink,
         enable_infiniband=enable_infiniband,
         enable_rdmacm=enable_rdmacm,
-        net_devices=ucx_net_devices,
     )
 
     # initialize client

--- a/examples/ucx/local_cuda_cluster.py
+++ b/examples/ucx/local_cuda_cluster.py
@@ -20,6 +20,11 @@ from dask_cuda import LocalCUDACluster
     help="Enable InfiniBand communication with RDMA",
 )
 @click.option(
+    "--enable-rdmacm/--disable-rdmacm",
+    default=False,
+    help="Enable RDMA connection manager, requires --enable-infiniband",
+)
+@click.option(
     "--interface",
     default=None,
     type=str,
@@ -35,15 +40,8 @@ from dask_cuda import LocalCUDACluster
     "an integer (bytes) or string (like 5GB or 5000M).",
 )
 def main(
-    enable_nvlink, enable_infiniband, interface, rmm_pool_size,
+    enable_nvlink, enable_infiniband, enable_rdmacm, interface, rmm_pool_size,
 ):
-
-    enable_rdmacm = False
-    ucx_net_devices = None
-
-    if enable_infiniband:
-        # enable_rdmacm = True  # RDMACM not working right now
-        ucx_net_devices = "auto"
 
     if (enable_infiniband or enable_nvlink) and not interface:
         raise ValueError(
@@ -56,7 +54,6 @@ def main(
         enable_nvlink=enable_nvlink,
         enable_infiniband=enable_infiniband,
         enable_rdmacm=enable_rdmacm,
-        ucx_net_devices=ucx_net_devices,
         interface=interface,
         rmm_pool_size=rmm_pool_size,
     )

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,5 +3,4 @@ filterwarnings =
     error::DeprecationWarning
     error::FutureWarning
     ignore::DeprecationWarning:pkg_resources
-    ignore:Support for UCX 1.9.0 is deprecated.*:FutureWarning:ucp
     ignore:distutils Version classes are deprecated.*:DeprecationWarning:


### PR DESCRIPTION
And about another ~500 fewer lines of fun here too.

Preparing for UCX-Py complete drop of UCX < 1.11.1 in https://github.com/rapidsai/ucx-py/pull/829.