### PR TITLE
Add `__rmatmul__` to `ProxyObject`

### DIFF
--- a/dask_cuda/proxy_object.py
+++ b/dask_cuda/proxy_object.py
@@ -660,6 +660,9 @@ class ProxyObject:
     def __ror__(self, other):
         return other | self._pxy_deserialize()
 
+    def __rmatmul__(self, other):
+        return self._pxy_deserialize().__rmatmul__(unproxy(other))
+
     def __iadd__(self, other):
         pxy = self._pxy_get(copy=True)
         proxied = pxy.deserialize(nbytes=self.__sizeof__())


### PR DESCRIPTION
Fixes https://github.com/rapidsai/dask-cuda/issues/959

If another object (like a `cupy.ndarray`) doesn't support `__matmul__` with `ProxyObject`, Python will try to fallback to `__rmatmul__`. As `__rmatmul__` was not defined before (and some cases like with CuPy now raise), this would raise. To fix, that this PR defines `__rmatmul__` for `ProxyObject`s to provide for this fallback layer.