### PR TITLE
Remove compiler variables

### DIFF
--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -19,9 +19,6 @@ build:
   string: py{{ py_version }}_{{ git_revision_count }}
   script_env:
     - VERSION_SUFFIX
-    - CC
-    - CXX
-    - CUDAHOSTCXX
 
 requirements:
   host:


### PR DESCRIPTION
With the PR below merged, we no longer set the `CXX`, `CC`, or `CUDAHOSTCXX` variables in any of our CI images. This PR cleans up some references to them.


- https://github.com/rapidsai/gpuci-build-environment/pull/265