### PR TITLE
Fix errors related with `distributed.worker.memory.terminate`

### DIFF
--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -406,7 +406,7 @@ async def test_worker_force_spill_to_disk():
     """Test Dask triggering CPU-to-Disk spilling"""
     cudf = pytest.importorskip("cudf")
 
-    with dask.config.set({"distributed.worker.memory.terminate": None}):
+    with dask.config.set({"distributed.worker.memory.terminate": False}):
         async with dask_cuda.LocalCUDACluster(
             n_workers=1, device_memory_limit="1MB", jit_unspill=True, asynchronous=True
         ) as cluster:


### PR DESCRIPTION
`None` is not a valid value for `distributed.worker.memory.terminate` anymore, we should use `False` instead.

Errors such as the one below are raised otherwise:

```
2022-04-25 13:42:48,943 - tornado.application - ERROR - Exception in callback functools.partial(<bound method NannyMemoryManager.memory_monitor of <distributed.worker_memory.NannyMemoryManager object at 0x7fd3de281b50>>, <Nanny: tcp://127.0.0.1:39989, threads: 1>)
Traceback (most recent call last):
  File "/datasets/pentschev/miniconda3/envs/tmp/lib/python3.8/site-packages/tornado/ioloop.py", line 905, in _run
    return self.callback()
  File "/datasets/pentschev/miniconda3/envs/tmp/lib/python3.8/site-packages/distributed/worker_memory.py", line 326, in memory_monitor
    if memory / self.memory_limit > self.memory_terminate_fraction:
TypeError: '>' not supported between instances of 'float' and 'NoneType'
```