### PR TITLE
Add option to track RMM allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,50 @@
 
 Please see https://github.com/rapidsai/dask-cuda/releases/tag/v22.02.00a for the latest changes to this development branch.
 
-# dask-cuda 21.12.00 (Date TBD)
+# dask-cuda 21.12.00 (9 Dec 2021)
 
-Please see https://github.com/rapidsai/dask-cuda/releases/tag/v21.12.00a for the latest changes to this development branch.
+## 🐛 Bug Fixes
+
+- Remove automatic `doc` labeler ([#807](https://github.com/rapidsai/dask-cuda/pull/807)) [@pentschev](https://github.com/pentschev)
+- Add create_cuda_context UCX config from Distributed ([#801](https://github.com/rapidsai/dask-cuda/pull/801)) [@pentschev](https://github.com/pentschev)
+- Ignore deprecation warnings from pkg_resources ([#784](https://github.com/rapidsai/dask-cuda/pull/784)) [@pentschev](https://github.com/pentschev)
+- Fix parsing of device by UUID ([#780](https://github.com/rapidsai/dask-cuda/pull/780)) [@pentschev](https://github.com/pentschev)
+- Avoid creating CUDA context in LocalCUDACluster parent process ([#765](https://github.com/rapidsai/dask-cuda/pull/765)) [@pentschev](https://github.com/pentschev)
+- Remove gen_cluster spill tests ([#758](https://github.com/rapidsai/dask-cuda/pull/758)) [@pentschev](https://github.com/pentschev)
+- Update memory_pause_fraction in test_spill ([#757](https://github.com/rapidsai/dask-cuda/pull/757)) [@pentschev](https://github.com/pentschev)
+
+## 📖 Documentation
+
+- Add troubleshooting page with PCI Bus ID issue description ([#777](https://github.com/rapidsai/dask-cuda/pull/777)) [@pentschev](https://github.com/pentschev)
+
+## 🚀 New Features
+
+- Handle UCX-Py FutureWarning on UCX &lt; 1.11.1 deprecation ([#799](https://github.com/rapidsai/dask-cuda/pull/799)) [@pentschev](https://github.com/pentschev)
+- Pin max `dask` &amp; `distributed` versions ([#794](https://github.com/rapidsai/dask-cuda/pull/794)) [@galipremsagar](https://github.com/galipremsagar)
+- Update to UCX-Py 0.23 ([#752](https://github.com/rapidsai/dask-cuda/pull/752)) [@pentschev](https://github.com/pentschev)
+
+## 🛠️ Improvements
+
+- Fix spill-to-disk triggered by Dask explicitly ([#800](https://github.com/rapidsai/dask-cuda/pull/800)) [@madsbk](https://github.com/madsbk)
+- Fix Changelog Merge Conflicts for `branch-21.12` ([#797](https://github.com/rapidsai/dask-cuda/pull/797)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Use unittest.mock.patch for all os.environ tests ([#787](https://github.com/rapidsai/dask-cuda/pull/787)) [@pentschev](https://github.com/pentschev)
+- Logging when RMM allocation fails ([#782](https://github.com/rapidsai/dask-cuda/pull/782)) [@madsbk](https://github.com/madsbk)
+- Tally IDs instead of device buffers directly ([#779](https://github.com/rapidsai/dask-cuda/pull/779)) [@madsbk](https://github.com/madsbk)
+- Avoid proxy object aliasing ([#775](https://github.com/rapidsai/dask-cuda/pull/775)) [@madsbk](https://github.com/madsbk)
+- Test of sizeof proxy object ([#774](https://github.com/rapidsai/dask-cuda/pull/774)) [@madsbk](https://github.com/madsbk)
+- gc.collect when spilling on demand ([#771](https://github.com/rapidsai/dask-cuda/pull/771)) [@madsbk](https://github.com/madsbk)
+- Reenable explicit comms tests ([#770](https://github.com/rapidsai/dask-cuda/pull/770)) [@madsbk](https://github.com/madsbk)
+- Simplify JIT-unspill and writing docs ([#768](https://github.com/rapidsai/dask-cuda/pull/768)) [@madsbk](https://github.com/madsbk)
+- Increase CUDAWorker close timeout ([#764](https://github.com/rapidsai/dask-cuda/pull/764)) [@pentschev](https://github.com/pentschev)
+- Ignore known but expected test warnings ([#759](https://github.com/rapidsai/dask-cuda/pull/759)) [@pentschev](https://github.com/pentschev)
+- Spilling on demand ([#756](https://github.com/rapidsai/dask-cuda/pull/756)) [@madsbk](https://github.com/madsbk)
+- Revert &quot;Temporarily skipping some tests because of a bug in Dask ([#753)&quot; (#754](https://github.com/rapidsai/dask-cuda/pull/753)&quot; (#754)) [@madsbk](https://github.com/madsbk)
+- Temporarily skipping some tests because of a bug in Dask ([#753](https://github.com/rapidsai/dask-cuda/pull/753)) [@madsbk](https://github.com/madsbk)
+- Removing the `FrameProxyObject` workaround ([#751](https://github.com/rapidsai/dask-cuda/pull/751)) [@madsbk](https://github.com/madsbk)
+- Use cuDF Frame instead of Table ([#748](https://github.com/rapidsai/dask-cuda/pull/748)) [@madsbk](https://github.com/madsbk)
+- Remove proxy object locks ([#747](https://github.com/rapidsai/dask-cuda/pull/747)) [@madsbk](https://github.com/madsbk)
+- Unpin `dask` &amp; `distributed` in CI ([#742](https://github.com/rapidsai/dask-cuda/pull/742)) [@galipremsagar](https://github.com/galipremsagar)
+- Update SSHCluster usage in benchmarks with new CUDAWorker ([#326](https://github.com/rapidsai/dask-cuda/pull/326)) [@pentschev](https://github.com/pentschev)
 
 # dask-cuda 21.10.00 (7 Oct 2021)
 

--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -120,6 +120,13 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
         are specified.""",
 )
 @click.option(
+    "--rmm-track-allocations",
+    default=False,
+    help="""Track memory allocations made by RMM. If ``True``, wraps the memory
+    resource of each worker with a ``rmm.mr.TrackingResourceAdaptor`` that
+    allows querying the amount of memory allocated by RMM."""
+)
+@click.option(
     "--pid-file", type=str, default="", help="File to write the process PID.",
 )
 @click.option(
@@ -293,6 +300,7 @@ def main(
     rmm_managed_memory,
     rmm_async,
     rmm_log_directory,
+    rmm_track_allocations,
     pid_file,
     resources,
     dashboard,
@@ -344,6 +352,7 @@ def main(
         rmm_managed_memory,
         rmm_async,
         rmm_log_directory,
+        rmm_track_allocations,
         pid_file,
         resources,
         dashboard,

--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -120,8 +120,9 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
         are specified.""",
 )
 @click.option(
-    "--rmm-track-allocations",
+    "--rmm-track-allocations/--no-rmm-track-allocations",
     default=False,
+    show_default=True,
     help="""Track memory allocations made by RMM. If ``True``, wraps the memory
     resource of each worker with a ``rmm.mr.TrackingResourceAdaptor`` that
     allows querying the amount of memory allocated by RMM."""

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -62,6 +62,7 @@ class CUDAWorker(Server):
         rmm_managed_memory=False,
         rmm_async=False,
         rmm_log_directory=None,
+        rmm_track_allocations=False,
         pid_file=None,
         resources=None,
         dashboard=True,
@@ -248,6 +249,7 @@ class CUDAWorker(Server):
                         rmm_managed_memory,
                         rmm_async,
                         rmm_log_directory,
+                        rmm_track_allocations
                     ),
                 },
                 name=name if nprocs == 1 or name is None else str(name) + "-" + str(i),

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -210,6 +210,7 @@ class LocalCUDACluster(LocalCluster):
         rmm_managed_memory=False,
         rmm_async=False,
         rmm_log_directory=None,
+        rmm_track_allocations=False,
         jit_unspill=None,
         log_spilling=False,
         worker_class=None,
@@ -272,6 +273,7 @@ class LocalCUDACluster(LocalCluster):
                 )
 
         self.rmm_log_directory = rmm_log_directory
+        self.rmm_track_allocations = rmm_track_allocations
 
         if not kwargs.pop("processes", True):
             raise ValueError(
@@ -415,6 +417,7 @@ class LocalCUDACluster(LocalCluster):
                         self.rmm_managed_memory,
                         self.rmm_async,
                         self.rmm_log_directory,
+                        self.rmm_track_allocations
                     ),
                 },
             }

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -152,6 +152,16 @@ class LocalCUDACluster(LocalCluster):
         .. note::
             Logging will only be enabled if ``rmm_pool_size`` is specified or
             ``rmm_managed_memory=True``.
+    rmm_track_allocations : bool, default False
+        If True, wraps the memory resource used by each worker with a
+        ``rmm.mr.TrackingResourceAdaptor``, which tracks the amount of
+        memory allocated.
+
+        .. note::
+             This option enables additional diagnostics to be collected and
+             reported by the Dask dashboard. However, there is significant overhead
+             associated with this and it should only be used for debugging and
+             memory profiling.
     jit_unspill : bool or None, default None
         Enable just-in-time unspilling. Can be a boolean or ``None`` to fall back on
         the value of ``dask.jit-unspill`` in the local Dask configuration, disabling

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -254,7 +254,7 @@ def test_cuda_visible_devices_uuid(loop):  # noqa: F811
                     result = client.run(lambda: os.environ["CUDA_VISIBLE_DEVICES"])
                     assert list(result.values())[0] == gpu_uuid
 
-                    
+
 def test_rmm_track_allocations(loop):  # noqa: F811
     rmm = pytest.importorskip("rmm")
     with popen(["dask-scheduler", "--port", "9369", "--no-dashboard"]):

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -267,7 +267,7 @@ def test_rmm_track_allocations(loop):  # noqa: F811
                 "--rmm-pool-size",
                 "2 GB",
                 "--no-dashboard",
-                "--rmm-track-allocations"
+                "--rmm-track-allocations",
             ]
         ):
             with Client("127.0.0.1:9369", loop=loop) as client:

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -253,3 +253,34 @@ def test_cuda_visible_devices_uuid(loop):  # noqa: F811
 
                     result = client.run(lambda: os.environ["CUDA_VISIBLE_DEVICES"])
                     assert list(result.values())[0] == gpu_uuid
+
+                    
+def test_rmm_track_allocations(loop):  # noqa: F811
+    rmm = pytest.importorskip("rmm")
+    with popen(["dask-scheduler", "--port", "9369", "--no-dashboard"]):
+        with popen(
+            [
+                "dask-cuda-worker",
+                "127.0.0.1:9369",
+                "--host",
+                "127.0.0.1",
+                "--rmm-pool-size",
+                "2 GB",
+                "--no-dashboard",
+                "--rmm-track-allocations"
+            ]
+        ):
+            with Client("127.0.0.1:9369", loop=loop) as client:
+                assert wait_workers(client, n_gpus=get_n_gpus())
+
+                memory_resource_type = client.run(
+                    rmm.mr.get_current_device_resource_type
+                )
+                for v in memory_resource_type.values():
+                    assert v is rmm.mr.TrackingResourceAdaptor
+
+                memory_resource_upstream_type = client.run(
+                    lambda: type(rmm.mr.get_current_device_resource().upstream_mr)
+                )
+                for v in memory_resource_upstream_type.values():
+                    assert v is rmm.mr.PoolMemoryResource

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -294,7 +294,9 @@ async def test_gpu_uuid():
 @gen_test(timeout=20)
 async def test_rmm_track_allocations():
     rmm = pytest.importorskip("rmm")
-    async with LocalCUDACluster(rmm_pool_size="2GB", asynchronous=True, rmm_track_allocations=True) as cluster:
+    async with LocalCUDACluster(
+        rmm_pool_size="2GB", asynchronous=True, rmm_track_allocations=True
+    ) as cluster:
         async with Client(cluster, asynchronous=True) as client:
             memory_resource_type = await client.run(
                 rmm.mr.get_current_device_resource_type

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -255,3 +255,21 @@ async def test_gpu_uuid():
 
             result = await client.run(lambda: os.environ["CUDA_VISIBLE_DEVICES"])
             assert list(result.values())[0] == gpu_uuid
+
+
+@gen_test(timeout=20)
+async def test_rmm_track_allocations():
+    rmm = pytest.importorskip("rmm")
+    async with LocalCUDACluster(rmm_pool_size="2GB", asynchronous=True, rmm_track_allocations=True) as cluster:
+        async with Client(cluster, asynchronous=True) as client:
+            memory_resource_type = await client.run(
+                rmm.mr.get_current_device_resource_type
+            )
+            for v in memory_resource_type.values():
+                assert v is rmm.mr.TrackingResourceAdaptor
+
+            memory_resource_upstream_type = await client.run(
+                lambda: type(rmm.mr.get_current_device_resource().upstream_mr)
+            )
+            for v in memory_resource_upstream_type.values():
+                assert v is rmm.mr.PoolMemoryResource

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -61,6 +61,7 @@ class RMMSetup:
 
     def setup(self, worker=None):
         if self.async_alloc:
+            import rmm
 
             rmm.mr.set_current_device_resource(rmm.mr.CudaAsyncMemoryResource())
             if self.logging:
@@ -70,6 +71,7 @@ class RMMSetup:
                     )
                 )
         elif self.initial_pool_size is not None or self.managed_memory:
+            import rmm
 
             pool_allocator = False if self.initial_pool_size is None else True
 

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -60,8 +60,6 @@ class RMMSetup:
         self.rmm_track_allocations = track_allocations
 
     def setup(self, worker=None):
-        import rmm
-
         if self.async_alloc:
 
             rmm.mr.set_current_device_resource(rmm.mr.CudaAsyncMemoryResource())

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -25,8 +25,6 @@ except ImportError:
     def nvtx_annotate(message=None, color="blue", domain=None):
         yield
 
-import rmm
-
 
 try:
     import ucp

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -84,6 +84,8 @@ class RMMSetup:
                 ),
             )
         if self.rmm_track_allocations:
+            import rmm
+
             mr = rmm.mr.get_current_device_resource()
             rmm.mr.set_current_device_resource(rmm.mr.TrackingResourceAdaptor(mr))
 


### PR DESCRIPTION
Adds the `rmm_track_allocations` option that enables workers to query the amount of RMM memory allocated at any time via `mr.get_allocated_bytes()`.

This is used in https://github.com/dask/distributed/pull/5740.