### PR TITLE
[REVIEW] Fix `distributed` error related to `loop_in_thread`

### DIFF
--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -10,7 +10,7 @@ import pytest
 
 from distributed import Client, wait
 from distributed.system import MEMORY_LIMIT
-from distributed.utils_test import cleanup, loop, popen  # noqa: F401
+from distributed.utils_test import cleanup, loop, popen, loop_in_thread  # noqa: F401
 
 from dask_cuda.utils import (
     get_gpu_count_mig,

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -10,7 +10,7 @@ import pytest
 
 from distributed import Client, wait
 from distributed.system import MEMORY_LIMIT
-from distributed.utils_test import cleanup, loop, popen, loop_in_thread  # noqa: F401
+from distributed.utils_test import cleanup, loop, loop_in_thread, popen  # noqa: F401
 
 from dask_cuda.utils import (
     get_gpu_count_mig,


### PR DESCRIPTION
This PR fixes following errors in pytest with latest `distributed`:
```python
  @pytest.mark.parametrize("delayed", [True, False])
  def test_basic(loop, delayed):  # noqa: F811
file /nvme/0/pgali/envs/cudfdev/lib/python3.9/site-packages/distributed/utils_test.py, line 145
  @pytest.fixture
  def loop(loop_in_thread):
E       fixture 'loop_in_thread' not found
>       available fixtures: benchmark, benchmark_weave, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, cleanup, current_cases, doctest_namespace, loop, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, testrun_uid, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory, worker_id
>       use 'pytest --fixtures [testpath]' for help on them.

/nvme/0/pgali/envs/cudfdev/lib/python3.9/site-packages/distributed/utils_test.py:145
```