### PR TITLE
Temporarily disable compression for communication protocols

### DIFF
--- a/dask_cuda/__init__.py
+++ b/dask_cuda/__init__.py
@@ -31,3 +31,7 @@ dask.dataframe.shuffle.shuffle_group = proxify_decorator(
     dask.dataframe.shuffle.shuffle_group
 )
 dask.dataframe.core._concat = unproxify_decorator(dask.dataframe.core._concat)
+
+# Until GPU-based compression is hooked up, turn off compression
+# in communication protocols (see https://github.com/rapidsai/dask-cuda/issues/935)
+dask.config.config["distributed"]["comm"]["compression"] = None


### PR DESCRIPTION
For GPU data, compression is worse rather than better because it
provokes device-to-host transfers when they are unnecessary.

This is a short-term fix for #935, in lieu of hooking up GPU-based
compression algorithms.