### PR TITLE
Remove line-break that's breaking link

### DIFF
--- a/docs/source/examples/best-practices.rst
+++ b/docs/source/examples/best-practices.rst
@@ -10,8 +10,8 @@ When choosing between two multi-GPU setups, it is best to pick the one where mos
 
 - Moving data between GPUs is costly and performance decreases when computation stops due to communication overheads, Host-to-Device/Device-to-Host transfers, etc
 - Multi-GPU instances often come with accelerated networking like `NVLink <https://www.nvidia.com/en-us/data-center/nvlink/>`_.  These accelerated
-networking paths usually have much higher throughput/bandwidth compared with traditional networking *and* don't force and Host-to-Device/Device-to-Host transfers.  See `
-Accelerated Networking`_ for more discussion
+networking paths usually have much higher throughput/bandwidth compared with traditional networking *and* don't force and Host-to-Device/Device-to-Host transfers.  See
+`Accelerated Networking`_ for more discussion
 
 .. code-block:: python
 


### PR DESCRIPTION
https://docs.rapids.ai/api/dask-cuda/nightly/examples/best-practices.html currently shows 

> [...] don’t force and Host-to-Device/Device-to-Host transfers. See ` Accelerated Networking`_ for more discussion

rather than the link. This should fix that.