### PR TITLE
Unpin `dask` and `distributed` for development

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -35,7 +35,7 @@ export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1
 
 # Install dask and distributed from main branch. Usually needed during
 # development time and disabled before a new dask-cuda release.
-export INSTALL_DASK_MAIN=0
+export INSTALL_DASK_MAIN=1
 
 # Dask version to install when `INSTALL_DASK_MAIN=0`
 export DASK_STABLE_VERSION="2022.7.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-dask==2022.7.1
-distributed==2022.7.1
+dask>=2022.7.1
+distributed>=2022.7.1
 pynvml>=11.0.0
 numpy>=1.16.0
 numba>=0.54


### PR DESCRIPTION
This PR unpins `dask` & `distributed` for `22.10` development.

xref: https://github.com/rapidsai/cudf/pull/11492