### PR TITLE
[REVIEW] Switch `language` from `None` to `"en"` in docs build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -72,7 +72,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
Needed for Sphinx 5 compatibility. Should fix the following warning occurring in doc builds.

```
Invalid configuration value found: 'language = None'. Update your configuration to a valid language code. Falling back to 'en' (English).
```

xref: https://github.com/sphinx-doc/sphinx/pull/10481
