### PR TITLE
Add util functions to simplify printing benchmarks results

### DIFF
--- a/dask_cuda/benchmarks/local_cudf_merge.py
+++ b/dask_cuda/benchmarks/local_cudf_merge.py
@@ -18,6 +18,8 @@ from dask_cuda.benchmarks.utils import (
     get_scheduler_workers,
     parse_benchmark_args,
     plot_benchmark,
+    print_key_value,
+    print_separator,
     setup_memory_pool,
 )
 from dask_cuda.utils import all_to_all
@@ -273,27 +275,30 @@ def main(args):
     if args.markdown:
         print("```")
     print("Merge benchmark")
-    print("-------------------------------")
-    print(f"backend        | {args.backend}")
-    print(f"merge type     | {args.type}")
-    print(f"rows-per-chunk | {args.chunk_size}")
-    print(f"base-chunks    | {args.base_chunks}")
-    print(f"other-chunks   | {args.other_chunks}")
-    print(f"broadcast      | {broadcast}")
-    print(f"protocol       | {args.protocol}")
-    print(f"device(s)      | {args.devs}")
+    print_separator(separator="-")
+    print_key_value(key="Backend", value=f"{args.backend}")
+    print_key_value(key="Merge type", value=f"{args.type}")
+    print_key_value(key="Rows-per-chunk", value=f"{args.chunk_size}")
+    print_key_value(key="Base-chunks", value=f"{args.base_chunks}")
+    print_key_value(key="Other-chunks", value=f"{args.other_chunks}")
+    print_key_value(key="Broadcast", value=f"{broadcast}")
+    print_key_value(key="Protocol", value=f"{args.protocol}")
+    print_key_value(key="Device(s)", value=f"{args.devs}")
     if args.device_memory_limit:
-        print(f"memory-limit   | {format_bytes(args.device_memory_limit)}")
-    print(f"rmm-pool       | {(not args.disable_rmm_pool)}")
-    print(f"frac-match     | {args.frac_match}")
+        print_key_value(
+            key="Device memory limit", value=f"{format_bytes(args.device_memory_limit)}"
+        )
+    print_key_value(key="RMM Pool", value=f"{not args.disable_rmm_pool}")
+    print_key_value(key="Frac-match", value=f"{args.frac_match}")
     if args.protocol == "ucx":
-        print(f"tcp            | {args.enable_tcp_over_ucx}")
-        print(f"ib             | {args.enable_infiniband}")
-        print(f"nvlink         | {args.enable_nvlink}")
-    print(f"data-processed | {format_bytes(took_list[0][0])}")
-    print("=" * 80)
-    print("Wall-clock     | Throughput")
-    print("-" * 80)
+        print_key_value(key="TCP", value=f"{args.enable_tcp_over_ucx}")
+        print_key_value(key="InfiniBand", value=f"{args.enable_infiniband}")
+        print_key_value(key="NVLink", value=f"{args.enable_nvlink}")
+    print_key_value(key="Worker thread(s)", value=f"{args.threads_per_worker}")
+    print_key_value(key="Data processed", value=f"{format_bytes(took_list[0][0])}")
+    print_separator(separator="=")
+    print_key_value(key="Wall clock", value="Throughput")
+    print_separator(separator="-")
     t_p = []
     times = []
     for idx, (data_processed, took) in enumerate(took_list):
@@ -301,17 +306,20 @@ def main(args):
         m = format_time(took)
         times.append(took)
         t_p.append(throughput)
-        m += " " * (15 - len(m))
-        print(f"{m}| {format_bytes(throughput)}/s")
+        print_key_value(key=f"{m}", value=f"{format_bytes(throughput)}/s")
         t_runs[idx] = float(format_bytes(throughput).split(" ")[0])
     t_p = numpy.asarray(t_p)
     times = numpy.asarray(times)
-    print("=" * 80)
-    print(f"Throughput     | {format_bytes(t_p.mean())} +/- {format_bytes(t_p.std()) }")
-    print(
-        f"Wall-Clock     | {format_time(times.mean())} +/- {format_time(times.std()) }"
+    print_separator(separator="=")
+    print_key_value(
+        key="Throughput",
+        value=f"{format_bytes(t_p.mean())} +/- {format_bytes(t_p.std()) }",
     )
-    print("=" * 80)
+    print_key_value(
+        key="Wall clock",
+        value=f"{format_time(times.mean())} +/- {format_time(times.std()) }",
+    )
+    print_separator(separator="=")
     if args.markdown:
         print("\n```")
 
@@ -321,15 +329,17 @@ def main(args):
     if args.backend == "dask":
         if args.markdown:
             print("<details>\n<summary>Worker-Worker Transfer Rates</summary>\n\n```")
-        print("(w1,w2)        | 25% 50% 75% (total nbytes)")
-        print("-------------------------------")
+        print_key_value(key="(w1,w2)", value="25% 50% 75% (total nbytes)")
+        print_separator(separator="-")
         for (d1, d2), bw in sorted(bandwidths.items()):
-            fmt = (
-                "(%s,%s)        | %s %s %s (%s)"
+            key = (
+                f"({d1},{d2})"
                 if args.multi_node or args.sched_addr
-                else "(%02d,%02d)        | %s %s %s (%s)"
+                else f"({d1:02d},{d2:02d})"
             )
-            print(fmt % (d1, d2, bw[0], bw[1], bw[2], total_nbytes[(d1, d2)]))
+            print_key_value(
+                key=key, value=f"{bw[0]} {bw[1]} {bw[2]} ({total_nbytes[(d1, d2)]})"
+            )
         if args.markdown:
             print("```\n</details>\n")
 

--- a/dask_cuda/benchmarks/local_cudf_shuffle.py
+++ b/dask_cuda/benchmarks/local_cudf_shuffle.py
@@ -18,6 +18,8 @@ from dask_cuda.benchmarks.utils import (
     get_scheduler_workers,
     parse_benchmark_args,
     plot_benchmark,
+    print_key_value,
+    print_separator,
     setup_memory_pool,
 )
 from dask_cuda.utils import all_to_all
@@ -149,30 +151,32 @@ def main(args):
     if args.markdown:
         print("```")
     print("Shuffle benchmark")
-    print("-------------------------------")
-    print(f"backend        | {args.backend}")
-    print(f"partition-size | {format_bytes(args.partition_size)}")
-    print(f"in-parts       | {args.in_parts}")
-    print(f"protocol       | {args.protocol}")
-    print(f"device(s)      | {args.devs}")
+    print_separator(separator="-")
+    print_key_value(key="Backend", value=f"{args.backend}")
+    print_key_value(key="Partition size", value=f"{format_bytes(args.partition_size)}")
+    print_key_value(key="Input partitions", value=f"{args.in_parts}")
+    print_key_value(key="Protocol", value=f"{args.protocol}")
+    print_key_value(key="Device(s)", value=f"{args.devs}")
     if args.device_memory_limit:
-        print(f"memory-limit   | {format_bytes(args.device_memory_limit)}")
-    print(f"rmm-pool       | {(not args.disable_rmm_pool)}")
+        print_key_value(
+            key="Device memory limit", value=f"{format_bytes(args.device_memory_limit)}"
+        )
+    print_key_value(key="RMM Pool", value=f"{not args.disable_rmm_pool}")
     if args.protocol == "ucx":
-        print(f"tcp            | {args.enable_tcp_over_ucx}")
-        print(f"ib             | {args.enable_infiniband}")
-        print(f"nvlink         | {args.enable_nvlink}")
-    print(f"data-processed | {format_bytes(took_list[0][0])}")
-    print("===============================")
-    print("Wall-clock     | Throughput")
-    print("-------------------------------")
+        print_key_value(key="TCP", value=f"{args.enable_tcp_over_ucx}")
+        print_key_value(key="InfiniBand", value=f"{args.enable_infiniband}")
+        print_key_value(key="NVLink", value=f"{args.enable_nvlink}")
+    print_key_value(key="Worker thread(s)", value=f"{args.threads_per_worker}")
+    print_key_value(key="Data processed", value=f"{format_bytes(took_list[0][0])}")
+    print_separator(separator="=")
+    print_key_value(key="Wall clock", value="Throughput")
+    print_separator(separator="-")
     for idx, (data_processed, took) in enumerate(took_list):
         throughput = int(data_processed / took)
         m = format_time(took)
-        m += " " * (15 - len(m))
-        print(f"{m}| {format_bytes(throughput)}/s")
+        print_key_value(key=f"{m}", value=f"{format_bytes(throughput)}/s")
         t_runs[idx] = float(format_bytes(throughput).split(" ")[0])
-    print("===============================")
+    print_separator(separator="=")
     if args.markdown:
         print("\n```")
 
@@ -182,15 +186,17 @@ def main(args):
     if args.backend == "dask":
         if args.markdown:
             print("<details>\n<summary>Worker-Worker Transfer Rates</summary>\n\n```")
-        print("(w1,w2)        | 25% 50% 75% (total nbytes)")
-        print("-------------------------------")
+        print_key_value(key="(w1,w2)", value="25% 50% 75% (total nbytes)")
+        print_separator(separator="-")
         for (d1, d2), bw in sorted(bandwidths.items()):
-            fmt = (
-                "(%s,%s)        | %s %s %s (%s)"
+            key = (
+                f"({d1},{d2})"
                 if args.multi_node or args.sched_addr
-                else "(%02d,%02d)        | %s %s %s (%s)"
+                else f"({d1:02d},{d2:02d})"
             )
-            print(fmt % (d1, d2, bw[0], bw[1], bw[2], total_nbytes[(d1, d2)]))
+            print_key_value(
+                key=key, value=f"{bw[0]} {bw[1]} {bw[2]} ({total_nbytes[(d1, d2)]})"
+            )
         if args.markdown:
             print("```\n</details>\n")
 

--- a/dask_cuda/benchmarks/local_cupy.py
+++ b/dask_cuda/benchmarks/local_cupy.py
@@ -15,6 +15,8 @@ from dask_cuda.benchmarks.utils import (
     get_cluster_options,
     get_scheduler_workers,
     parse_benchmark_args,
+    print_key_value,
+    print_separator,
     setup_memory_pool,
 )
 
@@ -237,36 +239,47 @@ async def run(args):
             }
 
             print("Roundtrip benchmark")
-            print("--------------------------")
-            print(f"Operation          | {args.operation}")
-            print(f"User size          | {args.size}")
-            print(f"User second size   | {args.second_size}")
-            print(f"User chunk-size    | {args.chunk_size}")
-            print(f"Compute shape      | {size}")
-            print(f"Compute chunk-size | {chunksize}")
-            print(f"Ignore-size        | {format_bytes(args.ignore_size)}")
-            print(f"Protocol           | {args.protocol}")
-            print(f"Device(s)          | {args.devs}")
+            print_separator(separator="-")
+            print_key_value(key="Operation", value=f"{args.operation}")
+            print_key_value(key="User size", value=f"{args.size}")
+            print_key_value(key="User second size", value=f"{args.second_size}")
+            print_key_value(key="User chunk size", value=f"{args.size}")
+            print_key_value(key="Compute shape", value=f"{size}")
+            print_key_value(key="Compute chunk size", value=f"{chunksize}")
+            print_key_value(
+                key="Ignore size", value=f"{format_bytes(args.ignore_size)}"
+            )
+            print_key_value(key="Device(s)", value=f"{args.devs}")
             if args.device_memory_limit:
-                print(f"Memory limit       | {format_bytes(args.device_memory_limit)}")
-            print(f"Worker Thread(s)   | {args.threads_per_worker}")
-            print("==========================")
-            print("Wall-clock         | npartitions")
-            print("--------------------------")
+                print_key_value(
+                    key="Device memory limit",
+                    value=f"{format_bytes(args.device_memory_limit)}",
+                )
+            print_key_value(key="RMM Pool", value=f"{not args.disable_rmm_pool}")
+            print_key_value(key="Protocol", value=f"{args.protocol}")
+            if args.protocol == "ucx":
+                print_key_value(key="TCP", value=f"{args.enable_tcp_over_ucx}")
+                print_key_value(key="InfiniBand", value=f"{args.enable_infiniband}")
+                print_key_value(key="NVLink", value=f"{args.enable_nvlink}")
+            print_key_value(key="Worker thread(s)", value=f"{args.threads_per_worker}")
+            print_separator(separator="=")
+            print_key_value(key="Wall clock", value="npartitions")
+            print_separator(separator="-")
             for (took, npartitions) in took_list:
                 t = format_time(took)
-                t += " " * (11 - len(t))
-                print(f"{t}        | {npartitions}")
-            print("==========================")
-            print("(w1,w2)            | 25% 50% 75% (total nbytes)")
-            print("--------------------------")
+                print_key_value(key=f"{t}", value=f"{npartitions}")
+            print_separator(separator="=")
+            print_key_value(key="(w1,w2)", value="25% 50% 75% (total nbytes)")
+            print_separator(separator="-")
             for (d1, d2), bw in sorted(bandwidths.items()):
-                fmt = (
-                    "(%s,%s)            | %s %s %s (%s)"
+                key = (
+                    f"({d1},{d2})"
                     if args.multi_node or args.sched_addr
-                    else "(%02d,%02d)            | %s %s %s (%s)"
+                    else f"({d1:02d},{d2:02d})"
                 )
-                print(fmt % (d1, d2, bw[0], bw[1], bw[2], total_nbytes[(d1, d2)]))
+                print_key_value(
+                    key=key, value=f"{bw[0]} {bw[1]} {bw[2]} ({total_nbytes[(d1, d2)]})"
+                )
 
             if args.benchmark_json:
                 bandwidths_json = {

--- a/dask_cuda/benchmarks/local_cupy_map_overlap.py
+++ b/dask_cuda/benchmarks/local_cupy_map_overlap.py
@@ -17,6 +17,8 @@ from dask_cuda.benchmarks.utils import (
     get_cluster_options,
     get_scheduler_workers,
     parse_benchmark_args,
+    print_key_value,
+    print_separator,
     setup_memory_pool,
 )
 
@@ -126,31 +128,43 @@ async def run(args):
             }
 
             print("Roundtrip benchmark")
-            print("--------------------------")
-            print(f"Size         | {args.size}*{args.size}")
-            print(f"Chunk-size   | {args.chunk_size}")
-            print(f"Ignore-size  | {format_bytes(args.ignore_size)}")
-            print(f"Protocol     | {args.protocol}")
-            print(f"Device(s)    | {args.devs}")
+            print_separator(separator="-")
+            print_key_value(key="Size", value=f"{args.size}*{args.size}")
+            print_key_value(key="Chunk size", value=f"{args.chunk_size}")
+            print_key_value(
+                key="Ignore size", value=f"{format_bytes(args.ignore_size)}"
+            )
+            print_key_value(key="Device(s)", value=f"{args.devs}")
             if args.device_memory_limit:
-                print(f"memory-limit | {format_bytes(args.device_memory_limit)}")
-            print("==========================")
-            print("Wall-clock   | npartitions")
-            print("--------------------------")
+                print_key_value(
+                    key="Device memory limit",
+                    value=f"{format_bytes(args.device_memory_limit)}",
+                )
+            print_key_value(key="RMM Pool", value=f"{not args.disable_rmm_pool}")
+            print_key_value(key="Protocol", value=f"{args.protocol}")
+            if args.protocol == "ucx":
+                print_key_value(key="TCP", value=f"{args.enable_tcp_over_ucx}")
+                print_key_value(key="InfiniBand", value=f"{args.enable_infiniband}")
+                print_key_value(key="NVLink", value=f"{args.enable_nvlink}")
+            print_key_value(key="Worker thread(s)", value=f"{args.threads_per_worker}")
+            print_separator(separator="=")
+            print_key_value(key="Wall clock", value="npartitions")
+            print_separator(separator="-")
             for (took, npartitions) in took_list:
                 t = format_time(took)
-                t += " " * (12 - len(t))
-                print(f"{t} | {npartitions}")
-            print("==========================")
-            print("(w1,w2)      | 25% 50% 75% (total nbytes)")
-            print("--------------------------")
+                print_key_value(key=f"{t}", value=f"{npartitions}")
+            print_separator(separator="=")
+            print_key_value(key="(w1,w2)", value="25% 50% 75% (total nbytes)")
+            print_separator(separator="-")
             for (d1, d2), bw in sorted(bandwidths.items()):
-                fmt = (
-                    "(%s,%s)      | %s %s %s (%s)"
+                key = (
+                    f"({d1},{d2})"
                     if args.multi_node or args.sched_addr
-                    else "(%02d,%02d)      | %s %s %s (%s)"
+                    else f"({d1:02d},{d2:02d})"
                 )
-                print(fmt % (d1, d2, bw[0], bw[1], bw[2], total_nbytes[(d1, d2)]))
+                print_key_value(
+                    key=key, value=f"{bw[0]} {bw[1]} {bw[2]} ({total_nbytes[(d1, d2)]})"
+                )
 
             if args.benchmark_json:
                 bandwidths_json = {

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -321,3 +321,11 @@ def plot_benchmark(t_runs, path, historical=False):
         fname_hist = today + "-benchmark-history.png"
         hist_path = os.path.join(d, fname_hist)
         fig.savefig(hist_path)
+
+
+def print_separator(separator="-", length=80):
+    print(separator * length)
+
+
+def print_key_value(key, value, key_length=25):
+    print(f"{key: <{key_length}} | {value}")


### PR DESCRIPTION
Two new utility functions are added to print benchmarks results to avoid the need to rearrange number of individual white spaces or separator lengths any time a new longer row is added, also preventing the count of spaces given indentation of code.