### PR TITLE
Add documentation for `RAPIDS_NO_INITIALIZE`

### DIFF
--- a/dask_cuda/explicit_comms/comms.py
+++ b/dask_cuda/explicit_comms/comms.py
@@ -191,16 +191,16 @@ class CommsContext:
         """Run a coroutine on a single worker
 
         The coroutine is given the worker's state dict as the first argument
-        and *args as the following arguments.
+        and ``*args`` as the following arguments.
 
         Parameters
         ----------
         worker: str
-            Worker to run the `coroutine`
+            Worker to run the ``coroutine``
         coroutine: coroutine
             The function to run on the worker
         *args:
-            Arguments for `coroutine`
+            Arguments for ``coroutine``
         wait: boolean, optional
             If True, waits for the coroutine to finished before returning.
 
@@ -224,14 +224,14 @@ class CommsContext:
         """Run a coroutine on multiple workers
 
         The coroutine is given the worker's state dict as the first argument
-        and *args as the following arguments.
+        and ``*args`` as the following arguments.
 
         Parameters
         ----------
         coroutine: coroutine
             The function to run on each worker
         *args:
-            Arguments for `coroutine`
+            Arguments for ``coroutine``
         workers: list, optional
             List of workers. Default is all workers
         lock_workers: bool, optional

--- a/docs/source/examples/ucx.rst
+++ b/docs/source/examples/ucx.rst
@@ -49,7 +49,7 @@ To connect a client to a cluster with all supported transports and an RMM pool:
     client = Client(cluster)
 
 dask-cuda-worker with Automatic Configuration
-------------------------------------------
+---------------------------------------------
 
 When using ``dask-cuda-worker`` with UCX communication and automatic configuration, the scheduler, workers, and client must all be started manually, but without specifying any UCX transports explicitly. This is only supported in Dask-CUDA 22.02 and newer and requires UCX >= 1.11.1.
 

--- a/docs/source/ucx.rst
+++ b/docs/source/ucx.rst
@@ -21,11 +21,12 @@ For this reason, it is strongly recommended to use `RAPIDS Memory Manager (RMM) 
 A memory pool also prevents the Dask scheduler from deserializing CUDA data, which will cause a crash.
 
 .. warning::
-    When using UCX integration, Dask-CUDA must create a CUDA context on the process initializating the cluster.
+    Dask-CUDA must create worker CUDA contexts during cluster initialization, and properly ordering that task is critical for correct UCX configuration.
     If a CUDA context already exists for this process at the time of cluster initialization, unexpected behavior can occur.
     To avoid this, it is advised to initialize any UCX-enabled clusters before doing operations that would result in a CUDA context being created.
+    Depending on the library, even an import can force CUDA context creation.
 
-    For some RAPIDS libraries, setting ``RAPIDS_NO_INITIALIZE=1`` at runtime will delay or disable their CUDA context creation, allowing for improved compatibility with UCX-enabled clusters.
+    For some RAPIDS libraries (e.g. cuDF), setting ``RAPIDS_NO_INITIALIZE=1`` at runtime will delay or disable their CUDA context creation, allowing for improved compatibility with UCX-enabled clusters and preventing runtime warnings.
 
 
 Configuration

--- a/docs/source/ucx.rst
+++ b/docs/source/ucx.rst
@@ -20,6 +20,14 @@ When using UCX, each NVLink and InfiniBand memory buffer must create a mapping b
 For this reason, it is strongly recommended to use `RAPIDS Memory Manager (RMM) <https://github.com/rapidsai/rmm>`_ to allocate a memory pool that is only prone to a single mapping operation, which all subsequent transfers may rely upon.
 A memory pool also prevents the Dask scheduler from deserializing CUDA data, which will cause a crash.
 
+.. warning::
+    When using UCX integration, Dask-CUDA must create a CUDA context on the process initializating the cluster.
+    If a CUDA context already exists for this process at the time of cluster initialization, unexpected behavior can occur.
+    To avoid this, it is advised to initialize any UCX-enabled clusters before doing operations that would result in a CUDA context being created.
+
+    For some RAPIDS libraries, setting ``RAPIDS_NO_INITIALIZE=1`` at runtime will delay or disable their CUDA context creation, allowing for improved compatibility with UCX-enabled clusters.
+
+
 Configuration
 -------------
 


### PR DESCRIPTION
Adds a warning to the UCX docs explaining the hazards of starting a CUDA context before initializing a UCX cluster, and how `RAPIDS_NO_INITIALIZE` can sometimes be used to avoid this.