### PR TITLE
LocalCUDACluster's memory limit: `None` means no limit

### DIFF
--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -173,7 +173,9 @@ class CUDAWorker(Server):
         else:
             self.jit_unspill = jit_unspill
 
-        if self.jit_unspill:
+        if device_memory_limit is None and memory_limit is None:
+            data = {}
+        elif self.jit_unspill:
             data = lambda i: (
                 ProxifyHostFile,
                 {

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -288,7 +288,9 @@ class LocalCUDACluster(LocalCluster):
 
         data = kwargs.pop("data", None)
         if data is None:
-            if self.jit_unspill:
+            if device_memory_limit is None and memory_limit is None:
+                data = {}
+            elif self.jit_unspill:
                 data = (
                     ProxifyHostFile,
                     {


### PR DESCRIPTION
Use a regular `dict` when creating a `LocalCUDACluster` with no host and no device memory limit.

Currently, setting `device_memory_limit=None` translate into the total available GPU memory.  However,  in some cases `DeviceHostFile` overestimate the GPU memory usage, which can trigger spilling even though `device_memory_limit=None`.