### PR TITLE
Raise `ImportError` when platform is not Linux

### DIFF
--- a/dask_cuda/__init__.py
+++ b/dask_cuda/__init__.py
@@ -1,3 +1,9 @@
+import sys
+
+if sys.platform != "linux":
+    raise ImportError("Only Linux is supported by Dask-CUDA at this time")
+
+
 import dask
 import dask.dataframe.core
 import dask.dataframe.shuffle


### PR DESCRIPTION
To prevent users inadvertently trying to use Dask-CUDA (and potentially other RAPIDS components) on a non-supported platform such as Windows, raise an `ImportError`.