### PR TITLE
Fix ci/local script

### DIFF
--- a/ci/local/build.sh
+++ b/ci/local/build.sh
@@ -131,7 +131,7 @@ DOCKER_MAJOR=$(docker -v|sed 's/[^[0-9]*\([0-9]*\).*/\1/')
 GPU_OPTS="--gpus device=${NVIDIA_VISIBLE_DEVICES}"
 if [ "$DOCKER_MAJOR" -lt 19 ]
 then
-    GPU_OPTS="--runtime=nvidia -e NVIDIA_VISIBLE_DEVICES='${NVIDIA_VISIBLE_DEVICES}'"
+    GPU_OPTS="--runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES}"
 fi
 
 docker run --rm -it ${GPU_OPTS} \


### PR DESCRIPTION
Currently the script is failing with a docker version < 19 with the following error:
```
container init caused \"process_linux.go:385: running prestart hook 1 caused \\\"error running hook: exit status 1, stdout: , stderr: exec command: [/usr/bin/nvidia-container-cli --load-kmods configure --ldconfig=@/sbin/ldconfig.real --device='0' --compute --utility --require=cuda>=11.0 brand=tesla,driver>=418,driver<419 brand=tesla,driver>=440,driver<441 driver>=450 --pid=40512 /raid/docker/overlay2/01b7488900f204208484913aa26e4c11866145e92a77444fa910e39d4aa532a5/merged]\\\\nnvidia-container-cli: device error: unknown device id: '0'\\\\n\\\"\"": unknown.
```
This is fixing the issue