### PR TITLE
Add xfail mark to `test_pre_import_not_found`

### DIFF
--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -217,6 +217,8 @@ def test_pre_import(loop):  # noqa: F811
                 assert all(imported)
 
 
+@pytest.mark.xfail(reason="https://github.com/dask/distributed/issues/6320")
+@pytest.mark.timeout(20)
 @patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0"})
 def test_pre_import_not_found():
     with popen(["dask-scheduler", "--port", "9369", "--no-dashboard"]):


### PR DESCRIPTION
Xfailing the test is needed for now due to https://github.com/dask/distributed/issues/6320 . This should not have any major impact unless the user specifies a module that cannot be imported via `--pre-import`, in which case the worker process will hang indefinitely.