### PR TITLE
Update auto host_memory computation when threads per worker > 1

### DIFF
--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -85,7 +85,7 @@ class CUDAWorker(Server):
         if nthreads < 1:
             raise ValueError("nthreads must be higher than 0.")
 
-        # Set nthreads to 1 during mem limit calculation since the host memory limit should be dictated by nprocs
+        # Set nthreads=1 when parsing mem_limit since it only depends on nprocs
         memory_limit = parse_memory_limit(
             memory_limit=memory_limit, nthreads=1, total_cores=nprocs
         )

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -85,7 +85,10 @@ class CUDAWorker(Server):
         if nthreads < 1:
             raise ValueError("nthreads must be higher than 0.")
 
-        memory_limit = parse_memory_limit(memory_limit, nthreads, total_cores=nprocs)
+        # Set nthreads to 1 during mem limit calculation since the host memory limit should be dictated by nprocs
+        memory_limit = parse_memory_limit(
+            memory_limit=memory_limit, nthreads=1, total_cores=nprocs
+        )
 
         if pid_file:
             with open(pid_file, "w") as f:

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -230,8 +230,9 @@ class LocalCUDACluster(LocalCluster):
             n_workers = len(CUDA_VISIBLE_DEVICES)
         if n_workers < 1:
             raise ValueError("Number of workers cannot be less than 1.")
+        # Set nthreads to 1 during mem limit calculation since the host memory limit should be dictated by n_workers
         self.memory_limit = parse_memory_limit(
-            memory_limit, threads_per_worker, n_workers
+            memory_limit=memory_limit, nthreads=1, total_cores=n_workers
         )
         self.device_memory_limit = parse_device_memory_limit(
             device_memory_limit, device_index=nvml_device_index(0, CUDA_VISIBLE_DEVICES)

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -230,7 +230,7 @@ class LocalCUDACluster(LocalCluster):
             n_workers = len(CUDA_VISIBLE_DEVICES)
         if n_workers < 1:
             raise ValueError("Number of workers cannot be less than 1.")
-        # Set nthreads to 1 during mem limit calculation since the host memory limit should be dictated by n_workers
+        # Set nthreads=1 when parsing mem_limit since it only depends on n_workers
         self.memory_limit = parse_memory_limit(
             memory_limit=memory_limit, nthreads=1, total_cores=n_workers
         )

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -59,7 +59,7 @@ def test_cuda_visible_devices_and_memory_limit_and_nthreads(loop):  # noqa: F811
 
                 workers = client.scheduler_info()["workers"]
                 for w in workers.values():
-                    assert w["memory_limit"] == MEMORY_LIMIT // len(workers) * nthreads
+                    assert w["memory_limit"] == MEMORY_LIMIT // len(workers)
 
                 assert len(expected) == 0
 

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -126,9 +126,7 @@ async def test_n_workers():
 async def test_threads_per_worker_and_memory_limit():
     async with LocalCUDACluster(threads_per_worker=4, asynchronous=True) as cluster:
         assert all(ws.nthreads == 4 for ws in cluster.scheduler.workers.values())
-        full_mem = sum(
-                w.memory_manager.memory_limit for w in cluster.workers.values()
-            )
+        full_mem = sum(w.memory_manager.memory_limit for w in cluster.workers.values())
         assert full_mem >= MEMORY_LIMIT - 1024 and full_mem < MEMORY_LIMIT + 1024
 
 

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -123,9 +123,13 @@ async def test_n_workers():
 
 
 @gen_test(timeout=20)
-async def test_threads_per_worker():
+async def test_threads_per_worker_and_memory_limit():
     async with LocalCUDACluster(threads_per_worker=4, asynchronous=True) as cluster:
         assert all(ws.nthreads == 4 for ws in cluster.scheduler.workers.values())
+        full_mem = sum(
+                w.memory_manager.memory_limit for w in cluster.workers.values()
+            )
+        assert full_mem >= MEMORY_LIMIT - 1024 and full_mem < MEMORY_LIMIT + 1024
 
 
 @gen_test(timeout=20)


### PR DESCRIPTION
Fixes #874 .

Updates the arguments to `parse_memory_limit` to set the right memory_limit values for cases where threads_per_worker > 1 as discussed in https://github.com/rapidsai/dask-cuda/issues/874#issuecomment-1101770211