### PR TITLE
[gpuCI] Forward-merge branch-22.04 to branch-22.06 [skip gpuci]

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -34,7 +34,7 @@ export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1
 
 # Install dask and distributed from master branch. Usually needed during
 # development time and disabled before a new dask-cuda release.
-export INSTALL_DASK_MASTER=1
+export INSTALL_DASK_MASTER=0
 
 ################################################################################
 # SETUP - Check environment

--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -27,11 +27,11 @@ requirements:
     - setuptools
   run:
     - python
-    - dask>=2022.03.0
-    - distributed>=2022.03.0
-    - pynvml >=8.0.3
-    - numpy >=1.16.0
-    - numba >=0.53.1
+    - dask==2022.03.0
+    - distributed==2022.03.0
+    - pynvml>=8.0.3
+    - numpy>=1.16.0
+    - numba>=0.53.1
 
 test:
   imports:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-dask>=2022.03.0
-distributed>=2022.03.0
+dask==2022.03.0
+distributed==2022.03.0
 pynvml>=11.0.0
 numpy>=1.16.0
 numba>=0.53.1


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.04` that creates a PR to keep `branch-22.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.