### PR TITLE
[REVIEW] Upgrade `numba` pinning to be in-line with rest of rapids

### DIFF
--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -401,7 +401,7 @@ def test_compatibility_mode_dataframe_shuffle(compatibility_mode, npartitions):
                     assert all(res)  # Only proxy objects
 
 
-@gen_test(timeout=30)
+@gen_test(timeout=60)
 async def test_worker_force_spill_to_disk():
     """Test Dask triggering CPU-to-Disk spilling"""
     cudf = pytest.importorskip("cudf")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ dask>=2022.03.0
 distributed>=2022.03.0
 pynvml>=11.0.0
 numpy>=1.16.0
-numba>=0.53.1
+numba>=0.54
 click==8.0.4


### PR DESCRIPTION
This PR upgrades minimum version pinning of `numba` to `0.54` from `0.53.1` to be in-sync with rest of the rapids packages: 
https://github.com/rapidsai/integration/blob/branch-22.06/conda/recipes/versions.yaml#L114