### PR TITLE
[REVIEW] Switch docs to use common `js` & `css` code

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -187,3 +187,9 @@ epub_exclude_files = ["search.html"]
 
 
 # -- Extension configuration -------------------------------------------------
+
+
+
+def setup(app):
+    app.add_css_file("https://docs.rapids.ai/assets/css/custom.css")
+    app.add_js_file("https://docs.rapids.ai/assets/js/custom.js", loading_method="defer")


### PR DESCRIPTION
This PR switches docs to use the custom common `js` & `css` code merged here: https://github.com/rapidsai/docs/pull/286