### PR TITLE
[REVIEW] Pin `dask` & `distributed` for release

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -35,10 +35,10 @@ export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1
 
 # Install dask and distributed from main branch. Usually needed during
 # development time and disabled before a new dask-cuda release.
-export INSTALL_DASK_MAIN=1
+export INSTALL_DASK_MAIN=0
 
 # Dask version to install when `INSTALL_DASK_MAIN=0`
-export DASK_STABLE_VERSION="2022.05.2"
+export DASK_STABLE_VERSION="2022.7.1"
 
 ################################################################################
 # SETUP - Check environment

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-dask>=2022.05.2
-distributed>=2022.05.2
+dask==2022.7.1
+distributed==2022.7.1
 pynvml>=11.0.0
 numpy>=1.16.0
 numba>=0.54


### PR DESCRIPTION
This PR pins dask & distributed to 2022.7.1 for 22.08 release.

xref: https://github.com/rapidsai/cudf/pull/11433