### PR TITLE
Fix useless property

### DIFF
--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -171,7 +171,7 @@ class CUDAWorker(Server):
         if jit_unspill is None:
             jit_unspill = dask.config.get("jit-unspill", default=False)
         if device_memory_limit is None and memory_limit is None:
-            data = {}
+            data = lambda _: {}
         elif jit_unspill:
             data = lambda i: (
                 ProxifyHostFile,

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -169,13 +169,10 @@ class CUDAWorker(Server):
         )
 
         if jit_unspill is None:
-            self.jit_unspill = dask.config.get("jit-unspill", default=False)
-        else:
-            self.jit_unspill = jit_unspill
-
+            jit_unspill = dask.config.get("jit-unspill", default=False)
         if device_memory_limit is None and memory_limit is None:
             data = {}
-        elif self.jit_unspill:
+        elif jit_unspill:
             data = lambda i: (
                 ProxifyHostFile,
                 {

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -277,20 +277,17 @@ class LocalCUDACluster(LocalCluster):
                 "Processes are necessary in order to use multiple GPUs with Dask"
             )
 
-        if jit_unspill is None:
-            self.jit_unspill = dask.config.get("jit-unspill", default=False)
-        else:
-            self.jit_unspill = jit_unspill
-
         if shared_filesystem is None:
             # Notice, we assume a shared filesystem
             shared_filesystem = dask.config.get("jit-unspill-shared-fs", default=True)
 
+        if jit_unspill is None:
+            jit_unspill = dask.config.get("jit-unspill", default=False)
         data = kwargs.pop("data", None)
         if data is None:
             if device_memory_limit is None and memory_limit is None:
                 data = {}
-            elif self.jit_unspill:
+            elif jit_unspill:
                 data = (
                     ProxifyHostFile,
                     {


### PR DESCRIPTION
Make the`jit_unspill` property a local as discussed in #944. 

In addition, fix a bug that was introduced in `dask-cuda-worker` in #944: the `data` argument has to be a callable, and should presumably return an object that is unique for each nanny.