### PR TITLE
test_gds: skip if GDS is not available

### DIFF
--- a/dask_cuda/tests/test_gds.py
+++ b/dask_cuda/tests/test_gds.py
@@ -22,10 +22,7 @@ def test_gds(gds_enabled, cuda_lib):
     try:
         ProxifyHostFile.register_disk_spilling()
         if gds_enabled and not ProxifyHostFile._gds_enabled:
-            pytest.importorskip("cucim.clara.filesystem")
-            # In this case, we know that cucim is available and for testing
-            # we enable cucim explicitly even if GDS is unavailable.
-            ProxifyHostFile._gds_enabled = True
+            pytest.skip("GDS not available")
 
         a = data_create()
         header, frames = serialize(a, serializers=("disk",))


### PR DESCRIPTION
CI segfaults sometimes because GDS isn't available. We now disable this test. When https://github.com/rapidsai/dask-cuda/issues/844 is implemented, we should be able to enable it again even when GDS isn't available.