### PR TITLE
Import `cleanup` fixture in `test_dask_cuda_worker.py`

### DIFF
--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -10,8 +10,7 @@ import pytest
 
 from distributed import Client, wait
 from distributed.system import MEMORY_LIMIT
-from distributed.utils_test import loop  # noqa: F401
-from distributed.utils_test import popen
+from distributed.utils_test import cleanup, loop, popen  # noqa: F401
 
 from dask_cuda.utils import (
     get_gpu_count_mig,


### PR DESCRIPTION
With changes from https://github.com/dask/distributed/pull/6231 , the `loop` fixture now depends on the `cleanup` fixture, which must be imported explicitly.