### PR TITLE
Increase spill tests timeout to 30 seconds

### DIFF
--- a/dask_cuda/tests/test_spill.py
+++ b/dask_cuda/tests/test_spill.py
@@ -118,7 +118,7 @@ def delayed_worker_assert(total_size, device_chunk_overhead, serialized_chunk_ov
         },
     ],
 )
-@gen_test(timeout=20)
+@gen_test(timeout=30)
 async def test_cupy_cluster_device_spill(params):
     cupy = pytest.importorskip("cupy")
     with dask.config.set({"distributed.worker.memory.terminate": False}):
@@ -203,7 +203,7 @@ async def test_cupy_cluster_device_spill(params):
         },
     ],
 )
-@gen_test(timeout=20)
+@gen_test(timeout=30)
 async def test_cudf_cluster_device_spill(params):
     cudf = pytest.importorskip("cudf")
 


### PR DESCRIPTION
Timeouts have occurred already in a few gpuCI instances, and locally those are consistently reproducible when the spill test is the first to run, where it takes just over 20 seconds probably due to added overhead of CUDA context creation. Increasing the timeout to 30 seconds seems sufficient.