### PR TITLE
[gpuCI] Forward-merge branch-22.04 to branch-22.06 [skip gpuci]

### DIFF
--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -29,9 +29,10 @@ requirements:
     - python
     - dask==2022.03.0
     - distributed==2022.03.0
-    - pynvml>=8.0.3
+    - pynvml>=11.0.0
     - numpy>=1.16.0
     - numba>=0.53.1
+    - click==8.0.4
 
 test:
   imports:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ distributed==2022.03.0
 pynvml>=11.0.0
 numpy>=1.16.0
 numba>=0.53.1
+click==8.0.4

--- a/setup.py
+++ b/setup.py
@@ -34,11 +34,11 @@ setup(
         "Topic :: Scientific/Engineering",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     packages=find_packages(exclude=["docs", "tests", "tests.*", "docs.*"]),
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=open("requirements.txt").read().strip().split("\n"),
     entry_points="""
         [console_scripts]


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.04` that creates a PR to keep `branch-22.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.