### PR TITLE
[gpuCI] Forward-merge branch-22.08 to branch-22.10 [skip gpuci]

### DIFF
--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -5,7 +5,6 @@
 {% set data = load_setup_py_data() %}
 
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
-{% set git_revision_count=environ.get('GIT_DESCRIBE_NUMBER', 0) %}
 {% set py_version=environ.get('CONDA_PY', 36) %}
 package:
   name: dask-cuda
@@ -15,10 +14,8 @@ source:
   git_url: ../../..
 
 build:
-  number: {{ git_revision_count }}
-  string: py{{ py_version }}_{{ git_revision_count }}
-  script_env:
-    - VERSION_SUFFIX
+  number: {{ GIT_DESCRIBE_NUMBER }}
+  string: py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
 
 requirements:
   host:

--- a/dask_cuda/get_device_memory_objects.py
+++ b/dask_cuda/get_device_memory_objects.py
@@ -95,10 +95,14 @@ def get_device_memory_objects_register_cudf():
 
     @dispatch.register(cudf.core.frame.Frame)
     def get_device_memory_objects_cudf_frame(obj):
-        ret = dispatch(obj._index)
+        ret = []
         for col in obj._data.columns:
             ret += dispatch(col)
         return ret
+
+    @dispatch.register(cudf.core.indexed_frame.IndexedFrame)
+    def get_device_memory_objects_cudf_indexed_frame(obj):
+        return dispatch(obj._index) + get_device_memory_objects_cudf_frame(obj)
 
     @dispatch.register(cudf.core.series.Series)
     def get_device_memory_objects_cudf_series(obj):

--- a/setup.py
+++ b/setup.py
@@ -10,16 +10,31 @@ with open(os.path.join(os.path.dirname(__file__), "README.md")) as f:
     long_description = f.read()
 
 if "GIT_DESCRIBE_TAG" in os.environ:
+    # Disgusting hack. For pypi uploads we cannot use the
+    # versioneer-provided version for non-release builds, since they
+    # strictly follow PEP440
+    # https://peps.python.org/pep-0440/#local-version-identifiers
+    # which disallows local version identifiers (as produced by
+    # versioneer) in public index servers.
+    # We still want to use versioneer infrastructure, so patch
+    # in our pypi-compatible version to the output of
+    # versioneer.get_versions.
+
+    orig_get_versions = versioneer.get_versions
     version = os.environ["GIT_DESCRIBE_TAG"] + os.environ.get("VERSION_SUFFIX", "")
-    cmdclass = {}
-else:
-    version = versioneer.get_version()
-    cmdclass = versioneer.get_cmdclass()
+
+    def get_versions():
+        data = orig_get_versions()
+        data["version"] = version
+        return data
+
+    versioneer.get_versions = get_versions
+
 
 setup(
     name="dask-cuda",
-    version=version,
-    cmdclass=cmdclass,
+    version=versioneer.get_version(),
+    cmdclass=versioneer.get_cmdclass(),
     description="Utilities for Dask and CUDA interactions",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.08` that creates a PR to keep `branch-22.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.