### PR TITLE
[gpuCI] Forward-merge branch-22.04 to branch-22.06 [skip gpuci]

### DIFF
--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -27,8 +27,8 @@ requirements:
     - setuptools
   run:
     - python
-    - dask>=2021.11.1
-    - distributed>=2021.11.1
+    - dask>=2022.03.0
+    - distributed>=2022.03.0
     - pynvml >=8.0.3
     - numpy >=1.16.0
     - numba >=0.53.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-dask>=2021.11.1
-distributed>=2021.11.1
+dask>=2022.03.0
+distributed>=2022.03.0
 pynvml>=11.0.0
 numpy>=1.16.0
 numba>=0.53.1


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.04` that creates a PR to keep `branch-22.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.