### PR TITLE
[gpuCI] Forward-merge branch-22.06 to branch-22.08 [skip gpuci]

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2019-2022, NVIDIA CORPORATION.
 ################################################################################
 # dask-cuda cpu build
 ################################################################################
@@ -68,8 +68,11 @@ pip install git+https://github.com/dask/distributed.git@main
 # BUILD - Package builds
 ################################################################################
 
+# FIXME: Move boa install to gpuci/rapidsai
+gpuci_mamba_retry install -c conda-forge boa
+
 gpuci_logger "Build conda pkg for dask-cuda"
-gpuci_conda_retry build conda/recipes/dask-cuda --python=${PYTHON}
+gpuci_conda_retry mambabuild conda/recipes/dask-cuda --python=${PYTHON}
 
 rm -rf dist/
 python setup.py sdist bdist_wheel

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -86,10 +86,13 @@ conda list --show-channel-urls
 # BUILD - Build dask-cuda
 ################################################################################
 
+# TODO: Move boa install to gpuci/rapidsai
+gpuci_mamba_retry install boa
+
 gpuci_logger "Build and install dask-cuda"
 cd "${WORKSPACE}"
 CONDA_BLD_DIR="${WORKSPACE}/.conda-bld"
-gpuci_conda_retry build --croot "${CONDA_BLD_DIR}" conda/recipes/dask-cuda --python="${PYTHON}"
+gpuci_conda_retry mambabuild --croot "${CONDA_BLD_DIR}" conda/recipes/dask-cuda --python="${PYTHON}"
 gpuci_mamba_retry install -c "${CONDA_BLD_DIR}" dask-cuda
 
 ################################################################################


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.06` that creates a PR to keep `branch-22.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.