### PR TITLE
Add --pre-import/pre_import argument

### DIFF
--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -277,6 +277,13 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     help="""Use a different class than Distributed's default (``distributed.Worker``)
     to spawn ``distributed.Nanny``.""",
 )
+@click.option(
+    "--pre-import",
+    default=None,
+    help="""Pre-import libraries as a Worker plugin to prevent long import times
+    bleeding through later Dask operations. Should be a list of comma-separated names,
+    such as "cudf,rmm".""",
+)
 def main(
     scheduler,
     host,
@@ -309,6 +316,7 @@ def main(
     net_devices,
     enable_jit_unspill,
     worker_class,
+    pre_import,
     **kwargs,
 ):
     if tls_ca_file and tls_cert and tls_key:
@@ -358,6 +366,7 @@ def main(
         net_devices,
         enable_jit_unspill,
         worker_class,
+        pre_import,
         **kwargs,
     )
 

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -24,6 +24,7 @@ from .initialize import initialize
 from .proxify_host_file import ProxifyHostFile
 from .utils import (
     CPUAffinity,
+    PreImport,
     RMMSetup,
     _ucx_111,
     cuda_visible_devices,
@@ -80,6 +81,7 @@ class CUDAWorker(Server):
         net_devices=None,
         jit_unspill=None,
         worker_class=None,
+        pre_import=None,
         **kwargs,
     ):
         # Required by RAPIDS libraries (e.g., cuDF) to ensure no context
@@ -249,6 +251,7 @@ class CUDAWorker(Server):
                         rmm_async,
                         rmm_log_directory,
                     ),
+                    PreImport(pre_import),
                 },
                 name=name if nprocs == 1 or name is None else str(name) + "-" + str(i),
                 local_directory=local_directory,

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -12,6 +12,7 @@ from .initialize import initialize
 from .proxify_host_file import ProxifyHostFile
 from .utils import (
     CPUAffinity,
+    PreImport,
     RMMSetup,
     _ucx_111,
     cuda_visible_devices,
@@ -164,6 +165,10 @@ class LocalCUDACluster(LocalCluster):
     log_spilling : bool, default True
         Enable logging of spilling operations directly to ``distributed.Worker`` with an
         ``INFO`` log level.
+    pre_import : str, list or None, default None
+        Pre-import libraries as a Worker plugin to prevent long import times bleeding
+        through later Dask operations. Should be a list of comma-separated names,
+        such as "cudf,rmm" or a list of strings such as ["cudf", "rmm"].
 
     Examples
     --------
@@ -213,6 +218,7 @@ class LocalCUDACluster(LocalCluster):
         jit_unspill=None,
         log_spilling=False,
         worker_class=None,
+        pre_import=None,
         **kwargs,
     ):
         # Required by RAPIDS libraries (e.g., cuDF) to ensure no context
@@ -360,6 +366,8 @@ class LocalCUDACluster(LocalCluster):
                 worker_class=worker_class,
             )
 
+        self.pre_import = pre_import
+
         super().__init__(
             n_workers=0,
             threads_per_worker=threads_per_worker,
@@ -416,6 +424,7 @@ class LocalCUDACluster(LocalCluster):
                         self.rmm_async,
                         self.rmm_log_directory,
                     ),
+                    PreImport(self.pre_import),
                 },
             }
         )

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -2,8 +2,10 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import subprocess
+import sys
 from unittest.mock import patch
 
+import pkg_resources
 import pytest
 
 from distributed import Client, wait
@@ -162,8 +164,8 @@ def test_rmm_logging(loop):  # noqa: F811
                     assert v is rmm.mr.LoggingResourceAdaptor
 
 
+@patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0"})
 def test_dashboard_address(loop):  # noqa: F811
-    os.environ["CUDA_VISIBLE_DEVICES"] = "0"
     with popen(["dask-scheduler", "--port", "9369", "--no-dashboard"]):
         with popen(
             [
@@ -187,6 +189,41 @@ def test_unknown_argument():
     ret = subprocess.run(["dask-cuda-worker", "--my-argument"], capture_output=True)
     assert ret.returncode != 0
     assert b"Scheduler address: --my-argument" in ret.stderr
+
+
+@patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0"})
+def test_pre_import(loop):  # noqa: F811
+    module = None
+
+    # Pick a module that isn't currently loaded
+    for m in pkg_resources.working_set:
+        if m.key not in sys.modules.keys():
+            module = m.key
+            break
+
+    if module is None:
+        pytest.skip("No module found that isn't already loaded")
+
+    with popen(["dask-scheduler", "--port", "9369", "--no-dashboard"]):
+        with popen(
+            ["dask-cuda-worker", "127.0.0.1:9369", "--pre-import", module,]
+        ):
+            with Client("127.0.0.1:9369", loop=loop) as client:
+                assert wait_workers(client, n_gpus=get_n_gpus())
+
+                imported = client.run(lambda: module in sys.modules)
+                assert all(imported)
+
+
+@patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0"})
+def test_pre_import_not_found():
+    with popen(["dask-scheduler", "--port", "9369", "--no-dashboard"]):
+        ret = subprocess.run(
+            ["dask-cuda-worker", "127.0.0.1:9369", "--pre-import", "my_module"],
+            capture_output=True,
+        )
+        assert ret.returncode != 0
+        assert b"ModuleNotFoundError: No module named 'my_module'" in ret.stderr
 
 
 @patch.dict(os.environ, {"DASK_DISTRIBUTED__DIAGNOSTICS__NVML": "False"})

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -1,6 +1,8 @@
 import os
+import sys
 from unittest.mock import patch
 
+import pkg_resources
 import pytest
 
 from dask.distributed import Client
@@ -82,6 +84,7 @@ async def test_with_subset_of_cuda_visible_devices():
 
 @pytest.mark.parametrize("protocol", ["ucx", None])
 @pytest.mark.asyncio
+@gen_test(timeout=20)
 async def test_ucx_protocol(protocol):
     pytest.importorskip("ucp")
 
@@ -96,6 +99,7 @@ async def test_ucx_protocol(protocol):
 
 @pytest.mark.asyncio
 @pytest.mark.filterwarnings("ignore:Exception ignored in")
+@gen_test(timeout=20)
 async def test_ucx_protocol_type_error():
     pytest.importorskip("ucp")
 
@@ -200,6 +204,36 @@ async def test_rmm_logging():
             )
             for v in memory_resource_type.values():
                 assert v is rmm.mr.LoggingResourceAdaptor
+
+
+@gen_test(timeout=20)
+async def test_pre_import():
+    module = None
+
+    # Pick a module that isn't currently loaded
+    for m in pkg_resources.working_set:
+        if m.key not in sys.modules.keys():
+            module = m.key
+            break
+
+    if module is None:
+        pytest.skip("No module found that isn't already loaded")
+
+    async with LocalCUDACluster(
+        n_workers=1, pre_import=module, asynchronous=True,
+    ) as cluster:
+        async with Client(cluster, asynchronous=True) as client:
+            imported = await client.run(lambda: module in sys.modules)
+
+            assert all(imported.values())
+
+
+# Intentionally not using @gen_test to skip cleanup checks
+async def test_pre_import_not_found():
+    with pytest.raises(ModuleNotFoundError):
+        await LocalCUDACluster(
+            n_workers=1, pre_import="my_module", asynchronous=True,
+        )
 
 
 @gen_test(timeout=20)

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -105,7 +105,6 @@ class PreImport:
 
     def setup(self, worker=None):
         for l in self.libraries:
-            print(f"Importing {l}")
             importlib.import_module(l)
 
 

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -1,3 +1,4 @@
+import importlib
 import math
 import os
 import time
@@ -92,6 +93,20 @@ class RMMSetup:
                     worker, self.logging, self.log_directory
                 ),
             )
+
+
+class PreImport:
+    def __init__(self, libraries):
+        if libraries is None:
+            libraries = []
+        elif isinstance(libraries, str):
+            libraries = libraries.split(",")
+        self.libraries = libraries
+
+    def setup(self, worker=None):
+        for l in self.libraries:
+            print(f"Importing {l}")
+            importlib.import_module(l)
 
 
 def unpack_bitmask(x, mask_bits=64):


### PR DESCRIPTION
Add argument to pre-import libraries as a Worker plugin to prevent long import times bleeding through later Dask operations.