### PR TITLE
Disable `include-ignored` coverage warnings

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,5 @@
 # Configuration file for Python coverage tests
 [run]
+disable_warnings = include-ignored
 include = dask_cuda/*
 omit = dask_cuda/tests/*


### PR DESCRIPTION
Disable warnings that are printed hundreds of times in CI:

```
/opt/conda/envs/rapids/lib/python3.8/site-packages/coverage/inorout.py:472:CoverageWarning: --include is ignored because --source is set (include-ignored)
  self.warn("--include is ignored because --source is set", slug="include-ignored")
```