### PR TITLE
Resolve build issues / consistency with conda-forge packages

### DIFF
--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - pynvml>=11.0.0
     - numpy>=1.16.0
     - numba>=0.53.1
+    - click<8.1
 
 test:
   imports:

--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - python
     - dask==2022.03.0
     - distributed==2022.03.0
-    - pynvml>=8.0.3
+    - pynvml>=11.0.0
     - numpy>=1.16.0
     - numba>=0.53.1
 

--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - pynvml>=11.0.0
     - numpy>=1.16.0
     - numba>=0.53.1
-    - click<8.1
+    - click==8.0.4
 
 test:
   imports:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ distributed==2022.03.0
 pynvml>=11.0.0
 numpy>=1.16.0
 numba>=0.53.1
-click<8.1
+click==8.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ distributed==2022.03.0
 pynvml>=11.0.0
 numpy>=1.16.0
 numba>=0.53.1
+click<8.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ distributed==2022.03.0
 pynvml>=11.0.0
 numpy>=1.16.0
 numba>=0.53.1
-click<8.10
+click<8.1

--- a/setup.py
+++ b/setup.py
@@ -34,11 +34,11 @@ setup(
         "Topic :: Scientific/Engineering",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     packages=find_packages(exclude=["docs", "tests", "tests.*", "docs.*"]),
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=open("requirements.txt").read().strip().split("\n"),
     entry_points="""
         [console_scripts]


### PR DESCRIPTION
This PR:

- bumps dask-cuda's minimum python version to 3.8 to coincide with other RAPIDS projects
- bumps the pynvml minimum version to 11.0.0 to match up with the [conda-forge package](https://github.com/conda-forge/dask-cuda-feedstock/blob/main/recipe/meta.yaml)
- adds a max version constraint for `click` to resolve the build issues arising from click 8.1.0