### PR TITLE
Skip tests on import error for some optional packages

### DIFF
--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -9,14 +9,9 @@ from dask.distributed import Client
 from distributed.system import MEMORY_LIMIT
 from distributed.utils_test import gen_test
 
-import rmm
-
 from dask_cuda import CUDAWorker, LocalCUDACluster, utils
 from dask_cuda.initialize import initialize
 from dask_cuda.utils import MockWorker, get_gpu_count_mig, get_gpu_uuid_from_index
-
-_driver_version = rmm._cuda.gpu.driverGetVersion()
-_runtime_version = rmm._cuda.gpu.runtimeGetVersion()
 
 
 @gen_test(timeout=20)
@@ -184,13 +179,14 @@ async def test_rmm_managed():
                 assert v is rmm.mr.ManagedMemoryResource
 
 
-@pytest.mark.skipif(
-    _driver_version < 11020 or _runtime_version < 11020,
-    reason="cudaMallocAsync not supported",
-)
 @gen_test(timeout=20)
 async def test_rmm_async():
     rmm = pytest.importorskip("rmm")
+
+    driver_version = rmm._cuda.gpu.driverGetVersion()
+    runtime_version = rmm._cuda.gpu.runtimeGetVersion()
+    if driver_version < 11020 or runtime_version < 11020:
+        pytest.skip("cudaMallocAsync not supported")
 
     async with LocalCUDACluster(
         rmm_async=True,

--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -16,8 +16,6 @@ from dask.sizeof import sizeof
 from distributed import Client
 from distributed.protocol.serialize import deserialize, serialize
 
-import dask_cudf
-
 import dask_cuda
 from dask_cuda import proxy_object
 from dask_cuda.disk_io import SpillToDiskFile
@@ -286,6 +284,7 @@ def test_fixed_attribute_name():
 def test_spilling_local_cuda_cluster(jit_unspill):
     """Testing spilling of a proxied cudf dataframe in a local cuda cluster"""
     cudf = pytest.importorskip("cudf")
+    dask_cudf = pytest.importorskip("dask_cudf")
 
     def task(x):
         assert isinstance(x, cudf.DataFrame)
@@ -511,6 +510,7 @@ def test_pandas():
 def test_from_cudf_of_proxy_object():
     """Check from_cudf() of a proxy object"""
     cudf = pytest.importorskip("cudf")
+    dask_cudf = pytest.importorskip("dask_cudf")
 
     df = proxy_object.asproxy(cudf.DataFrame({"a": range(10)}))
     assert has_parallel_type(df)


### PR DESCRIPTION
Packages such as `rmm` and `dask_cudf` are not requirements, thus we must ensure tests get skipped if they're not installed.