### PR TITLE
Introduce incompatible-types and enables spilling of CuPy arrays

### DIFF
--- a/dask_cuda/explicit_comms/dataframe/shuffle.py
+++ b/dask_cuda/explicit_comms/dataframe/shuffle.py
@@ -158,7 +158,7 @@ async def local_shuffle(
             if len(args) < 2:
                 return args[0]
 
-            return manager.proxify(dd_concat(args, ignore_index=ignore_index))
+            return manager.proxify(dd_concat(args, ignore_index=ignore_index))[0]
 
     else:
         concat = dd_concat

--- a/dask_cuda/proxify_device_objects.py
+++ b/dask_cuda/proxify_device_objects.py
@@ -2,7 +2,7 @@ import functools
 import pydoc
 from collections import defaultdict
 from functools import partial
-from typing import List, MutableMapping, TypeVar
+from typing import List, MutableMapping, Optional, Tuple, TypeVar
 
 import dask
 from dask.utils import Dispatch
@@ -10,33 +10,30 @@ from dask.utils import Dispatch
 from .proxy_object import ProxyObject, asproxy
 
 dispatch = Dispatch(name="proxify_device_objects")
-ignore_types = None
+incompatible_types: Optional[Tuple[type]] = None
 
 T = TypeVar("T")
 
 
-def _register_ignore_types():
-    """Lazy register types that shouldn't be proxified
+def _register_incompatible_types():
+    """Lazy register types that ProxifyHostFile should unproxify on retrieval.
 
-    It reads the config key "jit-unspill-ignore" (DASK_JIT_UNSPILL_IGNORE),
-    which should be a comma seperated list of types to ignore. The default
-    value is:
-        DASK_JIT_UNSPILL_IGNORE="cupy.ndarray"
-
-    Notice, it is not possible to ignore types explicitly handled by this
-    module such as `cudf.DataFrame`, `cudf.Series`, and `cudf.Index`.
+    It reads the config key "jit-unspill-incompatible"
+    (DASK_JIT_UNSPILL_INCOMPATIBLE), which should be a comma seperated
+    list of types. The default value is:
+        DASK_JIT_UNSPILL_INCOMPATIBLE="cupy.ndarray"
     """
-    global ignore_types
-    if ignore_types is not None:
+    global incompatible_types
+    if incompatible_types is not None:
         return  # Only register once
     else:
-        ignore_types = ()
+        incompatible_types = ()
 
-    ignores = dask.config.get("jit-unspill-ignore", "cupy.ndarray")
-    ignores = ignores.split(",")
+    incompatibles = dask.config.get("jit-unspill-incompatible", "cupy.ndarray")
+    incompatibles = incompatibles.split(",")
 
     toplevels = defaultdict(set)
-    for path in ignores:
+    for path in incompatibles:
         if path:
             toplevel = path.split(".", maxsplit=1)[0].strip()
             toplevels[toplevel].add(path.strip())
@@ -44,8 +41,10 @@ def _register_ignore_types():
     for toplevel, ignores in toplevels.items():
 
         def f(paths):
-            global ignore_types
-            ignore_types = ignore_types + tuple(pydoc.locate(p) for p in paths)
+            global incompatible_types
+            incompatible_types = incompatible_types + tuple(
+                pydoc.locate(p) for p in paths
+            )
 
         dispatch.register_lazy(toplevel, partial(f, ignores))
 
@@ -86,7 +85,7 @@ def proxify_device_objects(
     ret: Any
         A copy of `obj` where all CUDA device objects are wrapped in ProxyObject
     """
-    _register_ignore_types()
+    _register_incompatible_types()
 
     if proxied_id_to_proxy is None:
         proxied_id_to_proxy = {}
@@ -126,7 +125,11 @@ def unproxify_device_objects(obj: T, skip_explicit_proxies: bool = False) -> T:
         )  # type: ignore
     if isinstance(obj, ProxyObject):
         pxy = obj._pxy_get(copy=True)
-        if not skip_explicit_proxies or not pxy.explicit_proxy:
+        if (
+            not skip_explicit_proxies
+            or not pxy.explicit_proxy
+            or (incompatible_types and isinstance(obj, incompatible_types))
+        ):
             pxy.explicit_proxy = False
             obj = obj._pxy_deserialize(maybe_evict=False, proxy_detail=pxy)
     return obj
@@ -178,7 +181,7 @@ def proxify(obj, proxied_id_to_proxy, found_proxies, subclass=None):
 def proxify_device_object_default(
     obj, proxied_id_to_proxy, found_proxies, excl_proxies
 ):
-    if hasattr(obj, "__cuda_array_interface__") and not isinstance(obj, ignore_types):
+    if hasattr(obj, "__cuda_array_interface__"):
         return proxify(obj, proxied_id_to_proxy, found_proxies)
     return obj
 

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -618,12 +618,7 @@ class ProxifyHostFile(MutableMapping):
     def __getitem__(self, key):
         with self.lock:
             ret = self.store[key]
-        if self.compatibility_mode:
-            ret = unproxify_device_objects(ret, skip_explicit_proxies=True)
-            self.manager.maybe_evict()
-        elif self.key_containts_incompatible_type[key]:
-            # Notice, we only call `unproxify_device_objects()` when `key`
-            # contains incompatible types.
+        if self.compatibility_mode or self.key_containts_incompatible_type[key]:
             ret = unproxify_device_objects(ret, skip_explicit_proxies=True)
             self.manager.maybe_evict()
         return ret

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -319,8 +319,13 @@ class ProxyManager:
                         header, _ = pxy.obj
                         assert header["serializer"] == pxy.serializer
 
-    def proxify(self, obj: T) -> T:
-        """Proxify `obj` and add found proxies to the Proxies collections"""
+    def proxify(self, obj: T) -> Tuple[T, bool]:
+        """Proxify `obj` and add found proxies to the Proxies collections
+
+        Returns the proxified object and a boolean, which is True when one or
+        more incompatible-types were found.
+        """
+        incompatible_type_found = False
         with self.lock:
             found_proxies: List[ProxyObject] = []
             # In order detect already proxied object, proxify_device_objects()
@@ -336,8 +341,10 @@ class ProxyManager:
                 if not self.contains(id(p)):
                     pxy.manager = self
                     self.add(proxy=p, serializer=pxy.serializer)
+                if pdo.incompatible_types and isinstance(p, pdo.incompatible_types):
+                    incompatible_type_found = True
         self.maybe_evict()
-        return ret
+        return ret, incompatible_type_found
 
     def evict(
         self,
@@ -496,6 +503,7 @@ class ProxifyHostFile(MutableMapping):
         gds_spilling: bool = None,
     ):
         self.store: Dict[Hashable, Any] = {}
+        self.key_containts_incompatible_type: Dict[Hashable, bool] = {}
         self.manager = ProxyManager(device_memory_limit, memory_limit)
         self.register_disk_spilling(local_directory, shared_filesystem, gds_spilling)
         if compatibility_mode is None:
@@ -604,7 +612,8 @@ class ProxifyHostFile(MutableMapping):
             if key in self.store:
                 # Make sure we register the removal of an existing key
                 del self[key]
-            self.store[key] = self.manager.proxify(value)
+            self.store[key], incompatible_type_found = self.manager.proxify(value)
+            self.key_containts_incompatible_type[key] = incompatible_type_found
 
     def __getitem__(self, key):
         with self.lock:
@@ -612,7 +621,9 @@ class ProxifyHostFile(MutableMapping):
         if self.compatibility_mode:
             ret = unproxify_device_objects(ret, skip_explicit_proxies=True)
             self.manager.maybe_evict()
-        elif pdo.incompatible_types:
+        elif self.key_containts_incompatible_type[key]:
+            # Notice, we only call `unproxify_device_objects()` when `key`
+            # contains incompatible types.
             ret = unproxify_device_objects(ret, skip_explicit_proxies=True)
             self.manager.maybe_evict()
         return ret
@@ -620,6 +631,7 @@ class ProxifyHostFile(MutableMapping):
     def __delitem__(self, key):
         with self.lock:
             del self.store[key]
+            del self.key_containts_incompatible_type[key]
 
     @classmethod
     def gen_file_path(cls) -> str:

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -503,7 +503,7 @@ class ProxifyHostFile(MutableMapping):
         gds_spilling: bool = None,
     ):
         self.store: Dict[Hashable, Any] = {}
-        self.key_containts_incompatible_type: Dict[Hashable, bool] = {}
+        self.key_contains_incompatible_type: Dict[Hashable, bool] = {}
         self.manager = ProxyManager(device_memory_limit, memory_limit)
         self.register_disk_spilling(local_directory, shared_filesystem, gds_spilling)
         if compatibility_mode is None:
@@ -613,7 +613,7 @@ class ProxifyHostFile(MutableMapping):
                 # Make sure we register the removal of an existing key
                 del self[key]
             self.store[key], incompatible_type_found = self.manager.proxify(value)
-            self.key_containts_incompatible_type[key] = incompatible_type_found
+            self.key_contains_incompatible_type[key] = incompatible_type_found
 
     def __getitem__(self, key):
         with self.lock:
@@ -621,7 +621,7 @@ class ProxifyHostFile(MutableMapping):
         if self.compatibility_mode:
             ret = unproxify_device_objects(ret, skip_explicit_proxies=True)
             self.manager.maybe_evict()
-        elif self.key_containts_incompatible_type[key]:
+        elif self.key_contains_incompatible_type[key]:
             # Notice, we only call `unproxify_device_objects()` when `key`
             # contains incompatible types.
             ret = unproxify_device_objects(ret, only_incompatible_types=True)
@@ -631,7 +631,7 @@ class ProxifyHostFile(MutableMapping):
     def __delitem__(self, key):
         with self.lock:
             del self.store[key]
-            del self.key_containts_incompatible_type[key]
+            del self.key_contains_incompatible_type[key]
 
     @classmethod
     def gen_file_path(cls) -> str:

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -618,8 +618,13 @@ class ProxifyHostFile(MutableMapping):
     def __getitem__(self, key):
         with self.lock:
             ret = self.store[key]
-        if self.compatibility_mode or self.key_containts_incompatible_type[key]:
+        if self.compatibility_mode:
             ret = unproxify_device_objects(ret, skip_explicit_proxies=True)
+            self.manager.maybe_evict()
+        elif self.key_containts_incompatible_type[key]:
+            # Notice, we only call `unproxify_device_objects()` when `key`
+            # contains incompatible types.
+            ret = unproxify_device_objects(ret, only_incompatible_types=True)
             self.manager.maybe_evict()
         return ret
 

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -502,6 +502,9 @@ class ProxifyHostFile(MutableMapping):
         spill_on_demand: bool = None,
         gds_spilling: bool = None,
     ):
+        # each value of self.store is a tuple containing the proxified
+        # object, as well as a boolean indicating whether any
+        # incompatible types were found when proxifying it
         self.store: Dict[Hashable, Tuple[Any, bool]] = {}
         self.manager = ProxyManager(device_memory_limit, memory_limit)
         self.register_disk_spilling(local_directory, shared_filesystem, gds_spilling)

--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -36,7 +36,7 @@ def is_proxies_equal(p1: Iterable[ProxyObject], p2: Iterable[ProxyObject]):
     """Check that two collections of proxies contains the same proxies (unordered)
 
     In order to avoid deserializing proxy objects when comparing them,
-    this funcntion compares object IDs.
+    this function compares object IDs.
     """
 
     ids1 = sorted([id(p) for p in p1])
@@ -295,7 +295,8 @@ def test_externals():
     dhf = ProxifyHostFile(device_memory_limit=one_item_nbytes, memory_limit=1000)
     dhf["k1"] = one_item_array()
     k1 = dhf["k1"]
-    k2 = dhf.manager.proxify(one_item_array())
+    k2, incompatible_type_found = dhf.manager.proxify(one_item_array())
+    assert not incompatible_type_found
     # `k2` isn't part of the store but still triggers spilling of `k1`
     assert len(dhf) == 1
     assert k1._pxy_get().is_serialized()

--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -328,7 +328,7 @@ def test_externals():
 
 @patch("dask_cuda.proxify_device_objects.incompatible_types", (cupy.ndarray,))
 def test_incompatible_types():
-    """Check that ProxifyHostFile unproxify `cupy.ndarray` on retrival
+    """Check that ProxifyHostFile unproxify `cupy.ndarray` on retrieval
 
     Notice, in this test we add `cupy.ndarray` to the incompatible_types temporarily.
     """
@@ -336,7 +336,7 @@ def test_incompatible_types():
     cudf = pytest.importorskip("cudf")
     dhf = ProxifyHostFile(device_memory_limit=100, memory_limit=100)
 
-    # We expect `dhf` to unproxify `a1` (but not `a2`) on retrival
+    # We expect `dhf` to unproxify `a1` (but not `a2`) on retrieval
     a1, a2 = (cupy.arange(9), cudf.Series([1, 2, 3]))
     dhf["a"] = (a1, a2)
     b1, b2 = dhf["a"]

--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -333,12 +333,16 @@ def test_incompatible_types():
     Notice, in this test we add `cupy.ndarray` to the incompatible_types temporarily.
     """
     cupy = pytest.importorskip("cupy")
+    cudf = pytest.importorskip("cudf")
     dhf = ProxifyHostFile(device_memory_limit=100, memory_limit=100)
 
-    org = cupy.arange(9)
-    dhf["a"] = org
-    pxy = dhf["a"]
-    assert org is pxy
+    # We expect `dhf` to unproxify `a1` (but not `a2`) on retrival
+    a1, a2 = (cupy.arange(9), cudf.Series([1, 2, 3]))
+    dhf["a"] = (a1, a2)
+    b1, b2 = dhf["a"]
+    assert a1 is b1
+    assert isinstance(b2, ProxyObject)
+    assert a2 is unproxy(b2)
 
 
 @pytest.mark.parametrize("npartitions", [1, 2, 3])


### PR DESCRIPTION
This PR replaces `ignore_types` introduced in https://github.com/rapidsai/dask-cuda/pull/568 with `incompatible_types`, which is a list of types that `ProxifyHostFile` will unproxify on retrieval. This makes it possible to spill types we previously ignored completely such as  `cupy.ndarray`.

To mark a type incompatible, add it to the comma separated config value `"jit-unspill-incompatible"` or environment variable `DASK_JIT_UNSPILL_INCOMPATIBLE`.

The default value is: `DASK_JIT_UNSPILL_INCOMPATIBLE="cupy.ndarray"`

Closes https://github.com/rapidsai/dask-cuda/issues/855

Notice, I have marked the PR `breaking` because the `DASK_JIT_UNSPILL_IGNORE` option has been removed.

cc. @VibhuJawa