### PR TITLE
Spill to disk clean up

### DIFF
--- a/dask_cuda/disk_io.py
+++ b/dask_cuda/disk_io.py
@@ -73,7 +73,7 @@ class SpillToDiskFile:
         return os.path.exists(self.path)
 
     def __deepcopy__(self, memo) -> str:
-        """A deep copy is simple the path as a string.
+        """A deep copy is simply the path as a string.
 
         In order to avoid multiple instance of SpillToDiskFile pointing
         to the same file, we do not allow a direct copy.

--- a/dask_cuda/disk_io.py
+++ b/dask_cuda/disk_io.py
@@ -8,12 +8,12 @@ from typing import Callable, Iterable, Mapping, Optional, Union
 import numpy as np
 
 import dask
-from distributed.utils import Any, nbytes
+from distributed.utils import nbytes
 
-_new_cuda_buffer: Optional[Callable[[int], Any]] = None
+_new_cuda_buffer: Optional[Callable[[int], object]] = None
 
 
-def get_new_cuda_buffer() -> Callable[[int], Any]:
+def get_new_cuda_buffer() -> Callable[[int], object]:
     """Return a function to create an empty CUDA buffer"""
     global _new_cuda_buffer
     if _new_cuda_buffer is not None:

--- a/dask_cuda/disk_io.py
+++ b/dask_cuda/disk_io.py
@@ -72,11 +72,16 @@ class SpillToDiskFile:
     def exists(self):
         return os.path.exists(self.path)
 
-    def __copy__(self):
-        raise RuntimeError("Cannot copy, deepcopy, or pickle a SpillToDiskFile")
+    def __deepcopy__(self, memo) -> str:
+        """A deep copy is simple the path as a string.
 
-    def __deepcopy__(self, memo):
-        self.__copy__()
+        In order to avoid multiple instance of SpillToDiskFile pointing
+        to the same file, we do not allow a direct copy.
+        """
+        return self.path
+
+    def __copy__(self):
+        raise RuntimeError("Cannot copy or pickle a SpillToDiskFile")
 
     def __reduce__(self):
         self.__copy__()

--- a/dask_cuda/explicit_comms/comms.py
+++ b/dask_cuda/explicit_comms/comms.py
@@ -150,10 +150,10 @@ async def _stop_ucp_listeners(session_state):
 class CommsContext:
     """Communication handler for explicit communication
 
-        Parameters
-        ----------
-        client: Client, optional
-            Specify client to use for communication. If None, use the default client.
+    Parameters
+    ----------
+    client: Client, optional
+        Specify client to use for communication. If None, use the default client.
     """
 
     client: Client

--- a/dask_cuda/proxify_device_objects.py
+++ b/dask_cuda/proxify_device_objects.py
@@ -57,7 +57,7 @@ def proxify_device_objects(
     excl_proxies: bool = False,
     mark_as_explicit_proxies: bool = False,
 ) -> T:
-    """ Wrap device objects in ProxyObject
+    """Wrap device objects in ProxyObject
 
     Search through `obj` and wraps all CUDA device objects in ProxyObject.
     It uses `proxied_id_to_proxy` to make sure that identical CUDA device
@@ -99,7 +99,7 @@ def proxify_device_objects(
 
 
 def unproxify_device_objects(obj: T, skip_explicit_proxies: bool = False) -> T:
-    """ Unproxify device objects
+    """Unproxify device objects
 
     Search through `obj` and un-wraps all CUDA device objects.
 

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -496,16 +496,20 @@ class ProxifyHostFile(MutableMapping):
         self.manager = ProxyManager(device_memory_limit, memory_limit)
 
         # Create an instance of `SpillToDiskProperties` if it doesn't already exist
-        local_directory = os.path.join(
-            local_directory or dask.config.get("temporary-directory") or os.getcwd(),
-            "dask-worker-space",
-            "jit-unspill-disk-storage",
-        )
+        path = pathlib.Path(
+            os.path.join(
+                local_directory
+                or dask.config.get("temporary-directory")
+                or os.getcwd(),
+                "dask-worker-space",
+                "jit-unspill-disk-storage",
+            )
+        ).resolve()
         if ProxifyHostFile._spill_to_disk is None:
             ProxifyHostFile._spill_to_disk = SpillToDiskProperties(
-                local_directory, shared_filesystem, gds_spilling
+                path, shared_filesystem, gds_spilling
             )
-        elif ProxifyHostFile._spill_to_disk.root_dir != pathlib.Path(local_directory):
+        elif ProxifyHostFile._spill_to_disk.root_dir != path:
             raise ValueError("Cannot change the JIT-Unspilling disk path")
 
         self.register_disk_spilling()

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -680,7 +680,6 @@ class ProxifyHostFile(MutableMapping):
             frames = disk_read(
                 header["disk-io-header"], gds=cls._spill_to_disk.gds_enabled
             )
-            os.remove(header["disk-io-header"]["path"])
             if "compression" in header["serialize-header"]:
                 frames = decompress(header["serialize-header"], frames)
             return merge_and_deserialize(header["serialize-header"], frames)

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -276,7 +276,7 @@ class ProxyDetail:
                 return self.obj  # Nothing to be done
             else:
                 # The proxied object is serialized with other serializers
-                self.deserialize()
+                self.deserialize(maybe_evict=False)
 
         header, _ = self.obj = distributed.protocol.serialize(
             self.obj, serializers, on_error="raise"

--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -4,7 +4,6 @@ import operator
 import os
 import pickle
 import time
-import uuid
 from collections import OrderedDict
 from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Tuple, Type, Union
@@ -798,8 +797,12 @@ def handle_disk_serialized(pxy: ProxyDetail):
     header, frames = pxy.obj
     disk_io_header = header["disk-io-header"]
     if disk_io_header["shared-filesystem"]:
+        from .proxify_host_file import ProxifyHostFile
+
+        assert ProxifyHostFile._spill_to_disk
+
         old_path = disk_io_header["path"]
-        new_path = f"{old_path}-linked-{uuid.uuid4()}"
+        new_path = ProxifyHostFile._spill_to_disk.gen_file_path()
         os.link(old_path, new_path)
         header = _copy.deepcopy(header)
         header["disk-io-header"]["path"] = new_path

--- a/dask_cuda/tests/test_gds.py
+++ b/dask_cuda/tests/test_gds.py
@@ -1,8 +1,18 @@
+import tempfile
+
 import pytest
 
 from distributed.protocol.serialize import deserialize, serialize
 
 from dask_cuda.proxify_host_file import ProxifyHostFile
+
+# Make the "disk" serializer available and use a directory that are
+# remove on exit.
+if ProxifyHostFile._spill_to_disk is None:
+    tmpdir = tempfile.TemporaryDirectory()
+    ProxifyHostFile(
+        local_directory=tmpdir.name, device_memory_limit=1024, memory_limit=1024,
+    )
 
 
 @pytest.mark.parametrize("cuda_lib", ["cupy", "cudf", "numba.cuda"])
@@ -20,8 +30,7 @@ def test_gds(gds_enabled, cuda_lib):
         data_compare = lambda x, y: all(x.copy_to_host() == y.copy_to_host())
 
     try:
-        ProxifyHostFile.register_disk_spilling()
-        if gds_enabled and not ProxifyHostFile._gds_enabled:
+        if gds_enabled and not ProxifyHostFile._spill_to_disk.gds_enabled:
             pytest.skip("GDS not available")
 
         a = data_create()

--- a/dask_cuda/tests/test_gds.py
+++ b/dask_cuda/tests/test_gds.py
@@ -6,8 +6,8 @@ from distributed.protocol.serialize import deserialize, serialize
 
 from dask_cuda.proxify_host_file import ProxifyHostFile
 
-# Make the "disk" serializer available and use a directory that are
-# remove on exit.
+# Make the "disk" serializer available and use a directory that is
+# removed on exit.
 if ProxifyHostFile._spill_to_disk is None:
     tmpdir = tempfile.TemporaryDirectory()
     ProxifyHostFile(

--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -41,6 +41,8 @@ if ProxifyHostFile._spill_to_disk is None:
 assert ProxifyHostFile._spill_to_disk is not None
 
 # In order to use the same tmp dir, we use `root_dir` for all ProxifyHostFile creations
+# Notice, we use `../..` to remove the `dask-worker-space/jit-unspill-disk-storage` part
+# added by the ProxifyHostFile implicitly.
 root_dir = str(ProxifyHostFile._spill_to_disk.root_dir / ".." / "..")
 
 

--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -358,7 +358,9 @@ def test_incompatible_types():
     """
     cupy = pytest.importorskip("cupy")
     cudf = pytest.importorskip("cudf")
-    dhf = ProxifyHostFile(device_memory_limit=100, memory_limit=100)
+    dhf = ProxifyHostFile(
+        local_directory=root_dir, device_memory_limit=100, memory_limit=100
+    )
 
     # We expect `dhf` to unproxify `a1` (but not `a2`) on retrieval
     a1, a2 = (cupy.arange(9), cudf.Series([1, 2, 3]))

--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -314,10 +314,6 @@ def test_spilling_local_cuda_cluster(jit_unspill):
 def test_serializing_to_disk(obj):
     """Check serializing to disk"""
 
-    if isinstance(obj, str):
-        backend = pytest.importorskip(obj)
-        obj = backend.arange(100)
-
     # Serialize from device to disk
     pxy = proxy_object.asproxy(obj)
     ProxifyHostFile.serialize_proxy_to_disk_inplace(pxy)


### PR DESCRIPTION
This PR clean up spilling to disk by introducing a `SpillToDiskProperties` class.

- [x] Fixing long file names (cc. @pentschev)
- [x] Clean up files on exit 
- [x] Fix race condition when multiple accesses to a proxy object overlap