### PR TITLE
Add --multiprocessing-method option to benchmarks

### DIFF
--- a/dask_cuda/benchmarks/local_cudf_merge.py
+++ b/dask_cuda/benchmarks/local_cudf_merge.py
@@ -488,4 +488,12 @@ def parse_args():
 
 
 if __name__ == "__main__":
-    main(parse_args())
+    args = parse_args()
+    if args.multiprocessing_method == "forkserver":
+        import multiprocessing.forkserver as f
+
+        f.ensure_running()
+    with dask.config.set(
+        {"distributed.worker.multiprocessing-method": args.multiprocessing_method}
+    ):
+        main(args)

--- a/dask_cuda/benchmarks/local_cudf_shuffle.py
+++ b/dask_cuda/benchmarks/local_cudf_shuffle.py
@@ -305,4 +305,12 @@ def parse_args():
 
 
 if __name__ == "__main__":
-    main(parse_args())
+    args = parse_args()
+    if args.multiprocessing_method == "forkserver":
+        import multiprocessing.forkserver as f
+
+        f.ensure_running()
+    with dask.config.set(
+        {"distributed.worker.multiprocessing-method": args.multiprocessing_method}
+    ):
+        main(args)

--- a/dask_cuda/benchmarks/local_cupy.py
+++ b/dask_cuda/benchmarks/local_cupy.py
@@ -7,6 +7,7 @@ from warnings import filterwarnings
 import numpy as np
 from nvtx import end_range, start_range
 
+import dask
 from dask import array as da
 from dask.distributed import Client, performance_report, wait
 from dask.utils import format_bytes, format_time, parse_bytes
@@ -400,10 +401,17 @@ def parse_args():
     )
 
 
-def main():
-    args = parse_args()
+def main(args):
     asyncio.get_event_loop().run_until_complete(run(args))
 
 
 if __name__ == "__main__":
-    main()
+    args = parse_args()
+    if args.multiprocessing_method == "forkserver":
+        import multiprocessing.forkserver as f
+
+        f.ensure_running()
+    with dask.config.set(
+        {"distributed.worker.multiprocessing-method": args.multiprocessing_method}
+    ):
+        main(args)

--- a/dask_cuda/benchmarks/local_cupy_map_overlap.py
+++ b/dask_cuda/benchmarks/local_cupy_map_overlap.py
@@ -9,6 +9,7 @@ import numpy as np
 from cupyx.scipy.ndimage.filters import convolve as cp_convolve
 from scipy.ndimage import convolve as sp_convolve
 
+import dask
 from dask import array as da
 from dask.distributed import Client, performance_report, wait
 from dask.utils import format_bytes, format_time, parse_bytes
@@ -272,10 +273,17 @@ def parse_args():
     )
 
 
-def main():
-    args = parse_args()
+def main(args):
     asyncio.get_event_loop().run_until_complete(run(args))
 
 
 if __name__ == "__main__":
-    main()
+    args = parse_args()
+    if args.multiprocessing_method == "forkserver":
+        import multiprocessing.forkserver as f
+
+        f.ensure_running()
+    with dask.config.set(
+        {"distributed.worker.multiprocessing-method": args.multiprocessing_method}
+    ):
+        main(args)

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -20,6 +20,16 @@ def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]
         help="Number of Dask threads per worker (i.e., GPU).",
     )
     parser.add_argument(
+        "--multiprocessing-method",
+        default="spawn",
+        choices=["spawn", "fork", "forkserver"],
+        type=str,
+        help="Which method should multiprocessing use to start child processes? "
+        "On supercomputing systems with a high-performance interconnect, "
+        "'forkserver' can be used to avoid issues with fork not being allowed "
+        "after the networking stack has been initialised.",
+    )
+    parser.add_argument(
         "-p",
         "--protocol",
         choices=["tcp", "ucx"],

--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -284,9 +284,7 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 @click.option(
     "--multiprocessing-method",
     default="spawn",
-    show_default=True,
-    choices=["spawn", "fork", "forkserver"],
-    show_choices=True,
+    type=click.Choice(["spawn", "fork", "forkserver"]),
     help="""Method used to start new processes with multiprocessing""",
 )
 def main(

--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -5,6 +5,7 @@ import logging
 import click
 from tornado.ioloop import IOLoop, TimeoutError
 
+from dask import config
 from distributed.cli.utils import install_signal_handlers
 from distributed.preloading import validate_preload_argv
 from distributed.security import Security
@@ -280,6 +281,14 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     bleeding through later Dask operations. Should be a list of comma-separated names,
     such as "cudf,rmm".""",
 )
+@click.option(
+    "--multiprocessing-method",
+    default="spawn",
+    show_default=True,
+    choices=["spawn", "fork", "forkserver"],
+    show_choices=True,
+    help="""Method used to start new processes with multiprocessing""",
+)
 def main(
     scheduler,
     host,
@@ -313,8 +322,13 @@ def main(
     enable_jit_unspill,
     worker_class,
     pre_import,
+    multiprocessing_method,
     **kwargs,
 ):
+    if multiprocessing_method == "forkserver":
+        import multiprocessing.forkserver as f
+
+        f.ensure_running()
     if tls_ca_file and tls_cert and tls_key:
         security = Security(
             tls_ca_file=tls_ca_file,
@@ -334,58 +348,61 @@ def main(
     if worker_class is not None:
         worker_class = import_term(worker_class)
 
-    worker = CUDAWorker(
-        scheduler,
-        host,
-        nthreads,
-        name,
-        memory_limit,
-        device_memory_limit,
-        rmm_pool_size,
-        rmm_maximum_pool_size,
-        rmm_managed_memory,
-        rmm_async,
-        rmm_log_directory,
-        rmm_track_allocations,
-        pid_file,
-        resources,
-        dashboard,
-        dashboard_address,
-        local_directory,
-        shared_filesystem,
-        scheduler_file,
-        interface,
-        preload,
-        dashboard_prefix,
-        security,
-        enable_tcp_over_ucx,
-        enable_infiniband,
-        enable_nvlink,
-        enable_rdmacm,
-        enable_jit_unspill,
-        worker_class,
-        pre_import,
-        **kwargs,
-    )
+    with config.set(
+        {"distributed.worker.multiprocessing-method": multiprocessing_method}
+    ):
+        worker = CUDAWorker(
+            scheduler,
+            host,
+            nthreads,
+            name,
+            memory_limit,
+            device_memory_limit,
+            rmm_pool_size,
+            rmm_maximum_pool_size,
+            rmm_managed_memory,
+            rmm_async,
+            rmm_log_directory,
+            rmm_track_allocations,
+            pid_file,
+            resources,
+            dashboard,
+            dashboard_address,
+            local_directory,
+            shared_filesystem,
+            scheduler_file,
+            interface,
+            preload,
+            dashboard_prefix,
+            security,
+            enable_tcp_over_ucx,
+            enable_infiniband,
+            enable_nvlink,
+            enable_rdmacm,
+            enable_jit_unspill,
+            worker_class,
+            pre_import,
+            **kwargs,
+        )
 
-    async def on_signal(signum):
-        logger.info("Exiting on signal %d", signum)
-        await worker.close()
+        async def on_signal(signum):
+            logger.info("Exiting on signal %d", signum)
+            await worker.close()
 
-    async def run():
-        await worker
-        await worker.finished()
+        async def run():
+            await worker
+            await worker.finished()
 
-    loop = IOLoop.current()
+        loop = IOLoop.current()
 
-    install_signal_handlers(loop, cleanup=on_signal)
+        install_signal_handlers(loop, cleanup=on_signal)
 
-    try:
-        loop.run_sync(run)
-    except (KeyboardInterrupt, TimeoutError):
-        pass
-    finally:
-        logger.info("End worker")
+        try:
+            loop.run_sync(run)
+        except (KeyboardInterrupt, TimeoutError):
+            pass
+        finally:
+            logger.info("End worker")
 
 
 def go():

--- a/docs/source/ucx.rst
+++ b/docs/source/ucx.rst
@@ -95,9 +95,9 @@ initialized. Symptoms include jobs randomly hanging, or crashing,
 especially when using a large number of workers. To mitigate against
 this when using Dask-CUDA's UCX integration, processes launched via
 multiprocessing should use the start processes using the
-```"forkserver"``
+`"forkserver"
 <https://docs.python.org/dev/library/multiprocessing.html#contexts-and-start-methods>`_
-method. When launching workers using ```dask-cuda-worker`` <quickstart.html#dask-cuda-worker>`_, this can be
+method. When launching workers using `dask-cuda-worker <quickstart.html#dask-cuda-worker>`_, this can be
 achieved by passing ``--multiprocessing-method forkserver`` as an
 argument. In user code, the method can be controlled with the
 ``distributed.worker.multiprocessing-method`` configuration key in
@@ -122,7 +122,7 @@ therefore do something like the following:
 
    In addition to this, at present one must also set
    ``PTXCOMPILER_CHECK_NUMBA_CODEGEN_PATCH_NEEDED=0`` in the
-   environment to avoid a subprocess call from ```ptxcompiler``
+   environment to avoid a subprocess call from `ptxcompiler
    <https://github.com/rapidsai/ptxcompiler>`_
 
 .. note::


### PR DESCRIPTION
Allows selection of the method multiprocessing uses to start child
processes. Additionally, in the forkserver case, ensure the fork
server is up and running before any computation happens.

Potentially fixes #930. Needs dask/distributed#6580.

cc: @pentschev, @quasiben