### PR TITLE
Remove click pinning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ distributed==2022.05.2
 pynvml>=11.0.0
 numpy>=1.16.0
 numba>=0.54
-click==8.0.4


### PR DESCRIPTION
With the `click` breakage in Distributed presumably resolved, we should be good removing this click pinning.

Closes #931