### PR TITLE
Benchmark refactoring: tidy data and multi-node capability via `--scheduler-file`

### DIFF
--- a/dask_cuda/benchmarks/common.py
+++ b/dask_cuda/benchmarks/common.py
@@ -1,0 +1,164 @@
+from argparse import Namespace
+from functools import partial
+from typing import Any, Callable, List, Mapping, NamedTuple, Optional, Tuple
+from warnings import filterwarnings
+
+import numpy as np
+import pandas as pd
+
+from distributed import Client
+
+from dask_cuda.benchmarks.utils import (
+    address_to_index,
+    aggregate_transfer_log_data,
+    bandwidth_statistics,
+    get_cluster_options,
+    get_worker_addresses,
+    peer_to_peer_bandwidths,
+    save_benchmark_data,
+    setup_memory_pools,
+    wait_for_cluster,
+)
+from dask_cuda.utils import all_to_all
+
+__all__ = ("run_client_from_file", "run_create_client")
+
+
+class Config(NamedTuple):
+    """Benchmark configuration"""
+
+    bench_once: Callable[[Client, Namespace, Optional[str]], Any]
+    """Callable to run a single benchmark iteration
+
+    Parameters
+    ----------
+    client
+        distributed Client object
+    args
+        Benchmark parsed arguments
+    write_profile
+        Should a profile be written?
+
+    Returns
+    -------
+    Benchmark data to be interpreted by ``pretty_print_results`` and
+    ``create_tidy_results``.
+    """
+    create_tidy_results: Callable[
+        [Namespace, np.ndarray, List[Any]], Tuple[pd.DataFrame, np.ndarray]
+    ]
+    """Callable to create tidy results for saving to disk
+
+    Parameters
+    ----------
+    args
+        Benchmark parsed arguments
+    p2p_bw
+        Array of point-to-point bandwidths
+    results: list
+        List of results from running ``bench_once``
+    Returns
+    -------
+    tuple
+        two-tuple of a pandas dataframe and the point-to-point bandwidths
+    """
+    pretty_print_results: Callable[
+        [Namespace, Mapping[str, int], np.ndarray, List[Any]], None
+    ]
+    """Callable to pretty-print results for human consumption
+
+    Parameters
+    ----------
+    args
+        Benchmark parsed arguments
+    address_to_index
+        Mapping from worker addresses to indices
+    p2p_bw
+        Array of point-to-point bandwidths
+    results: list
+        List of results from running ``bench_once``
+    """
+
+
+def run_benchmark(client: Client, args: Namespace, config: Config):
+    """Run a benchmark a specified number of times
+
+    If ``args.profile`` is set, the final run is profiled."""
+    results = []
+    for _ in range(max(1, args.runs) - 1):
+        res = config.bench_once(client, args, write_profile=None)
+        results.append(res)
+    results.append(config.bench_once(client, args, write_profile=args.profile))
+    return results
+
+
+def gather_bench_results(client: Client, args: Namespace, config: Config):
+    """Collect benchmark results from the workers"""
+    address2index = address_to_index(client.run_on_scheduler(get_worker_addresses))
+    if args.all_to_all:
+        all_to_all(client)
+    results = run_benchmark(client, args, config)
+    # Collect aggregated peer-to-peer bandwidth
+    message_data = client.run(
+        partial(aggregate_transfer_log_data, bandwidth_statistics, args.ignore_size)
+    )
+    return address2index, results, message_data
+
+
+def run(client: Client, args: Namespace, config: Config):
+    """Run the full benchmark on the cluster
+
+    Waits for the cluster, sets up memory pools, prints and saves results"""
+    wait_for_cluster(client, shutdown_on_failure=True)
+    setup_memory_pools(
+        client,
+        args.type == "gpu",
+        args.rmm_pool_size,
+        args.disable_rmm_pool,
+        args.rmm_log_directory,
+    )
+    address_to_index, results, message_data = gather_bench_results(client, args, config)
+    p2p_bw = peer_to_peer_bandwidths(message_data, address_to_index)
+    config.pretty_print_results(args, address_to_index, p2p_bw, results)
+    if args.output_basename:
+        save_benchmark_data(
+            args.output_basename,
+            address_to_index,
+            *config.create_tidy_results(args, p2p_bw, results),
+        )
+
+
+def run_client_from_file(args: Namespace, config: Config):
+    """Set up a client by connecting to a scheduler and run
+
+    Shuts down the cluster at the end of the benchmark
+    """
+    scheduler_file = args.scheduler_file
+    if scheduler_file is None:
+        raise RuntimeError("Need scheduler file to be provided")
+    with Client(scheduler_file=scheduler_file) as client:
+        run(client, args, config)
+        client.shutdown()
+
+
+def run_create_client(args, config):
+    """Create a client + cluster and run
+
+    Shuts down the cluster at the end of the benchmark"""
+    cluster_options = get_cluster_options(args)
+    Cluster = cluster_options["class"]
+    cluster_args = cluster_options["args"]
+    cluster_kwargs = cluster_options["kwargs"]
+    scheduler_addr = cluster_options["scheduler_addr"]
+
+    filterwarnings("ignore", message=".*NVLink.*rmm_pool_size.*", category=UserWarning)
+
+    with Cluster(*cluster_args, **cluster_kwargs) as cluster:
+        # Use the scheduler address with an SSHCluster rather than the cluster
+        # object, otherwise we can't shut it down.
+        with Client(scheduler_addr if args.multi_node else cluster) as client:
+            run(client, args, config)
+            # An SSHCluster will not automatically shut down, we have to
+            # ensure it does.
+            if args.multi_node:
+                client.shutdown()

--- a/dask_cuda/benchmarks/common.py
+++ b/dask_cuda/benchmarks/common.py
@@ -14,7 +14,6 @@ from dask_cuda.benchmarks.utils import (
     aggregate_transfer_log_data,
     bandwidth_statistics,
     get_cluster_options,
-    get_worker_addresses,
     peer_to_peer_bandwidths,
     save_benchmark_data,
     setup_memory_pools,
@@ -97,7 +96,7 @@ def run_benchmark(client: Client, args: Namespace, config: Config):
 
 def gather_bench_results(client: Client, args: Namespace, config: Config):
     """Collect benchmark results from the workers"""
-    address2index = address_to_index(client.run_on_scheduler(get_worker_addresses))
+    address2index = address_to_index(client)
     if args.all_to_all:
         all_to_all(client)
     results = run_benchmark(client, args, config)

--- a/dask_cuda/benchmarks/common.py
+++ b/dask_cuda/benchmarks/common.py
@@ -21,7 +21,7 @@ from dask_cuda.benchmarks.utils import (
 )
 from dask_cuda.utils import all_to_all
 
-__all__ = ("run_client_from_file", "run_create_client")
+__all__ = ("run_client_from_file", "run_create_client", "Config")
 
 
 class Config(NamedTuple):

--- a/dask_cuda/benchmarks/local_cudf_merge.py
+++ b/dask_cuda/benchmarks/local_cudf_merge.py
@@ -1,11 +1,13 @@
 import contextlib
+import itertools
 import math
-from collections import defaultdict
-from json import dumps
+import operator
+from collections import ChainMap, defaultdict
 from time import perf_counter
 from warnings import filterwarnings
 
-import numpy
+import numpy as np
+import pandas as pd
 
 import dask
 from dask.base import tokenize
@@ -18,7 +20,10 @@ from dask_cuda.benchmarks.utils import (
     get_scheduler_workers,
     parse_benchmark_args,
     plot_benchmark,
-    setup_memory_pool,
+    setup_memory_pools,
+    wait_for_cluster,
+    worker_renamer,
+    write_benchmark_data_as_json,
 )
 from dask_cuda.utils import all_to_all
 
@@ -104,7 +109,7 @@ def generate_chunk(i_chunk, local_size, num_chunks, chunk_type, frac_match, gpu)
 
 def get_random_ddf(chunk_size, num_chunks, frac_match, chunk_type, args):
 
-    parts = [chunk_size for i in range(num_chunks)]
+    parts = [chunk_size for _ in range(num_chunks)]
     device_type = True if args.type == "gpu" else False
     meta = generate_chunk(0, 4, 1, chunk_type, None, device_type)
     divisions = [None] * (len(parts) + 1)
@@ -151,7 +156,7 @@ def merge(args, ddf1, ddf2):
     wait(ddf_join.persist())
 
 
-def run(client, args, n_workers, write_profile=None):
+def bench_once(client, args, write_profile=None):
     # Generate random Dask dataframes
     ddf_base = get_random_ddf(
         args.chunk_size, args.base_chunks, args.frac_match, "build", args
@@ -183,67 +188,7 @@ def run(client, args, n_workers, write_profile=None):
     return (data_processed, t2 - t1)
 
 
-def main(args):
-    cluster_options = get_cluster_options(args)
-    Cluster = cluster_options["class"]
-    cluster_args = cluster_options["args"]
-    cluster_kwargs = cluster_options["kwargs"]
-    scheduler_addr = cluster_options["scheduler_addr"]
-
-    if args.sched_addr:
-        client = Client(args.sched_addr)
-    else:
-        filterwarnings(
-            "ignore", message=".*NVLink.*rmm_pool_size.*", category=UserWarning
-        )
-
-        cluster = Cluster(*cluster_args, **cluster_kwargs)
-        if args.multi_node:
-            import time
-
-            # Allow some time for workers to start and connect to scheduler
-            # TODO: make this a command-line argument?
-            time.sleep(15)
-
-        client = Client(scheduler_addr if args.multi_node else cluster)
-
-    if args.type == "gpu":
-        client.run(
-            setup_memory_pool,
-            pool_size=args.rmm_pool_size,
-            disable_pool=args.disable_rmm_pool,
-            log_directory=args.rmm_log_directory,
-        )
-        # Create an RMM pool on the scheduler due to occasional deserialization
-        # of CUDA objects. May cause issues with InfiniBand otherwise.
-        client.run_on_scheduler(
-            setup_memory_pool,
-            pool_size=1e9,
-            disable_pool=args.disable_rmm_pool,
-            log_directory=args.rmm_log_directory,
-        )
-
-    scheduler_workers = client.run_on_scheduler(get_scheduler_workers)
-    n_workers = len(scheduler_workers)
-    client.wait_for_workers(n_workers)
-
-    # Allow the number of chunks to vary between
-    # the "base" and "other" DataFrames
-    args.base_chunks = args.base_chunks or n_workers
-    args.other_chunks = args.other_chunks or n_workers
-
-    if args.all_to_all:
-        all_to_all(client)
-
-    took_list = []
-    for _ in range(args.runs - 1):
-        took_list.append(run(client, args, n_workers, write_profile=None))
-    took_list.append(
-        run(client, args, n_workers, write_profile=args.profile)
-    )  # Only profiling the last run
-
-    # Collect, aggregate, and print peer-to-peer bandwidths
-    incoming_logs = client.run(lambda dask_worker: dask_worker.incoming_transfer_log)
+def pretty_print_results(args, incoming_logs, scheduler_workers, results):
     bandwidths = defaultdict(list)
     total_nbytes = defaultdict(list)
     for k, L in incoming_logs.items():
@@ -251,16 +196,20 @@ def main(args):
             if d["total"] >= args.ignore_size:
                 bandwidths[k, d["who"]].append(d["bandwidth"])
                 total_nbytes[k, d["who"]].append(d["total"])
+    renamer = worker_renamer(
+        scheduler_workers.values(),
+        args.multi_node or args.sched_addr or args.scheduler_file,
+    )
     bandwidths = {
-        (scheduler_workers[w1].name, scheduler_workers[w2].name): [
-            "%s/s" % format_bytes(x) for x in numpy.quantile(v, [0.25, 0.50, 0.75])
+        (renamer(scheduler_workers[w1].name), renamer(scheduler_workers[w2].name)): [
+            "%s/s" % format_bytes(x) for x in np.quantile(v, [0.25, 0.50, 0.75])
         ]
         for (w1, w2), v in bandwidths.items()
     }
     total_nbytes = {
         (
-            scheduler_workers[w1].name,
-            scheduler_workers[w2].name,
+            renamer(scheduler_workers[w1].name),
+            renamer(scheduler_workers[w2].name),
         ): format_bytes(sum(nb))
         for (w1, w2), nb in total_nbytes.items()
     }
@@ -269,7 +218,7 @@ def main(args):
         False if args.shuffle_join else (True if args.broadcast_join else "default")
     )
 
-    t_runs = numpy.empty(len(took_list))
+    t_runs = np.empty(len(results))
     if args.markdown:
         print("```")
     print("Merge benchmark")
@@ -290,13 +239,13 @@ def main(args):
         print(f"tcp            | {args.enable_tcp_over_ucx}")
         print(f"ib             | {args.enable_infiniband}")
         print(f"nvlink         | {args.enable_nvlink}")
-    print(f"data-processed | {format_bytes(took_list[0][0])}")
+    print(f"data-processed | {format_bytes(results[0][0])}")
     print("=" * 80)
     print("Wall-clock     | Throughput")
     print("-" * 80)
     t_p = []
     times = []
-    for idx, (data_processed, took) in enumerate(took_list):
+    for idx, (data_processed, took) in enumerate(results):
         throughput = int(data_processed / took)
         m = format_time(took)
         times.append(took)
@@ -304,8 +253,8 @@ def main(args):
         m += " " * (15 - len(m))
         print(f"{m}| {format_bytes(throughput)}/s")
         t_runs[idx] = float(format_bytes(throughput).split(" ")[0])
-    t_p = numpy.asarray(t_p)
-    times = numpy.asarray(times)
+    t_p = np.asarray(t_p)
+    times = np.asarray(times)
     print("=" * 80)
     print(f"Throughput     | {format_bytes(t_p.mean())} +/- {format_bytes(t_p.std()) }")
     print(
@@ -324,59 +273,167 @@ def main(args):
         print("(w1,w2)        | 25% 50% 75% (total nbytes)")
         print("-------------------------------")
         for (d1, d2), bw in sorted(bandwidths.items()):
-            fmt = (
-                "(%s,%s)        | %s %s %s (%s)"
-                if args.multi_node or args.sched_addr
-                else "(%02d,%02d)        | %s %s %s (%s)"
-            )
-            print(fmt % (d1, d2, bw[0], bw[1], bw[2], total_nbytes[(d1, d2)]))
+            n1 = f"{d1[0]}-{d1[1]}"
+            n2 = f"{d2[0]}-{d2[1]}"
+            fmt = "(%s,%s)        | %s %s %s (%s)"
+            print(fmt % (n1, n2, bw[0], bw[1], bw[2], total_nbytes[(d1, d2)]))
         if args.markdown:
             print("```\n</details>\n")
 
-    if args.benchmark_json:
-        bandwidths_json = {
-            "bandwidth_({d1},{d2})_{i}"
-            if args.multi_node or args.sched_addr
-            else "(%02d,%02d)_%s" % (d1, d2, i): parse_bytes(v.rstrip("/s"))
-            for (d1, d2), bw in sorted(bandwidths.items())
-            for i, v in zip(
-                ["25%", "50%", "75%", "total_nbytes"],
-                [bw[0], bw[1], bw[2], total_nbytes[(d1, d2)]],
-            )
-        }
 
-        with open(args.benchmark_json, "a") as fp:
-            for data_processed, took in took_list:
-                fp.write(
-                    dumps(
-                        dict(
-                            {
-                                "backend": args.backend,
-                                "merge_type": args.type,
-                                "rows_per_chunk": args.chunk_size,
-                                "base_chunks": args.base_chunks,
-                                "other_chunks": args.other_chunks,
-                                "broadcast": broadcast,
-                                "protocol": args.protocol,
-                                "devs": args.devs,
-                                "device_memory_limit": args.device_memory_limit,
-                                "rmm_pool": not args.disable_rmm_pool,
-                                "tcp": args.enable_tcp_over_ucx,
-                                "ib": args.enable_infiniband,
-                                "nvlink": args.enable_nvlink,
-                                "data_processed": data_processed,
-                                "wall_clock": took,
-                                "throughput": data_processed / took,
-                            },
-                            **bandwidths_json,
-                        )
+def create_tidy_results(args, incoming_logs, scheduler_workers, results):
+    result, *_ = results
+    broadcast = (
+        False if args.shuffle_join else (True if args.broadcast_join else "default")
+    )
+    configuration = {
+        "backend": args.backend,
+        "merge_type": args.type,
+        "base_chunks": args.base_chunks,
+        "other_chunks": args.other_chunks,
+        "broadcast": broadcast,
+        "rows_per_chunk": args.chunk_size,
+        "ignore_size": args.ignore_size,
+        "frac_match": args.frac_match,
+        "devices": args.devs,
+        "device_memory_limit": args.device_memory_limit,
+        "worker_threads": args.threads_per_worker,
+        "rmm_pool": not args.disable_rmm_pool,
+        "protocol": args.protocol,
+        "tcp": args.enable_tcp_over_ucx,
+        "ib": args.enable_infiniband,
+        "nvlink": args.enable_nvlink,
+        "nreps": args.runs,
+        "data_processed": result[0],
+    }
+    series = []
+    times = np.asarray([r[1] for r in results], dtype=float)
+    q25, q75 = np.quantile(times, [0.25, 0.75])
+    timing = {
+        "time_mean": times.mean(),
+        "time_median": np.median(times),
+        "time_std": times.std(),
+        "time_q25": q25,
+        "time_q75": q75,
+        "time_min": times.min(),
+        "time_max": times.max(),
+    }
+    if args.backend == "dask":
+        # worker-to-worker bandwidth available
+        bandwidths = defaultdict(list)
+        total_nbytes = defaultdict(list)
+
+        renamer = worker_renamer(
+            scheduler_workers.values(),
+            args.multi_node or args.sched_addr or args.scheduler_file,
+        )
+
+        for k, L in incoming_logs.items():
+            source = scheduler_workers[k].name
+            for d in L:
+                dest = scheduler_workers[d["who"]].name
+                key = tuple(map(renamer, (source, dest)))
+                bandwidths[key].append(d["bandwidth"])
+                total_nbytes[key].append(d["total"])
+        for (_, group) in itertools.groupby(
+            sorted(bandwidths.keys()), key=operator.itemgetter(0)
+        ):
+            for key in group:
+                ((source_node, source_device), (dest_node, dest_device)) = key
+                bandwidth = np.asarray(bandwidths[key])
+                nbytes = np.asarray(total_nbytes[key])
+                q25, q75 = np.quantile(bandwidth, [0.25, 0.75])
+                data = pd.Series(
+                    data=ChainMap(
+                        configuration,
+                        timing,
+                        {
+                            "source_node": source_node,
+                            "source_device": source_device,
+                            "dest_node": dest_node,
+                            "dest_device": dest_device,
+                            "total_bytes": nbytes.sum(),
+                            "bandwidth_mean": bandwidth.mean(),
+                            "bandwidth_median": np.median(bandwidth),
+                            "bandwidth_std": bandwidth.std(),
+                            "bandwidth_q25": q25,
+                            "bandwidth_q75": q75,
+                            "bandwidth_min": bandwidth.min(),
+                            "bandwidth_max": bandwidth.max(),
+                        },
                     )
-                    + "\n"
                 )
+                series.append(data)
+        return pd.DataFrame(series)
+    else:
+        return pd.DataFrame([pd.Series(data=ChainMap(configuration, timing))])
 
-    if args.multi_node:
+
+def run_benchmark(client, args):
+    results = []
+    for _ in range(max(1, args.runs) - 1):
+        results.append(bench_once(client, args, write_profile=None))
+    # Only profile final run (if wanted)
+    results.append(bench_once(client, args, write_profile=args.profile))
+    return results
+
+
+def gather_bench_results(client, args):
+    scheduler_workers = client.run_on_scheduler(get_scheduler_workers)
+    n_workers = len(scheduler_workers)
+    client.wait_for_workers(n_workers)
+    # Allow the number of chunks to vary between
+    # the "base" and "other" DataFrames
+    args.base_chunks = args.base_chunks or n_workers
+    args.other_chunks = args.other_chunks or n_workers
+    if args.all_to_all:
+        all_to_all(client)
+    results = run_benchmark(client, args)
+    # Collect, aggregate, and print peer-to-peer bandwidths
+    incoming_logs = client.run(lambda dask_worker: dask_worker.incoming_transfer_log)
+    return scheduler_workers, results, incoming_logs
+
+
+def run(client, args):
+    wait_for_cluster(client, shutdown_on_failure=True)
+    setup_memory_pools(
+        client,
+        args.type == "gpu",
+        args.rmm_pool_size,
+        args.disable_rmm_pool,
+        args.rmm_log_directory,
+    )
+    scheduler_workers, results, incoming_logs = gather_bench_results(client, args)
+    pretty_print_results(args, incoming_logs, scheduler_workers, results)
+    if args.benchmark_json:
+        write_benchmark_data_as_json(
+            args.benchmark_json,
+            create_tidy_results(args, incoming_logs, scheduler_workers, results),
+        )
+
+
+def run_client_from_file(args):
+    scheduler_file = args.scheduler_file
+    if scheduler_file is None:
+        raise RuntimeError("Need scheduler file to be provided")
+    with Client(scheduler_file=scheduler_file) as client:
+        run(client, args)
         client.shutdown()
-        client.close()
+
+
+def run_create_client(args):
+    cluster_options = get_cluster_options(args)
+    Cluster = cluster_options["class"]
+    cluster_args = cluster_options["args"]
+    cluster_kwargs = cluster_options["kwargs"]
+    scheduler_addr = cluster_options["scheduler_addr"]
+
+    filterwarnings("ignore", message=".*NVLink.*rmm_pool_size.*", category=UserWarning)
+    with Cluster(*cluster_args, **cluster_kwargs) as cluster:
+        with Client(scheduler_addr if args.multi_node else cluster) as client:
+            run(client, args)
+            if args.multi_node:
+                client.shutdown()
 
 
 def parse_args():
@@ -478,4 +535,8 @@ def parse_args():
 
 
 if __name__ == "__main__":
-    main(parse_args())
+    args = parse_args()
+    if args.scheduler_file is not None:
+        run_client_from_file(args)
+    else:
+        run_create_client(args)

--- a/dask_cuda/benchmarks/local_cudf_merge.py
+++ b/dask_cuda/benchmarks/local_cudf_merge.py
@@ -12,7 +12,7 @@ from dask.dataframe.core import new_dd_object
 from dask.distributed import performance_report, wait
 from dask.utils import format_bytes, parse_bytes
 
-from dask_cuda.benchmarks.common import Config, run_client_from_file, run_create_client
+from dask_cuda.benchmarks.common import Config, execute_benchmark
 from dask_cuda.benchmarks.utils import (
     parse_benchmark_args,
     print_key_value,
@@ -360,20 +360,11 @@ def parse_args():
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    if args.multiprocessing_method == "forkserver":
-        import multiprocessing.forkserver as f
-
-        f.ensure_running()
-    with dask.config.set(
-        {"distributed.worker.multiprocessing-method": args.multiprocessing_method}
-    ):
-        config = Config(
+    execute_benchmark(
+        Config(
+            args=parse_args(),
             bench_once=bench_once,
             create_tidy_results=create_tidy_results,
             pretty_print_results=pretty_print_results,
         )
-        if args.scheduler_file is not None:
-            run_client_from_file(args, config)
-        else:
-            run_create_client(args, config)
+    )

--- a/dask_cuda/benchmarks/local_cudf_shuffle.py
+++ b/dask_cuda/benchmarks/local_cudf_shuffle.py
@@ -1,30 +1,23 @@
 import contextlib
-from json import dumps
+from collections import ChainMap
 from time import perf_counter as clock
-from warnings import filterwarnings
 
-import numpy as np
+import pandas as pd
 
 import dask
 from dask import array as da
 from dask.dataframe.shuffle import shuffle
-from dask.distributed import Client, performance_report, wait
-from dask.utils import format_bytes, format_time, parse_bytes
+from dask.distributed import performance_report, wait
+from dask.utils import format_bytes, parse_bytes
 
 import dask_cuda.explicit_comms.dataframe.shuffle
+from dask_cuda.benchmarks.common import Config, run_client_from_file, run_create_client
 from dask_cuda.benchmarks.utils import (
-    get_cluster_options,
-    get_scheduler_workers,
-    hmean,
-    hstd,
     parse_benchmark_args,
-    peer_to_peer_bandwidths,
-    plot_benchmark,
     print_key_value,
     print_separator,
-    setup_memory_pool,
+    print_throughput_bandwidth,
 )
-from dask_cuda.utils import all_to_all
 
 
 def shuffle_dask(df):
@@ -39,7 +32,7 @@ def shuffle_explicit_comms(df):
     )
 
 
-def run(client, args, n_workers, write_profile=None):
+def bench_once(client, args, write_profile=None):
     # Generate random Dask dataframe
     chunksize = args.partition_size // 8  # Convert bytes to float64
     nchunks = args.in_parts
@@ -72,69 +65,7 @@ def run(client, args, n_workers, write_profile=None):
     return (data_processed, t2 - t1)
 
 
-def main(args):
-    cluster_options = get_cluster_options(args)
-    Cluster = cluster_options["class"]
-    cluster_args = cluster_options["args"]
-    cluster_kwargs = cluster_options["kwargs"]
-    scheduler_addr = cluster_options["scheduler_addr"]
-
-    if args.sched_addr:
-        client = Client(args.sched_addr)
-    else:
-        filterwarnings(
-            "ignore", message=".*NVLink.*rmm_pool_size.*", category=UserWarning
-        )
-
-        cluster = Cluster(*cluster_args, **cluster_kwargs)
-        if args.multi_node:
-            import time
-
-            # Allow some time for workers to start and connect to scheduler
-            # TODO: make this a command-line argument?
-            time.sleep(15)
-
-        client = Client(scheduler_addr if args.multi_node else cluster)
-
-    if args.type == "gpu":
-        client.run(
-            setup_memory_pool,
-            pool_size=args.rmm_pool_size,
-            disable_pool=args.disable_rmm_pool,
-            log_directory=args.rmm_log_directory,
-        )
-        # Create an RMM pool on the scheduler due to occasional deserialization
-        # of CUDA objects. May cause issues with InfiniBand otherwise.
-        client.run_on_scheduler(
-            setup_memory_pool,
-            pool_size=1e9,
-            disable_pool=args.disable_rmm_pool,
-            log_directory=args.rmm_log_directory,
-        )
-
-    scheduler_workers = client.run_on_scheduler(get_scheduler_workers)
-    n_workers = len(scheduler_workers)
-    client.wait_for_workers(n_workers)
-
-    if args.all_to_all:
-        all_to_all(client)
-
-    took_list = []
-    for _ in range(args.runs - 1):
-        took_list.append(run(client, args, n_workers, write_profile=None))
-    took_list.append(
-        run(client, args, n_workers, write_profile=args.profile)
-    )  # Only profiling the last run
-
-    incoming_logs = client.run(lambda dask_worker: dask_worker.incoming_transfer_log)
-    p2p_bw_dict = peer_to_peer_bandwidths(
-        incoming_logs, scheduler_workers, args.ignore_size
-    )
-    bandwidths = p2p_bw_dict["bandwidths"]
-    bandwidths_all = p2p_bw_dict["bandwidths_all"]
-    total_nbytes = p2p_bw_dict["total_nbytes"]
-
-    t_runs = np.empty(len(took_list))
+def pretty_print_results(args, address_to_index, p2p_bw, results):
     if args.markdown:
         print("```")
     print("Shuffle benchmark")
@@ -154,102 +85,41 @@ def main(args):
         print_key_value(key="InfiniBand", value=f"{args.enable_infiniband}")
         print_key_value(key="NVLink", value=f"{args.enable_nvlink}")
     print_key_value(key="Worker thread(s)", value=f"{args.threads_per_worker}")
-    print_key_value(key="Data processed", value=f"{format_bytes(took_list[0][0])}")
-    print_separator(separator="=")
-    print_key_value(key="Wall clock", value="Throughput")
-    print_separator(separator="-")
-    t_p = []
-    times = []
-    for idx, (data_processed, took) in enumerate(took_list):
-        throughput = int(data_processed / took)
-        m = format_time(took)
-        times.append(took)
-        t_p.append(throughput)
-        print_key_value(key=f"{m}", value=f"{format_bytes(throughput)}/s")
-        t_runs[idx] = float(format_bytes(throughput).split(" ")[0])
-    t_p = np.asarray(t_p)
-    times = np.asarray(times)
-    bandwidths_all = np.asarray(bandwidths_all)
-    print_separator(separator="=")
-    print_key_value(
-        key="Throughput",
-        value=f"{format_bytes(hmean(t_p))}/s +/- {format_bytes(hstd(t_p))}/s",
-    )
-    print_key_value(
-        key="Bandwidth",
-        value=f"{format_bytes(hmean(bandwidths_all))}/s +/- "
-        f"{format_bytes(hstd(bandwidths_all))}/s",
-    )
-    print_key_value(
-        key="Wall clock",
-        value=f"{format_time(times.mean())} +/- {format_time(times.std()) }",
-    )
-    print_separator(separator="=")
-
+    print_key_value(key="Data processed", value=f"{format_bytes(results[0][0])}")
     if args.markdown:
         print("\n```")
+    data_processed, durations = zip(*results)
+    print_throughput_bandwidth(
+        args, durations, data_processed, p2p_bw, address_to_index
+    )
 
-    if args.plot is not None:
-        plot_benchmark(t_runs, args.plot, historical=True)
 
-    if args.backend == "dask":
-        if args.markdown:
-            print("<details>\n<summary>Worker-Worker Transfer Rates</summary>\n\n```")
-        print_key_value(key="(w1,w2)", value="25% 50% 75% (total nbytes)")
-        print_separator(separator="-")
-        for (d1, d2), bw in sorted(bandwidths.items()):
-            key = (
-                f"({d1},{d2})"
-                if args.multi_node or args.sched_addr
-                else f"({d1:02d},{d2:02d})"
-            )
-            print_key_value(
-                key=key, value=f"{bw[0]} {bw[1]} {bw[2]} ({total_nbytes[(d1, d2)]})"
-            )
-        if args.markdown:
-            print("```\n</details>\n")
-
-    if args.benchmark_json:
-        bandwidths_json = {
-            "bandwidth_({d1},{d2})_{i}"
-            if args.multi_node or args.sched_addr
-            else "(%02d,%02d)_%s" % (d1, d2, i): parse_bytes(v.rstrip("/s"))
-            for (d1, d2), bw in sorted(bandwidths.items())
-            for i, v in zip(
-                ["25%", "50%", "75%", "total_nbytes"],
-                [bw[0], bw[1], bw[2], total_nbytes[(d1, d2)]],
-            )
-        }
-
-        with open(args.benchmark_json, "a") as fp:
-            for data_processed, took in took_list:
-                fp.write(
-                    dumps(
-                        dict(
-                            {
-                                "backend": args.backend,
-                                "partition_size": args.partition_size,
-                                "in_parts": args.in_parts,
-                                "protocol": args.protocol,
-                                "devs": args.devs,
-                                "device_memory_limit": args.device_memory_limit,
-                                "rmm_pool": not args.disable_rmm_pool,
-                                "tcp": args.enable_tcp_over_ucx,
-                                "ib": args.enable_infiniband,
-                                "nvlink": args.enable_nvlink,
-                                "data_processed": data_processed,
-                                "wall_clock": took,
-                                "throughput": data_processed / took,
-                            },
-                            **bandwidths_json,
-                        )
-                    )
-                    + "\n"
+def create_tidy_results(args, p2p_bw, results):
+    configuration = {
+        "dataframe_type": "cudf" if args.type == "gpu" else "pandas",
+        "backend": args.backend,
+        "partition_size": args.partition_size,
+        "in_parts": args.in_parts,
+        "protocol": args.protocol,
+        "devs": args.devs,
+        "device_memory_limit": args.device_memory_limit,
+        "rmm_pool": not args.disable_rmm_pool,
+        "tcp": args.enable_tcp_over_ucx,
+        "ib": args.enable_infiniband,
+        "nvlink": args.enable_nvlink,
+    }
+    timing_data = pd.DataFrame(
+        [
+            pd.Series(
+                data=ChainMap(
+                    configuration,
+                    {"wallclock": duration, "data_processed": data_processed},
                 )
-
-    if args.multi_node:
-        client.shutdown()
-        client.close()
+            )
+            for data_processed, duration in results
+        ]
+    )
+    return timing_data, p2p_bw
 
 
 def parse_args():
@@ -296,11 +166,6 @@ def parse_args():
             "help": "Ignore messages smaller than this (default '1 MB')",
         },
         {
-            "name": "--markdown",
-            "action": "store_true",
-            "help": "Write output as markdown",
-        },
-        {
             "name": "--runs",
             "default": 3,
             "type": int,
@@ -314,4 +179,13 @@ def parse_args():
 
 
 if __name__ == "__main__":
-    main(parse_args())
+    args = parse_args()
+    config = Config(
+        bench_once=bench_once,
+        create_tidy_results=create_tidy_results,
+        pretty_print_results=pretty_print_results,
+    )
+    if args.scheduler_file is not None:
+        run_client_from_file(args, config)
+    else:
+        run_create_client(args, config)

--- a/dask_cuda/benchmarks/local_cudf_shuffle.py
+++ b/dask_cuda/benchmarks/local_cudf_shuffle.py
@@ -11,7 +11,7 @@ from dask.distributed import performance_report, wait
 from dask.utils import format_bytes, parse_bytes
 
 import dask_cuda.explicit_comms.dataframe.shuffle
-from dask_cuda.benchmarks.common import Config, run_client_from_file, run_create_client
+from dask_cuda.benchmarks.common import Config, execute_benchmark
 from dask_cuda.benchmarks.utils import (
     parse_benchmark_args,
     print_key_value,
@@ -179,20 +179,11 @@ def parse_args():
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    if args.multiprocessing_method == "forkserver":
-        import multiprocessing.forkserver as f
-
-        f.ensure_running()
-    with dask.config.set(
-        {"distributed.worker.multiprocessing-method": args.multiprocessing_method}
-    ):
-        config = Config(
+    execute_benchmark(
+        Config(
+            args=parse_args(),
             bench_once=bench_once,
             create_tidy_results=create_tidy_results,
             pretty_print_results=pretty_print_results,
         )
-        if args.scheduler_file is not None:
-            run_client_from_file(args, config)
-        else:
-            run_create_client(args, config)
+    )

--- a/dask_cuda/benchmarks/local_cupy.py
+++ b/dask_cuda/benchmarks/local_cupy.py
@@ -21,6 +21,7 @@ from dask_cuda.benchmarks.utils import (
     worker_renamer,
     write_benchmark_data_as_json,
 )
+from dask_cuda.utils import all_to_all
 
 
 def bench_once(client, args):
@@ -322,6 +323,8 @@ def run_benchmark(client, args):
 
 def gather_bench_results(client, args):
     scheduler_workers = client.run_on_scheduler(get_scheduler_workers)
+    if args.all_to_all:
+        all_to_all(client)
     results = run_benchmark(client, args)
     # Collect, aggregate, and print peer-to-peer bandwidths
     incoming_logs = client.run(lambda dask_worker: dask_worker.incoming_transfer_log)

--- a/dask_cuda/benchmarks/local_cupy.py
+++ b/dask_cuda/benchmarks/local_cupy.py
@@ -178,6 +178,9 @@ def pretty_print_results(args, address_to_index, p2p_bw, results):
     print_key_value(key="Compute chunk size", value=f"{result['chunksize']}")
     print_key_value(key="Ignore size", value=f"{format_bytes(args.ignore_size)}")
     print_key_value(key="Device(s)", value=f"{args.devs}")
+    print_key_value(
+        key="Data processed", value=f"{format_bytes(result['data_processed'])}"
+    )
     if args.device_memory_limit:
         print_key_value(
             key="Device memory limit",

--- a/dask_cuda/benchmarks/local_cupy.py
+++ b/dask_cuda/benchmarks/local_cupy.py
@@ -1,35 +1,25 @@
-import itertools
-import operator
-from collections import ChainMap, defaultdict
+import contextlib
+from collections import ChainMap
 from time import perf_counter as clock
-from warnings import filterwarnings
 
 import numpy as np
 import pandas as pd
 from nvtx import end_range, start_range
 
 from dask import array as da
-from dask.distributed import Client, performance_report, wait
-from dask.utils import format_bytes, format_time, parse_bytes
+from dask.distributed import performance_report, wait
+from dask.utils import format_bytes, parse_bytes
 
+from dask_cuda.benchmarks.common import Config, run_client_from_file, run_create_client
 from dask_cuda.benchmarks.utils import (
-    get_cluster_options,
-    get_scheduler_workers,
-    hmean,
-    hstd,
     parse_benchmark_args,
-    peer_to_peer_bandwidths,
     print_key_value,
     print_separator,
-    setup_memory_pools,
-    wait_for_cluster,
-    worker_renamer,
-    write_benchmark_data_as_json,
+    print_throughput_bandwidth,
 )
-from dask_cuda.utils import all_to_all
 
 
-def bench_once(client, args):
+def bench_once(client, args, write_profile=None):
     if args.type == "gpu":
         import cupy as xp
     else:
@@ -151,16 +141,12 @@ def bench_once(client, args):
     data_processed = sum(arg.nbytes for arg in func_args)
 
     # Execute the operations to benchmark
-    if args.profile is not None:
-        with performance_report(filename=args.profile):
-            rng = start_range(message=args.operation, color="purple")
-            t1 = clock()
-            wait(client.persist(func(*func_args)))
-            if args.type == "gpu":
-                client.run(lambda xp: xp.cuda.Device().synchronize(), xp)
-            took = clock() - t1
-            end_range(rng)
+    if args.profile is not None and write_profile is not None:
+        ctx = performance_report(filename=args.profile)
     else:
+        ctx = contextlib.nullcontext()
+
+    with ctx:
         rng = start_range(message=args.operation, color="purple")
         t1 = clock()
         wait(client.persist(func(*func_args)))
@@ -177,35 +163,10 @@ def bench_once(client, args):
     }
 
 
-def pretty_print_results(args, incoming_logs, scheduler_workers, results):
-    p2p_bw_dict = peer_to_peer_bandwidths(
-        incoming_logs, scheduler_workers, args.ignore_size
-    )
-    bandwidths = p2p_bw_dict["bandwidths"]
-    bandwidths_all = p2p_bw_dict["bandwidths_all"]
-    total_nbytes = p2p_bw_dict["total_nbytes"]
-    renamer = worker_renamer(
-        scheduler_workers.values(),
-        args.multi_node or args.sched_addr or args.scheduler_file,
-    )
-
-    bandwidths = {
-        (
-            renamer(scheduler_workers[w1].name),
-            renamer(scheduler_workers[w2].name),
-        ): ["%s/s" % format_bytes(x) for x in np.quantile(v, [0.25, 0.50, 0.75])]
-        for (w1, w2), v in bandwidths.items()
-    }
-    total_nbytes = {
-        (
-            renamer(scheduler_workers[w1].name),
-            renamer(scheduler_workers[w2].name),
-        ): format_bytes(sum(nb))
-        for (w1, w2), nb in total_nbytes.items()
-    }
-
+def pretty_print_results(args, address_to_index, p2p_bw, results):
     result, *_ = results
-
+    if args.markdown:
+        print("```")
     print("Roundtrip benchmark")
     print_separator(separator="-")
     print_key_value(key="Operation", value=f"{args.operation}")
@@ -229,61 +190,23 @@ def pretty_print_results(args, incoming_logs, scheduler_workers, results):
         print_key_value(key="InfiniBand", value=f"{args.enable_infiniband}")
         print_key_value(key="NVLink", value=f"{args.enable_nvlink}")
     print_key_value(key="Worker thread(s)", value=f"{args.threads_per_worker}")
-    print_separator(separator="=")
-    print_key_value(key="Wall clock", value="Throughput")
-    print_separator(separator="-")
-    t_p = []
-    times = []
-    for result in results:
-        took = result["took"]
-        data_processed = result["data_processed"]
-        throughput = data_processed / took
-        times.append(took)
-        t_p.append(throughput)
-        print_key_value(
-            key=f"{format_time(took)}", value=f"{format_bytes(throughput)}/s"
-        )
-    t_p = np.asarray(t_p)
-    times = np.asarray(times)
-    bandwidths_all = np.asarray(bandwidths_all)
-    print_separator(separator="=")
-    print_key_value(
-        key="Throughput",
-        value=f"{format_bytes(hmean(t_p))}/s +/- {format_bytes(hstd(t_p))}/s",
+    data_processed, durations = zip(
+        *((result["data_processed"], result["took"]) for result in results)
     )
-    print_key_value(
-        key="Bandwidth",
-        value=f"{format_bytes(hmean(bandwidths_all))}/s +/- "
-        f"{format_bytes(hstd(bandwidths_all))}/s",
+    if args.markdown:
+        print("\n```")
+    print_throughput_bandwidth(
+        args, durations, data_processed, p2p_bw, address_to_index
     )
-    print_key_value(
-        key="Wall clock",
-        value=f"{format_time(times.mean())} +/- {format_time(times.std()) }",
-    )
-    print_separator(separator="=")
-    print_key_value(key="(w1,w2)", value="25% 50% 75% (total nbytes)")
-    print_separator(separator="-")
-    for (d1, d2), bw in sorted(bandwidths.items()):
-        # hostid-deviceid
-        n1 = f"{d1[0]}-{d1[1]}"
-        n2 = f"{d2[0]}-{d2[1]}"
-        print_key_value(
-            key=f"({n1},{n2})",
-            value=f"{bw[0]} {bw[1]} {bw[2]} ({total_nbytes[(d1, d2)]})",
-        )
 
 
-def create_tidy_results(args, incoming_logs, scheduler_workers, results):
-    result, *_ = results
+def create_tidy_results(args, p2p_bw, results):
     configuration = {
         "operation": args.operation,
         "array_type": "cupy" if args.type == "gpu" else "numpy",
         "user_size": args.size,
         "user_second_size": args.second_size,
         "user_chunk_size": args.chunk_size,
-        "compute_shape": result["shape"],
-        "compute_chunk_size": result["chunksize"],
-        "npartitions": result["npartitions"],
         "ignore_size": args.ignore_size,
         "devices": args.devs,
         "device_memory_limit": args.device_memory_limit,
@@ -295,128 +218,23 @@ def create_tidy_results(args, incoming_logs, scheduler_workers, results):
         "nvlink": args.enable_nvlink,
         "nreps": args.runs,
     }
-    series = []
-    times = np.asarray([r["took"] for r in results], dtype=float)
-    q25, q75 = np.quantile(times, [0.25, 0.75])
-    timing = {
-        "time_mean": times.mean(),
-        "time_median": np.median(times),
-        "time_std": times.std(),
-        "time_q25": q25,
-        "time_q75": q75,
-        "time_min": times.min(),
-        "time_max": times.max(),
-    }
-    bandwidths = defaultdict(list)
-    total_nbytes = defaultdict(list)
-
-    renamer = worker_renamer(
-        scheduler_workers.values(),
-        args.multi_node or args.sched_addr or args.scheduler_file,
-    )
-
-    for k, L in incoming_logs.items():
-        source = scheduler_workers[k].name
-        for d in L:
-            dest = scheduler_workers[d["who"]].name
-            key = tuple(map(renamer, (source, dest)))
-            bandwidths[key].append(d["bandwidth"])
-            total_nbytes[key].append(d["total"])
-    for (_, group) in itertools.groupby(
-        sorted(bandwidths.keys()), key=operator.itemgetter(0)
-    ):
-        for key in group:
-            ((source_node, source_device), (dest_node, dest_device)) = key
-            bandwidth = np.asarray(bandwidths[key])
-            nbytes = np.asarray(total_nbytes[key])
-            q25, q75 = np.quantile(bandwidth, [0.25, 0.75])
-            data = pd.Series(
+    timing_data = pd.DataFrame(
+        [
+            pd.Series(
                 data=ChainMap(
                     configuration,
-                    timing,
                     {
-                        "source_node": source_node,
-                        "source_device": source_device,
-                        "dest_node": dest_node,
-                        "dest_device": dest_device,
-                        "total_bytes": nbytes.sum(),
-                        "bandwidth_mean": bandwidth.mean(),
-                        "bandwidth_median": np.median(bandwidth),
-                        "bandwidth_std": bandwidth.std(),
-                        "bandwidth_q25": q25,
-                        "bandwidth_q75": q75,
-                        "bandwidth_min": bandwidth.min(),
-                        "bandwidth_max": bandwidth.max(),
+                        "wallclock": result["took"],
+                        "compute_shape": result["shape"],
+                        "compute_chunk_size": result["chunksize"],
+                        "data_processed": result["data_processed"],
                     },
                 )
             )
-            series.append(data)
-    return pd.DataFrame(series)
-
-
-def run_benchmark(client, args):
-    results = []
-    for _ in range(max(1, args.runs)):
-        res = bench_once(client, args)
-        results.append(res)
-    return results
-
-
-def gather_bench_results(client, args):
-    scheduler_workers = client.run_on_scheduler(get_scheduler_workers)
-    if args.all_to_all:
-        all_to_all(client)
-    results = run_benchmark(client, args)
-    # Collect, aggregate, and print peer-to-peer bandwidths
-    incoming_logs = client.run(lambda dask_worker: dask_worker.incoming_transfer_log)
-    return scheduler_workers, results, incoming_logs
-
-
-def run(client, args):
-    wait_for_cluster(client, shutdown_on_failure=True)
-    setup_memory_pools(
-        client,
-        args.type == "gpu",
-        args.rmm_pool_size,
-        args.disable_rmm_pool,
-        args.rmm_log_directory,
+            for result in results
+        ]
     )
-    scheduler_workers, results, incoming_logs = gather_bench_results(client, args)
-    pretty_print_results(args, incoming_logs, scheduler_workers, results)
-    if args.benchmark_json:
-        write_benchmark_data_as_json(
-            args.benchmark_json,
-            create_tidy_results(args, incoming_logs, scheduler_workers, results),
-        )
-
-
-def run_client_from_file(args):
-    scheduler_file = args.scheduler_file
-    if scheduler_file is None:
-        raise RuntimeError("Need scheduler file to be provided")
-    with Client(scheduler_file=scheduler_file) as client:
-        run(client, args)
-        client.shutdown()
-
-
-def run_create_client(args):
-    cluster_options = get_cluster_options(args)
-    Cluster = cluster_options["class"]
-    cluster_args = cluster_options["args"]
-    cluster_kwargs = cluster_options["kwargs"]
-    scheduler_addr = cluster_options["scheduler_addr"]
-
-    filterwarnings("ignore", message=".*NVLink.*rmm_pool_size.*", category=UserWarning)
-
-    with Cluster(*cluster_args, **cluster_kwargs) as cluster:
-        # Use the scheduler address with an SSHCluster rather than the cluster
-        # object, otherwise we can't shut it down.
-        with Client(scheduler_addr if args.multi_node else cluster) as client:
-            run(client, args)
-            # An SSHCluster will not automatically shut down, we have to
-            # ensure it does.
-            if args.multi_node:
-                client.shutdown()
+    return timing_data, p2p_bw
 
 
 def parse_args():
@@ -492,7 +310,12 @@ def parse_args():
 
 if __name__ == "__main__":
     args = parse_args()
+    config = Config(
+        bench_once=bench_once,
+        create_tidy_results=create_tidy_results,
+        pretty_print_results=pretty_print_results,
+    )
     if args.scheduler_file is not None:
-        run_client_from_file(args)
+        run_client_from_file(args, config)
     else:
-        run_create_client(args)
+        run_create_client(args, config)

--- a/dask_cuda/benchmarks/local_cupy.py
+++ b/dask_cuda/benchmarks/local_cupy.py
@@ -1,10 +1,11 @@
-import asyncio
-from collections import defaultdict
-from json import dumps
+import itertools
+import operator
+from collections import ChainMap, defaultdict
 from time import perf_counter as clock
 from warnings import filterwarnings
 
 import numpy as np
+import pandas as pd
 from nvtx import end_range, start_range
 
 from dask import array as da
@@ -15,11 +16,14 @@ from dask_cuda.benchmarks.utils import (
     get_cluster_options,
     get_scheduler_workers,
     parse_benchmark_args,
-    setup_memory_pool,
+    setup_memory_pools,
+    wait_for_cluster,
+    worker_renamer,
+    write_benchmark_data_as_json,
 )
 
 
-async def _run(client, args):
+def bench_once(client, args):
     if args.type == "gpu":
         import cupy as xp
     else:
@@ -31,7 +35,7 @@ async def _run(client, args):
     if args.operation == "transpose_sum":
         rng = start_range(message="make array(s)", color="green")
         x = rs.random((args.size, args.size), chunks=args.chunk_size).persist()
-        await wait(x)
+        wait(x)
         end_range(rng)
 
         func_args = (x,)
@@ -41,8 +45,8 @@ async def _run(client, args):
         rng = start_range(message="make array(s)", color="green")
         x = rs.random((args.size, args.size), chunks=args.chunk_size).persist()
         y = rs.random((args.size, args.size), chunks=args.chunk_size).persist()
-        await wait(x)
-        await wait(y)
+        wait(x)
+        wait(y)
         end_range(rng)
 
         func_args = (x, y)
@@ -54,7 +58,7 @@ async def _run(client, args):
             (args.size, args.second_size),
             chunks=(int(args.chunk_size), args.second_size),
         ).persist()
-        await wait(x)
+        wait(x)
         end_range(rng)
 
         func_args = (x,)
@@ -65,7 +69,7 @@ async def _run(client, args):
         x = rs.random(
             (args.size, args.size), chunks=(args.size, args.chunk_size)
         ).persist()
-        await wait(x)
+        wait(x)
         end_range(rng)
 
         func_args = (x,)
@@ -74,7 +78,7 @@ async def _run(client, args):
     elif args.operation == "sum":
         rng = start_range(message="make array(s)", color="green")
         x = rs.random((args.size, args.size), chunks=args.chunk_size).persist()
-        await wait(x)
+        wait(x)
         end_range(rng)
 
         func_args = (x,)
@@ -83,7 +87,7 @@ async def _run(client, args):
     elif args.operation == "mean":
         rng = start_range(message="make array(s)", color="green")
         x = rs.random((args.size, args.size), chunks=args.chunk_size).persist()
-        await wait(x)
+        wait(x)
         end_range(rng)
 
         func_args = (x,)
@@ -92,7 +96,7 @@ async def _run(client, args):
     elif args.operation == "slice":
         rng = start_range(message="make array(s)", color="green")
         x = rs.random((args.size, args.size), chunks=args.chunk_size).persist()
-        await wait(x)
+        wait(x)
         end_range(rng)
 
         func_args = (x,)
@@ -102,8 +106,8 @@ async def _run(client, args):
         rng = start_range(message="make array(s)", color="green")
         x = rs.normal(10, 1, (args.size,), chunks=args.chunk_size).persist()
         y = rs.normal(10, 1, (args.size,), chunks=args.chunk_size).persist()
-        await wait(x)
-        await wait(y)
+        wait(x)
+        wait(y)
         end_range(rng)
 
         func_args = (x, y)
@@ -113,8 +117,8 @@ async def _run(client, args):
         rng = start_range(message="make array(s)", color="green")
         x = rs.normal(10, 1, (args.size,), chunks=args.chunk_size).persist()
         y = rs.normal(10, 1, (args.size,), chunks=args.chunk_size).persist()
-        await wait(x)
-        await wait(y)
+        wait(x)
+        wait(y)
         end_range(rng)
 
         func_args = (x, y)
@@ -126,45 +130,232 @@ async def _run(client, args):
         idx = rs.randint(
             0, len(x), (args.second_size,), chunks=args.chunk_size
         ).persist()
-        await wait(x)
-        await wait(idx)
+        wait(x)
+        wait(idx)
         end_range(rng)
 
         func_args = (x, idx)
 
         func = lambda x, idx: x[idx]
-
-    shape = x.shape
-    chunksize = x.chunksize
+    else:
+        raise ValueError(f"Unknown operation type {args.operation}")
 
     # Execute the operations to benchmark
     if args.profile is not None:
-        async with performance_report(filename=args.profile):
+        with performance_report(filename=args.profile):
             rng = start_range(message=args.operation, color="purple")
             t1 = clock()
-            await wait(client.persist(func(*func_args)))
+            wait(client.persist(func(*func_args)))
             if args.type == "gpu":
-                await client.run(lambda xp: xp.cuda.Device().synchronize(), xp)
+                client.run(lambda xp: xp.cuda.Device().synchronize(), xp)
             took = clock() - t1
             end_range(rng)
     else:
         rng = start_range(message=args.operation, color="purple")
         t1 = clock()
-        await wait(client.persist(func(*func_args)))
+        wait(client.persist(func(*func_args)))
         if args.type == "gpu":
-            await client.run(lambda xp: xp.cuda.Device().synchronize(), xp)
+            client.run(lambda xp: xp.cuda.Device().synchronize(), xp)
         took = clock() - t1
         end_range(rng)
 
     return {
         "took": took,
         "npartitions": x.npartitions,
-        "shape": shape,
-        "chunksize": chunksize,
+        "shape": x.shape,
+        "chunksize": x.chunksize,
     }
 
 
-async def run(args):
+def pretty_print_results(args, incoming_logs, scheduler_workers, results):
+    bandwidths = defaultdict(list)
+    total_nbytes = defaultdict(list)
+    for k, L in incoming_logs.items():
+        for d in L:
+            if d["total"] >= args.ignore_size:
+                bandwidths[k, d["who"]].append(d["bandwidth"])
+                total_nbytes[k, d["who"]].append(d["total"])
+
+    renamer = worker_renamer(
+        scheduler_workers.values(),
+        args.multi_node or args.sched_addr or args.scheduler_file,
+    )
+
+    bandwidths = {
+        (
+            renamer(scheduler_workers[w1].name),
+            renamer(scheduler_workers[w2].name),
+        ): ["%s/s" % format_bytes(x) for x in np.quantile(v, [0.25, 0.50, 0.75])]
+        for (w1, w2), v in bandwidths.items()
+    }
+    total_nbytes = {
+        (
+            renamer(scheduler_workers[w1].name),
+            renamer(scheduler_workers[w2].name),
+        ): format_bytes(sum(nb))
+        for (w1, w2), nb in total_nbytes.items()
+    }
+
+    result, *_ = results
+
+    print("Roundtrip benchmark")
+    print("--------------------------")
+    print(f"Operation          | {args.operation}")
+    print(f"Array type         | {'cupy' if args.type == 'gpu' else 'numpy'}")
+    print(f"User size          | {args.size}")
+    print(f"User second size   | {args.second_size}")
+    print(f"User chunk-size    | {args.chunk_size}")
+    print(f"Compute shape      | {result['shape']}")
+    print(f"Compute chunk-size | {result['chunksize']}")
+    print(f"Ignore-size        | {format_bytes(args.ignore_size)}")
+    print(f"Protocol           | {args.protocol}")
+    print(f"Device(s)          | {args.devs}")
+    if args.device_memory_limit:
+        print(f"Memory limit       | {format_bytes(args.device_memory_limit)}")
+    print(f"Worker Thread(s)   | {args.threads_per_worker}")
+    print("==========================")
+    print("Wall-clock         | npartitions")
+    print("--------------------------")
+    for result in results:
+        t = format_time(result["took"])
+        t += " " * (11 - len(t))
+        print(f"{t}        | {result['npartitions']}")
+    print("==========================")
+    print("(w1,w2)            | 25% 50% 75% (total nbytes)")
+    print("--------------------------")
+    fmt = "(%s,%s)            | %s %s %s (%s)"
+    for (d1, d2), bw in sorted(bandwidths.items()):
+        # hostid-deviceid
+        n1 = f"{d1[0]}-{d1[1]}"
+        n2 = f"{d2[0]}-{d2[1]}"
+        print(fmt % (n1, n2, bw[0], bw[1], bw[2], total_nbytes[(d1, d2)]))
+
+
+def create_tidy_results(args, incoming_logs, scheduler_workers, results):
+    result, *_ = results
+    configuration = {
+        "operation": args.operation,
+        "array_type": "cupy" if args.type == "gpu" else "numpy",
+        "user_size": args.size,
+        "user_second_size": args.second_size,
+        "user_chunk_size": args.chunk_size,
+        "compute_shape": result["shape"],
+        "compute_chunk_size": result["chunksize"],
+        "npartitions": result["npartitions"],
+        "ignore_size": args.ignore_size,
+        "devices": args.devs,
+        "device_memory_limit": args.device_memory_limit,
+        "worker_threads": args.threads_per_worker,
+        "rmm_pool": not args.disable_rmm_pool,
+        "protocol": args.protocol,
+        "tcp": args.enable_tcp_over_ucx,
+        "ib": args.enable_infiniband,
+        "nvlink": args.enable_nvlink,
+        "nreps": args.runs,
+    }
+    series = []
+    times = np.asarray([r["took"] for r in results], dtype=float)
+    q25, q75 = np.quantile(times, [0.25, 0.75])
+    timing = {
+        "time_mean": times.mean(),
+        "time_median": np.median(times),
+        "time_std": times.std(),
+        "time_q25": q25,
+        "time_q75": q75,
+        "time_min": times.min(),
+        "time_max": times.max(),
+    }
+    bandwidths = defaultdict(list)
+    total_nbytes = defaultdict(list)
+
+    renamer = worker_renamer(
+        scheduler_workers.values(),
+        args.multi_node or args.sched_addr or args.scheduler_file,
+    )
+
+    for k, L in incoming_logs.items():
+        source = scheduler_workers[k].name
+        for d in L:
+            dest = scheduler_workers[d["who"]].name
+            key = tuple(map(renamer, (source, dest)))
+            bandwidths[key].append(d["bandwidth"])
+            total_nbytes[key].append(d["total"])
+    for (_, group) in itertools.groupby(
+        sorted(bandwidths.keys()), key=operator.itemgetter(0)
+    ):
+        for key in group:
+            ((source_node, source_device), (dest_node, dest_device)) = key
+            bandwidth = np.asarray(bandwidths[key])
+            nbytes = np.asarray(total_nbytes[key])
+            q25, q75 = np.quantile(bandwidth, [0.25, 0.75])
+            data = pd.Series(
+                data=ChainMap(
+                    configuration,
+                    timing,
+                    {
+                        "source_node": source_node,
+                        "source_device": source_device,
+                        "dest_node": dest_node,
+                        "dest_device": dest_device,
+                        "total_bytes": nbytes.sum(),
+                        "bandwidth_mean": bandwidth.mean(),
+                        "bandwidth_median": np.median(bandwidth),
+                        "bandwidth_std": bandwidth.std(),
+                        "bandwidth_q25": q25,
+                        "bandwidth_q75": q75,
+                        "bandwidth_min": bandwidth.min(),
+                        "bandwidth_max": bandwidth.max(),
+                    },
+                )
+            )
+            series.append(data)
+    return pd.DataFrame(series)
+
+
+def run_benchmark(client, args):
+    results = []
+    for _ in range(max(1, args.runs)):
+        res = bench_once(client, args)
+        results.append(res)
+    return results
+
+
+def gather_bench_results(client, args):
+    scheduler_workers = client.run_on_scheduler(get_scheduler_workers)
+    results = run_benchmark(client, args)
+    # Collect, aggregate, and print peer-to-peer bandwidths
+    incoming_logs = client.run(lambda dask_worker: dask_worker.incoming_transfer_log)
+    return scheduler_workers, results, incoming_logs
+
+
+def run(client, args):
+    wait_for_cluster(client, shutdown_on_failure=True)
+    setup_memory_pools(
+        client,
+        args.type == "gpu",
+        args.rmm_pool_size,
+        args.disable_rmm_pool,
+        args.rmm_log_directory,
+    )
+    scheduler_workers, results, incoming_logs = gather_bench_results(client, args)
+    pretty_print_results(args, incoming_logs, scheduler_workers, results)
+    if args.benchmark_json:
+        write_benchmark_data_as_json(
+            args.benchmark_json,
+            create_tidy_results(args, incoming_logs, scheduler_workers, results),
+        )
+
+
+def run_client_from_file(args):
+    scheduler_file = args.scheduler_file
+    if scheduler_file is None:
+        raise RuntimeError("Need scheduler file to be provided")
+    with Client(scheduler_file=scheduler_file) as client:
+        run(client, args)
+        client.shutdown()
+
+
+def run_create_client(args):
     cluster_options = get_cluster_options(args)
     Cluster = cluster_options["class"]
     cluster_args = cluster_options["args"]
@@ -173,147 +364,15 @@ async def run(args):
 
     filterwarnings("ignore", message=".*NVLink.*rmm_pool_size.*", category=UserWarning)
 
-    async with Cluster(*cluster_args, **cluster_kwargs, asynchronous=True) as cluster:
-        if args.multi_node:
-            import time
-
-            # Allow some time for workers to start and connect to scheduler
-            # TODO: make this a command-line argument?
-            time.sleep(15)
-
+    with Cluster(*cluster_args, **cluster_kwargs) as cluster:
         # Use the scheduler address with an SSHCluster rather than the cluster
         # object, otherwise we can't shut it down.
-        async with Client(
-            scheduler_addr if args.multi_node else cluster, asynchronous=True
-        ) as client:
-            scheduler_workers = await client.run_on_scheduler(get_scheduler_workers)
-
-            await client.run(
-                setup_memory_pool,
-                pool_size=args.rmm_pool_size,
-                disable_pool=args.disable_rmm_pool,
-                log_directory=args.rmm_log_directory,
-            )
-            # Create an RMM pool on the scheduler due to occasional deserialization
-            # of CUDA objects. May cause issues with InfiniBand otherwise.
-            await client.run_on_scheduler(
-                setup_memory_pool,
-                pool_size=1e9,
-                disable_pool=args.disable_rmm_pool,
-                log_directory=args.rmm_log_directory,
-            )
-
-            took_list = []
-            for i in range(args.runs):
-                res = await _run(client, args)
-                took_list.append((res["took"], res["npartitions"]))
-                size = res["shape"]
-                chunksize = res["chunksize"]
-
-            # Collect, aggregate, and print peer-to-peer bandwidths
-            incoming_logs = await client.run(
-                lambda dask_worker: dask_worker.incoming_transfer_log
-            )
-            bandwidths = defaultdict(list)
-            total_nbytes = defaultdict(list)
-            for k, L in incoming_logs.items():
-                for d in L:
-                    if d["total"] >= args.ignore_size:
-                        bandwidths[k, d["who"]].append(d["bandwidth"])
-                        total_nbytes[k, d["who"]].append(d["total"])
-
-            bandwidths = {
-                (scheduler_workers[w1].name, scheduler_workers[w2].name,): [
-                    "%s/s" % format_bytes(x) for x in np.quantile(v, [0.25, 0.50, 0.75])
-                ]
-                for (w1, w2), v in bandwidths.items()
-            }
-            total_nbytes = {
-                (
-                    scheduler_workers[w1].name,
-                    scheduler_workers[w2].name,
-                ): format_bytes(sum(nb))
-                for (w1, w2), nb in total_nbytes.items()
-            }
-
-            print("Roundtrip benchmark")
-            print("--------------------------")
-            print(f"Operation          | {args.operation}")
-            print(f"User size          | {args.size}")
-            print(f"User second size   | {args.second_size}")
-            print(f"User chunk-size    | {args.chunk_size}")
-            print(f"Compute shape      | {size}")
-            print(f"Compute chunk-size | {chunksize}")
-            print(f"Ignore-size        | {format_bytes(args.ignore_size)}")
-            print(f"Protocol           | {args.protocol}")
-            print(f"Device(s)          | {args.devs}")
-            if args.device_memory_limit:
-                print(f"Memory limit       | {format_bytes(args.device_memory_limit)}")
-            print(f"Worker Thread(s)   | {args.threads_per_worker}")
-            print("==========================")
-            print("Wall-clock         | npartitions")
-            print("--------------------------")
-            for (took, npartitions) in took_list:
-                t = format_time(took)
-                t += " " * (11 - len(t))
-                print(f"{t}        | {npartitions}")
-            print("==========================")
-            print("(w1,w2)            | 25% 50% 75% (total nbytes)")
-            print("--------------------------")
-            for (d1, d2), bw in sorted(bandwidths.items()):
-                fmt = (
-                    "(%s,%s)            | %s %s %s (%s)"
-                    if args.multi_node or args.sched_addr
-                    else "(%02d,%02d)            | %s %s %s (%s)"
-                )
-                print(fmt % (d1, d2, bw[0], bw[1], bw[2], total_nbytes[(d1, d2)]))
-
-            if args.benchmark_json:
-                bandwidths_json = {
-                    "bandwidth_({d1},{d2})_{i}"
-                    if args.multi_node or args.sched_addr
-                    else "(%02d,%02d)_%s" % (d1, d2, i): parse_bytes(v.rstrip("/s"))
-                    for (d1, d2), bw in sorted(bandwidths.items())
-                    for i, v in zip(
-                        ["25%", "50%", "75%", "total_nbytes"],
-                        [bw[0], bw[1], bw[2], total_nbytes[(d1, d2)]],
-                    )
-                }
-
-                with open(args.benchmark_json, "a") as fp:
-                    for took, npartitions in took_list:
-                        fp.write(
-                            dumps(
-                                dict(
-                                    {
-                                        "operation": args.operation,
-                                        "user_size": args.size,
-                                        "user_second_size": args.second_size,
-                                        "user_chunk_size": args.chunk_size,
-                                        "compute_size": size,
-                                        "compute_chunk_size": chunksize,
-                                        "ignore_size": args.ignore_size,
-                                        "protocol": args.protocol,
-                                        "devs": args.devs,
-                                        "device_memory_limit": args.device_memory_limit,
-                                        "worker_threads": args.threads_per_worker,
-                                        "rmm_pool": not args.disable_rmm_pool,
-                                        "tcp": args.enable_tcp_over_ucx,
-                                        "ib": args.enable_infiniband,
-                                        "nvlink": args.enable_nvlink,
-                                        "wall_clock": took,
-                                        "npartitions": npartitions,
-                                    },
-                                    **bandwidths_json,
-                                )
-                            )
-                            + "\n"
-                        )
-
+        with Client(scheduler_addr if args.multi_node else cluster) as client:
+            run(client, args)
             # An SSHCluster will not automatically shut down, we have to
             # ensure it does.
             if args.multi_node:
-                await client.shutdown()
+                client.shutdown()
 
 
 def parse_args():
@@ -387,10 +446,9 @@ def parse_args():
     )
 
 
-def main():
-    args = parse_args()
-    asyncio.get_event_loop().run_until_complete(run(args))
-
-
 if __name__ == "__main__":
-    main()
+    args = parse_args()
+    if args.scheduler_file is not None:
+        run_client_from_file(args)
+    else:
+        run_create_client(args)

--- a/dask_cuda/benchmarks/local_cupy.py
+++ b/dask_cuda/benchmarks/local_cupy.py
@@ -6,12 +6,11 @@ import numpy as np
 import pandas as pd
 from nvtx import end_range, start_range
 
-import dask
 from dask import array as da
 from dask.distributed import performance_report, wait
 from dask.utils import format_bytes, parse_bytes
 
-from dask_cuda.benchmarks.common import Config, run_client_from_file, run_create_client
+from dask_cuda.benchmarks.common import Config, execute_benchmark
 from dask_cuda.benchmarks.utils import (
     parse_benchmark_args,
     print_key_value,
@@ -310,20 +309,11 @@ def parse_args():
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    if args.multiprocessing_method == "forkserver":
-        import multiprocessing.forkserver as f
-
-        f.ensure_running()
-    with dask.config.set(
-        {"distributed.worker.multiprocessing-method": args.multiprocessing_method}
-    ):
-        config = Config(
+    execute_benchmark(
+        Config(
+            args=parse_args(),
             bench_once=bench_once,
             create_tidy_results=create_tidy_results,
             pretty_print_results=pretty_print_results,
         )
-        if args.scheduler_file is not None:
-            run_client_from_file(args, config)
-        else:
-            run_create_client(args, config)
+    )

--- a/dask_cuda/benchmarks/local_cupy_map_overlap.py
+++ b/dask_cuda/benchmarks/local_cupy_map_overlap.py
@@ -8,12 +8,11 @@ import pandas as pd
 from cupyx.scipy.ndimage.filters import convolve as cp_convolve
 from scipy.ndimage import convolve as sp_convolve
 
-import dask
 from dask import array as da
 from dask.distributed import performance_report, wait
 from dask.utils import format_bytes, parse_bytes
 
-from dask_cuda.benchmarks.common import Config, run_client_from_file, run_create_client
+from dask_cuda.benchmarks.common import Config, execute_benchmark
 from dask_cuda.benchmarks.utils import (
     parse_benchmark_args,
     print_key_value,
@@ -184,20 +183,11 @@ def parse_args():
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    if args.multiprocessing_method == "forkserver":
-        import multiprocessing.forkserver as f
-
-        f.ensure_running()
-    with dask.config.set(
-        {"distributed.worker.multiprocessing-method": args.multiprocessing_method}
-    ):
-        config = Config(
+    execute_benchmark(
+        Config(
+            args=parse_args(),
             bench_once=bench_once,
             create_tidy_results=create_tidy_results,
             pretty_print_results=pretty_print_results,
         )
-        if args.scheduler_file is not None:
-            run_client_from_file(args, config)
-        else:
-            run_create_client(args, config)
+    )

--- a/dask_cuda/benchmarks/local_cupy_map_overlap.py
+++ b/dask_cuda/benchmarks/local_cupy_map_overlap.py
@@ -1,27 +1,23 @@
-import asyncio
-from json import dumps
+import contextlib
+from collections import ChainMap
 from time import perf_counter as clock
-from warnings import filterwarnings
 
 import cupy as cp
 import numpy as np
+import pandas as pd
 from cupyx.scipy.ndimage.filters import convolve as cp_convolve
 from scipy.ndimage import convolve as sp_convolve
 
 from dask import array as da
-from dask.distributed import Client, performance_report, wait
-from dask.utils import format_bytes, format_time, parse_bytes
+from dask.distributed import performance_report, wait
+from dask.utils import format_bytes, parse_bytes
 
+from dask_cuda.benchmarks.common import Config, run_client_from_file, run_create_client
 from dask_cuda.benchmarks.utils import (
-    get_cluster_options,
-    get_scheduler_workers,
-    hmean,
-    hstd,
     parse_benchmark_args,
-    peer_to_peer_bandwidths,
     print_key_value,
     print_separator,
-    setup_memory_pool,
+    print_throughput_bandwidth,
 )
 
 
@@ -33,7 +29,7 @@ def mean_filter(a, shape):
         return sp_convolve(a, a_k)
 
 
-async def _run(client, args):
+def bench_once(client, args, write_profile=None):
     # Create a simple random array
     if args.type == "gpu":
         rs = da.random.RandomState(RandomState=cp.random.RandomState)
@@ -41,183 +37,87 @@ async def _run(client, args):
         rs = da.random.RandomState(RandomState=np.random.RandomState)
     x = rs.random((args.size, args.size), chunks=args.chunk_size).persist()
     ks = 2 * (2 * args.kernel_size + 1,)
-    await wait(x)
+    wait(x)
 
     data_processed = x.nbytes
 
     # Execute the operations to benchmark
-    if args.profile is not None:
-        async with performance_report(filename=args.profile):
-            t1 = clock()
-            await wait(
-                client.persist(x.map_overlap(mean_filter, args.kernel_size, shape=ks))
-            )
-            took = clock() - t1
+    if args.profile is not None and write_profile is not None:
+        ctx = performance_report(filename=args.profile)
     else:
+        ctx = contextlib.nullcontext()
+
+    with ctx:
         t1 = clock()
-        await wait(
-            client.persist(x.map_overlap(mean_filter, args.kernel_size, shape=ks))
-        )
+        wait(client.persist(x.map_overlap(mean_filter, args.kernel_size, shape=ks)))
         took = clock() - t1
 
-    return (took, data_processed)
+    return (data_processed, took)
 
 
-async def run(args):
-    cluster_options = get_cluster_options(args)
-    Cluster = cluster_options["class"]
-    cluster_args = cluster_options["args"]
-    cluster_kwargs = cluster_options["kwargs"]
-    scheduler_addr = cluster_options["scheduler_addr"]
+def pretty_print_results(args, address_to_index, p2p_bw, results):
+    if args.markdown:
+        print("```")
+    print("Cupy map overlap benchmark")
+    print_separator(separator="-")
+    print_key_value(key="Array type", value="cupy" if args.type == "gpu" else "numpy")
+    print_key_value(key="Size", value=f"{args.size}*{args.size}")
+    print_key_value(key="Chunk size", value=f"{args.chunk_size}")
+    print_key_value(key="Ignore size", value=f"{format_bytes(args.ignore_size)}")
+    print_key_value(key="Kernel size", value=f"{args.kernel_size}")
+    print_key_value(key="Device(s)", value=f"{args.devs}")
+    if args.device_memory_limit:
+        print_key_value(
+            key="Device memory limit",
+            value=f"{format_bytes(args.device_memory_limit)}",
+        )
+    print_key_value(key="RMM Pool", value=f"{not args.disable_rmm_pool}")
+    print_key_value(key="Protocol", value=f"{args.protocol}")
+    if args.protocol == "ucx":
+        print_key_value(key="TCP", value=f"{args.enable_tcp_over_ucx}")
+        print_key_value(key="InfiniBand", value=f"{args.enable_infiniband}")
+        print_key_value(key="NVLink", value=f"{args.enable_nvlink}")
+    print_key_value(key="Worker thread(s)", value=f"{args.threads_per_worker}")
+    data_processed, durations = zip(*results)
+    if args.markdown:
+        print("\n```")
+    print_throughput_bandwidth(
+        args, durations, data_processed, p2p_bw, address_to_index
+    )
 
-    filterwarnings("ignore", message=".*NVLink.*rmm_pool_size.*", category=UserWarning)
 
-    async with Cluster(*cluster_args, **cluster_kwargs, asynchronous=True) as cluster:
-        if args.multi_node:
-            import time
-
-            # Allow some time for workers to start and connect to scheduler
-            # TODO: make this a command-line argument?
-            time.sleep(15)
-
-        # Use the scheduler address with an SSHCluster rather than the cluster
-        # object, otherwise we can't shut it down.
-        async with Client(
-            scheduler_addr if args.multi_node else cluster, asynchronous=True
-        ) as client:
-            scheduler_workers = await client.run_on_scheduler(get_scheduler_workers)
-
-            await client.run(
-                setup_memory_pool,
-                disable_pool=args.disable_rmm_pool,
-                log_directory=args.rmm_log_directory,
-            )
-            # Create an RMM pool on the scheduler due to occasional deserialization
-            # of CUDA objects. May cause issues with InfiniBand otherwise.
-            await client.run_on_scheduler(
-                setup_memory_pool,
-                pool_size=1e9,
-                disable_pool=args.disable_rmm_pool,
-                log_directory=args.rmm_log_directory,
-            )
-
-            took_list = []
-            for i in range(args.runs):
-                took_list.append(await _run(client, args))
-
-            incoming_logs = await client.run(
-                lambda dask_worker: dask_worker.incoming_transfer_log
-            )
-            p2p_bw_dict = peer_to_peer_bandwidths(
-                incoming_logs, scheduler_workers, args.ignore_size
-            )
-            bandwidths = p2p_bw_dict["bandwidths"]
-            bandwidths_all = p2p_bw_dict["bandwidths_all"]
-            total_nbytes = p2p_bw_dict["total_nbytes"]
-
-            print("Roundtrip benchmark")
-            print_separator(separator="-")
-            print_key_value(key="Size", value=f"{args.size}*{args.size}")
-            print_key_value(key="Chunk size", value=f"{args.chunk_size}")
-            print_key_value(
-                key="Ignore size", value=f"{format_bytes(args.ignore_size)}"
-            )
-            print_key_value(key="Device(s)", value=f"{args.devs}")
-            if args.device_memory_limit:
-                print_key_value(
-                    key="Device memory limit",
-                    value=f"{format_bytes(args.device_memory_limit)}",
+def create_tidy_results(args, p2p_bw, results):
+    configuration = {
+        "array_type": "cupy" if args.type == "gpu" else "numpy",
+        "user_size": args.size,
+        "chunk_size": args.chunk_size,
+        "ignore_size": args.ignore_size,
+        "devices": args.devs,
+        "device_memory_limit": args.device_memory_limit,
+        "worker_threads": args.threads_per_worker,
+        "rmm_pool": not args.disable_rmm_pool,
+        "protocol": args.protocol,
+        "tcp": args.enable_tcp_over_ucx,
+        "ib": args.enable_infiniband,
+        "nvlink": args.enable_nvlink,
+        "nreps": args.runs,
+        "kernel_size": args.kernel_size,
+    }
+    timing_data = pd.DataFrame(
+        [
+            pd.Series(
+                data=ChainMap(
+                    configuration,
+                    {
+                        "wallclock": duration,
+                        "data_processed": data_processed,
+                    },
                 )
-            print_key_value(key="RMM Pool", value=f"{not args.disable_rmm_pool}")
-            print_key_value(key="Protocol", value=f"{args.protocol}")
-            if args.protocol == "ucx":
-                print_key_value(key="TCP", value=f"{args.enable_tcp_over_ucx}")
-                print_key_value(key="InfiniBand", value=f"{args.enable_infiniband}")
-                print_key_value(key="NVLink", value=f"{args.enable_nvlink}")
-            print_key_value(key="Worker thread(s)", value=f"{args.threads_per_worker}")
-            print_separator(separator="=")
-            print_key_value(key="Wall clock", value="Partitions")
-            print_separator(separator="-")
-            t_p = []
-            times = []
-            for (took, data_processed) in took_list:
-                throughput = int(data_processed / took)
-                m = format_time(took)
-                times.append(took)
-                t_p.append(throughput)
-                print_key_value(key=f"{m}", value=f"{format_bytes(throughput)}/s")
-            t_p = np.asarray(t_p)
-            times = np.asarray(times)
-            bandwidths_all = np.asarray(bandwidths_all)
-            print_separator(separator="=")
-            print_key_value(
-                key="Throughput",
-                value=f"{format_bytes(hmean(t_p))}/s +/- {format_bytes(hstd(t_p))}/s",
             )
-            print_key_value(
-                key="Bandwidth",
-                value=f"{format_bytes(hmean(bandwidths_all))}/s +/- "
-                f"{format_bytes(hstd(bandwidths_all))}/s",
-            )
-            print_key_value(
-                key="Wall clock",
-                value=f"{format_time(times.mean())} +/- {format_time(times.std()) }",
-            )
-            print_separator(separator="=")
-            print_key_value(key="(w1,w2)", value="25% 50% 75% (total nbytes)")
-            print_separator(separator="-")
-            for (d1, d2), bw in sorted(bandwidths.items()):
-                key = (
-                    f"({d1},{d2})"
-                    if args.multi_node or args.sched_addr
-                    else f"({d1:02d},{d2:02d})"
-                )
-                print_key_value(
-                    key=key, value=f"{bw[0]} {bw[1]} {bw[2]} ({total_nbytes[(d1, d2)]})"
-                )
-
-            if args.benchmark_json:
-                bandwidths_json = {
-                    "bandwidth_({d1},{d2})_{i}"
-                    if args.multi_node or args.sched_addr
-                    else "(%02d,%02d)_%s" % (d1, d2, i): parse_bytes(v.rstrip("/s"))
-                    for (d1, d2), bw in sorted(bandwidths.items())
-                    for i, v in zip(
-                        ["25%", "50%", "75%", "total_nbytes"],
-                        [bw[0], bw[1], bw[2], total_nbytes[(d1, d2)]],
-                    )
-                }
-
-                with open(args.benchmark_json, "a") as fp:
-                    for took, data_processed in took_list:
-                        fp.write(
-                            dumps(
-                                dict(
-                                    {
-                                        "size": args.size * args.size,
-                                        "chunk_size": args.chunk_size,
-                                        "ignore_size": args.ignore_size,
-                                        "protocol": args.protocol,
-                                        "devs": args.devs,
-                                        "device_memory_limit": args.device_memory_limit,
-                                        "worker_threads": args.threads_per_worker,
-                                        "rmm_pool": not args.disable_rmm_pool,
-                                        "tcp": args.enable_tcp_over_ucx,
-                                        "ib": args.enable_infiniband,
-                                        "nvlink": args.enable_nvlink,
-                                        "wall_clock": took,
-                                        "npartitions": data_processed / took,
-                                    },
-                                    **bandwidths_json,
-                                )
-                            )
-                            + "\n"
-                        )
-
-            # An SSHCluster will not automatically shut down, we have to
-            # ensure it does.
-            if args.multi_node:
-                await client.shutdown()
+            for (data_processed, duration) in results
+        ]
+    )
+    return timing_data, p2p_bw
 
 
 def parse_args():
@@ -282,10 +182,14 @@ def parse_args():
     )
 
 
-def main():
-    args = parse_args()
-    asyncio.get_event_loop().run_until_complete(run(args))
-
-
 if __name__ == "__main__":
-    main()
+    args = parse_args()
+    config = Config(
+        bench_once=bench_once,
+        create_tidy_results=create_tidy_results,
+        pretty_print_results=pretty_print_results,
+    )
+    if args.scheduler_file is not None:
+        run_client_from_file(args, config)
+    else:
+        run_create_client(args, config)

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -135,19 +135,41 @@ def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]
         dest="interface",
         help="Network interface Dask processes will use to listen for connections.",
     )
+    group = cluster_args.add_mutually_exclusive_group()
+    group.add_argument(
+        "--scheduler-address",
+        default=None,
+        type=str,
+        dest="sched_addr",
+        help="Scheduler Address -- assumes cluster is created outside of benchmark. "
+        "If provided, worker configuration options provided to this script are ignored "
+        "since the workers are assumed to be started separately. Similarly the other "
+        "cluster configuration options have no effect.",
+    )
+    group.add_argument(
+        "--scheduler-file",
+        default=None,
+        type=str,
+        dest="scheduler_file",
+        help="Read cluster configuration from specified file. "
+        "If provided, worker configuration options provided to this script are ignored "
+        "since the workers are assumed to be started separately. Similarly the other "
+        "cluster configuration options have no effect.",
+    )
+    cluster_args.add_argument(
+        "--shutdown-external-cluster-on-exit",
+        default=False,
+        action="store_true",
+        dest="shutdown_cluster",
+        help="If connecting to an external cluster, should we shut down the cluster "
+        "when the benchmark exits?",
+    )
     cluster_args.add_argument(
         "--multi-node",
         action="store_true",
         dest="multi_node",
         help="Runs a multi-node cluster on the hosts specified by --hosts."
         "Requires the ``asyncssh`` module to be installed.",
-    )
-    cluster_args.add_argument(
-        "--scheduler-address",
-        default=None,
-        type=str,
-        dest="sched_addr",
-        help="Scheduler Address -- assumes cluster is created outside of benchmark.",
     )
     cluster_args.add_argument(
         "--hosts",
@@ -163,16 +185,6 @@ def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]
         "'10.10.10.10', and 'dgx13'. "
         "Note: --devs is currently ignored in multi-node mode and for each host "
         "one worker per GPU will be launched.",
-    )
-    cluster_args.add_argument(
-        "--scheduler-file",
-        default=None,
-        type=str,
-        dest="scheduler_file",
-        help="Read cluster configuration from specified file. "
-        "If provided, worker configuration options provided to this script are ignored "
-        "since the workers are assumed to be started separately. Similarly the other "
-        "cluster configuration options are ignored.",
     )
     parser.add_argument(
         "--all-to-all",

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -31,21 +31,6 @@ def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]
         help="Number of Dask threads per worker (i.e., GPU).",
     )
     worker_args.add_argument(
-        "-p",
-        "--protocol",
-        choices=["tcp", "ucx"],
-        default="tcp",
-        type=str,
-        help="The communication protocol to use.",
-    )
-    parser.add_argument(
-        "--profile",
-        metavar="PATH",
-        default=None,
-        type=str,
-        help="Write dask profile report (E.g. dask-report.html)",
-    )
-    worker_args.add_argument(
         "--device-memory-limit",
         default=None,
         type=parse_bytes,
@@ -55,83 +40,91 @@ def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]
         "``'auto'``, 0, or ``None`` to disable spilling to host (i.e. allow full "
         "device memory usage).",
     )
-    worker_args.add_argument(
+    cluster_args = parser.add_argument_group(description="Cluster configuration")
+    cluster_args.add_argument(
+        "-p",
+        "--protocol",
+        choices=["tcp", "ucx"],
+        default="tcp",
+        type=str,
+        help="The communication protocol to use.",
+    )
+    cluster_args.add_argument(
         "--rmm-pool-size",
         default=None,
         type=parse_bytes,
         help="The size of the RMM memory pool. Can be an integer (bytes) or a string "
         "(like '4GB' or '5000M'). By default, 1/2 of the total GPU memory is used.",
     )
-    worker_args.add_argument(
+    cluster_args.add_argument(
         "--disable-rmm-pool", action="store_true", help="Disable the RMM memory pool"
     )
-    worker_args.add_argument(
+    cluster_args.add_argument(
         "--rmm-log-directory",
         default=None,
         type=str,
         help="Directory to write worker and scheduler RMM log files to. "
         "Logging is only enabled if RMM memory pool is enabled.",
     )
-    worker_args.add_argument(
+    cluster_args.add_argument(
         "--enable-tcp-over-ucx",
         default=None,
         action="store_true",
         dest="enable_tcp_over_ucx",
         help="Enable TCP over UCX.",
     )
-    worker_args.add_argument(
+    cluster_args.add_argument(
         "--enable-infiniband",
         default=None,
         action="store_true",
         dest="enable_infiniband",
         help="Enable InfiniBand over UCX.",
     )
-    worker_args.add_argument(
+    cluster_args.add_argument(
         "--enable-nvlink",
         default=None,
         action="store_true",
         dest="enable_nvlink",
         help="Enable NVLink over UCX.",
     )
-    worker_args.add_argument(
+    cluster_args.add_argument(
         "--enable-rdmacm",
         default=None,
         action="store_true",
         dest="enable_rdmacm",
         help="Enable RDMACM with UCX.",
     )
-    worker_args.add_argument(
+    cluster_args.add_argument(
         "--disable-tcp-over-ucx",
         action="store_false",
         dest="enable_tcp_over_ucx",
         help="Disable TCP over UCX.",
     )
-    worker_args.add_argument(
+    cluster_args.add_argument(
         "--disable-infiniband",
         action="store_false",
         dest="enable_infiniband",
         help="Disable InfiniBand over UCX.",
     )
-    worker_args.add_argument(
+    cluster_args.add_argument(
         "--disable-nvlink",
         action="store_false",
         dest="enable_nvlink",
         help="Disable NVLink over UCX.",
     )
-    worker_args.add_argument(
+    cluster_args.add_argument(
         "--disable-rdmacm",
         action="store_false",
         dest="enable_rdmacm",
         help="Disable RDMACM with UCX.",
     )
-    worker_args.add_argument(
+    cluster_args.add_argument(
         "--interface",
         default=None,
         type=str,
         dest="interface",
         help="Network interface Dask processes will use to listen for connections.",
     )
-    cluster_args = parser.add_argument_group(description="Cluster configuration")
     cluster_args.add_argument(
         "--multi-node",
         action="store_true",
@@ -193,6 +186,13 @@ def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]
         default=False,
         action="store_true",
         help="Write output as markdown",
+    )
+    parser.add_argument(
+        "--profile",
+        metavar="PATH",
+        default=None,
+        type=str,
+        help="Write dask profile report (E.g. dask-report.html)",
     )
     # See save_benchmark_data for more information
     parser.add_argument(

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -538,7 +538,6 @@ def print_throughput_bandwidth(
         value=f"{format_bytes(hmean(throughputs))}/s "
         f"+/- {format_bytes(hstd(throughputs))}/s",
     )
-    # Hack
     bandwidth_hmean = p2p_bw[..., BandwidthStats._fields.index("hmean")].reshape(-1)
     bandwidths_all = bandwidth_hmean[bandwidth_hmean > 0]
     print_key_value(
@@ -676,6 +675,9 @@ def peer_to_peer_bandwidths(
     data = np.zeros((nworker, nworker, len(BandwidthStats._fields)), dtype=np.float32)
     for w1, per_worker in aggregate_bandwidth_data.items():
         for w2, stats in per_worker.items():
+            # This loses type information on each entry, but we just
+            # need indexing information which we can obtain from the
+            # BandwidthStats._fields slot.
             data[address_to_index[w1], address_to_index[w2], :] = stats
     return data
 

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -140,7 +140,6 @@ def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]
         "--scheduler-address",
         default=None,
         type=str,
-        dest="sched_addr",
         help="Scheduler Address -- assumes cluster is created outside of benchmark. "
         "If provided, worker configuration options provided to this script are ignored "
         "since the workers are assumed to be started separately. Similarly the other "

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -156,6 +156,16 @@ def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]
         "Note: --devs is currently ignored in multi-node mode and for each host "
         "one worker per GPU will be launched.",
     )
+    cluster_args.add_argument(
+        "--scheduler-file",
+        default=None,
+        type=str,
+        dest="scheduler_file",
+        help="Read cluster configuration from specified file. "
+        "If provided, worker configuration options provided to this script are ignored "
+        "since the workers are assumed to be started separately. Similarly the other "
+        "cluster configuration options are ignored.",
+    )
     parser.add_argument(
         "--all-to-all",
         action="store_true",


### PR DESCRIPTION
This is a move towards using the benchmarks for regular profiling on more than one node.

That requires two substantive changes:

1. Refactor benchmark running and data processing to bring a client up from an external source (here a `--scheduler-file`, `dask-mpi` could be used I think, but I haven't done so).
2. As well as producing human-readable output, produce data that can be consumed by downstream scripts

I've refactored the benchmarks into common infrastructure, which simplifies new benchmark creation.

