### PR TITLE
Always use versioneer command classes in setup.py

### DIFF
--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -5,7 +5,6 @@
 {% set data = load_setup_py_data() %}
 
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
-{% set git_revision_count=environ.get('GIT_DESCRIBE_NUMBER', 0) %}
 {% set py_version=environ.get('CONDA_PY', 36) %}
 package:
   name: dask-cuda
@@ -15,10 +14,8 @@ source:
   git_url: ../../..
 
 build:
-  number: {{ git_revision_count }}
-  string: py{{ py_version }}_{{ git_revision_count }}
-  script_env:
-    - VERSION_SUFFIX
+  number: {{ GIT_DESCRIBE_NUMBER }}
+  string: py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
 
 requirements:
   host:

--- a/setup.py
+++ b/setup.py
@@ -9,17 +9,10 @@ import versioneer
 with open(os.path.join(os.path.dirname(__file__), "README.md")) as f:
     long_description = f.read()
 
-if "GIT_DESCRIBE_TAG" in os.environ:
-    version = os.environ["GIT_DESCRIBE_TAG"] + os.environ.get("VERSION_SUFFIX", "")
-    cmdclass = {}
-else:
-    version = versioneer.get_version()
-    cmdclass = versioneer.get_cmdclass()
-
 setup(
     name="dask-cuda",
-    version=version,
-    cmdclass=cmdclass,
+    version=versioneer.get_version(),
+    cmdclass=versioneer.get_cmdclass(),
     description="Utilities for Dask and CUDA interactions",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
The `GIT_DESCRIBE_TAG` and `VERSION_SUFFIX` environment variables are used
to control the name and version of the created conda/pypi package.
They should, however, not be used to control the version of the
installed package by overriding the versioneer cmdclass since that
leaves an unmodified _version.py file in the installed package
directory. A consequence is that the version reported by
`dask_cuda.__version__` is `"0+unknown"`. 

We cannot always use the versioneer-provided cmdclass unmodified since
PEP440 specifically forbids PyPI from accepting packages that have local
version identifiers (as used by versioneer). To get around this, when setup.py
detects it is building a PyPI package (`GIT_DESCRIBE_TAG` is in the environment),
patch the version returned from versioneer with a PyPI-compatible one.

While we're here, bring the conda version string into line with the
rest of the rapids ecosystem.

Closes #336.