### PR TITLE
Add pytest fixture to revert `CUDA_VISIBLE_DEVICES`

### DIFF
--- a/dask_cuda/tests/conftest.py
+++ b/dask_cuda/tests/conftest.py
@@ -1,0 +1,12 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def revert_cuda_visible_devices(request):
+    def _revert():
+        if "CUDA_VISIBLE_DEVICES" in os.environ:
+            del os.environ["CUDA_VISIBLE_DEVICES"]
+
+    request.addfinalizer(_revert)


### PR DESCRIPTION
This is a temporary workaround to unblock CI until https://github.com/rapidsai/dask-cuda/pull/955 or another proper solution can be merged.