### PR TITLE
Support cuDF's built-in spilling

### DIFF
--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -284,9 +284,9 @@ class DeviceHostFile(ZictBase):
     def __getitem__(self, key):
         if key in self.others:
             return self.others[key]
-        if key in self.device_keys:
+        elif key in self.device_keys:
             return self.device_buffer[key]
-        if key in self.host_buffer:
+        elif key in self.host_buffer:
             return self.host_buffer[key]
         raise KeyError(key)
 

--- a/dask_cuda/is_spillable_object.py
+++ b/dask_cuda/is_spillable_object.py
@@ -1,0 +1,55 @@
+from __future__ import absolute_import, division, print_function
+
+from typing import Optional
+
+from dask.utils import Dispatch
+
+is_spillable_object = Dispatch(name="is_spillable_object")
+
+
+@is_spillable_object.register(list)
+@is_spillable_object.register(tuple)
+@is_spillable_object.register(set)
+@is_spillable_object.register(frozenset)
+def _(seq):
+    return any([is_spillable_object(s) for s in seq])
+
+
+@is_spillable_object.register(dict)
+def _(seq):
+    return any([is_spillable_object(s) for s in seq.items()])
+
+
+@is_spillable_object.register(object)
+def _(o):
+    return False
+
+
+@is_spillable_object.register_lazy("cudf")
+def register_cudf():
+    import cudf
+    from cudf.core.frame import Frame
+
+    @is_spillable_object.register(Frame)
+    def is_device_object_cudf_dataframe(df):
+        return cudf_spilling_status()
+
+    @is_spillable_object.register(cudf.BaseIndex)
+    def is_device_object_cudf_index(s):
+        return cudf_spilling_status()
+
+
+def cudf_spilling_status() -> Optional[bool]:
+    """Check the status of cudf's build-in spilling
+
+    Returns:
+        - True if cudf's internal spilling is enabled, or
+        - False if it is disabled, or
+        - None if the current version of cudf doesn't support spilling, or
+        - None if cudf isn't available.
+    """
+    try:
+        from cudf.core.buffer.spill_manager import get_global_manager
+    except ImportError:
+        return None
+    return get_global_manager() is not None

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -40,6 +40,7 @@ from distributed.protocol.serialize import (
 from . import proxify_device_objects as pdo
 from .disk_io import SpillToDiskProperties, disk_read, disk_write
 from .get_device_memory_objects import DeviceMemoryId, get_device_memory_ids
+from .is_spillable_object import cudf_spilling_status
 from .proxify_device_objects import proxify_device_objects, unproxify_device_objects
 from .proxy_object import ProxyObject
 
@@ -500,6 +501,12 @@ class ProxifyHostFile(MutableMapping):
         spill_on_demand: bool = None,
         gds_spilling: bool = None,
     ):
+        if cudf_spilling_status():
+            warnings.warn(
+                "JIT-Unspill and cuDF's built-in spilling doesn't mix well, please "
+                "disable one of them (`CUDF_SPILL=off` or `DASK_JIT_UNSPILL=off`)"
+            )
+
         # each value of self.store is a tuple containing the proxified
         # object, as well as a boolean indicating whether any
         # incompatible types were found when proxifying it

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -503,8 +503,9 @@ class ProxifyHostFile(MutableMapping):
     ):
         if cudf_spilling_status():
             warnings.warn(
-                "JIT-Unspill and cuDF's built-in spilling doesn't mix well, please "
-                "disable one of them (`CUDF_SPILL=off` or `DASK_JIT_UNSPILL=off`)"
+                "JIT-Unspill and cuDF's built-in spilling don't work together, please "
+                "disable one of them by setting either `CUDF_SPILL=off` or "
+                "`DASK_JIT_UNSPILL=off` environment variable."
             )
 
         # each value of self.store is a tuple containing the proxified

--- a/dask_cuda/tests/test_cudf_builtin_spilling.py
+++ b/dask_cuda/tests/test_cudf_builtin_spilling.py
@@ -10,7 +10,7 @@ pandas = pytest.importorskip("pandas")
 
 pytest.importorskip(
     "cudf.core.buffer.spill_manager",
-    reason="Current version of cudf doesn't support native spilling",
+    reason="Current version of cudf doesn't support built-in spilling",
 )
 
 import cudf  # noqa: E402
@@ -24,7 +24,7 @@ from cudf.testing._utils import assert_eq  # noqa: E402
 if get_global_manager() is not None:
     pytest.skip(
         reason=(
-            "cannot test cudf native spilling, if already enabled globally. "
+            "cannot test cudf built-in spilling, if already enabled globally. "
             "Please set `CUDF_SPILL=off`"
         ),
         allow_module_level=True,

--- a/dask_cuda/tests/test_cudf_builtin_spilling.py
+++ b/dask_cuda/tests/test_cudf_builtin_spilling.py
@@ -136,7 +136,8 @@ def test_proxify_host_file(tmp_path_factory, manager: SpillManager):
         tmpdir = ProxifyHostFile._spill_to_disk.root_dir / ".."
 
     with pytest.warns(
-        UserWarning, match="JIT-Unspill and cuDF's built-in spilling don't work together"
+        UserWarning,
+        match="JIT-Unspill and cuDF's built-in spilling don't work together",
     ):
         dhf = ProxifyHostFile(
             device_memory_limit=1000,

--- a/dask_cuda/tests/test_cudf_builtin_spilling.py
+++ b/dask_cuda/tests/test_cudf_builtin_spilling.py
@@ -100,3 +100,27 @@ def test_device_host_file_step_by_step(tmp_path, manager: SpillManager):
     assert set(dhf.device.keys()) == set()
     assert set(dhf.host.keys()) == set(["pa2"])
     assert set(dhf.disk.keys()) == set(["pa1"])
+
+    del dhf["cu1"]
+    assert set(dhf.others.keys()) == set(["cu2"])
+    assert set(dhf.device.keys()) == set()
+    assert set(dhf.host.keys()) == set(["pa2"])
+    assert set(dhf.disk.keys()) == set(["pa1"])
+
+    del dhf["pa2"]
+    assert set(dhf.others.keys()) == set(["cu2"])
+    assert set(dhf.device.keys()) == set()
+    assert set(dhf.host.keys()) == set()
+    assert set(dhf.disk.keys()) == set(["pa1"])
+
+    del dhf["pa1"]
+    assert set(dhf.others.keys()) == set(["cu2"])
+    assert set(dhf.device.keys()) == set()
+    assert set(dhf.host.keys()) == set()
+    assert set(dhf.disk.keys()) == set()
+
+    del dhf["cu2"]
+    assert set(dhf.others.keys()) == set()
+    assert set(dhf.device.keys()) == set()
+    assert set(dhf.host.keys()) == set()
+    assert set(dhf.disk.keys()) == set()

--- a/dask_cuda/tests/test_cudf_native_spilling.py
+++ b/dask_cuda/tests/test_cudf_native_spilling.py
@@ -1,0 +1,102 @@
+import pytest
+
+from distributed.sizeof import safe_sizeof
+
+from dask_cuda.device_host_file import DeviceHostFile
+from dask_cuda.is_spillable_object import is_spillable_object
+
+cupy = pytest.importorskip("cupy")
+pandas = pytest.importorskip("pandas")
+
+pytest.importorskip(
+    "cudf.core.buffer.spill_manager",
+    reason="Current version of cudf doesn't support native spilling",
+)
+
+import cudf  # noqa: E402
+from cudf.core.buffer.spill_manager import (  # noqa: E402
+    SpillManager,
+    get_global_manager,
+    set_global_manager,
+)
+from cudf.testing._utils import assert_eq  # noqa: E402
+
+if get_global_manager() is not None:
+    pytest.skip(
+        reason=(
+            "cannot test cudf native spilling, if already enabled globally. "
+            "Please set `CUDF_SPILL=off`"
+        ),
+        allow_module_level=True,
+    )
+
+
+@pytest.fixture
+def manager(request):
+    """Fixture to enable and make a spilling manager availabe"""
+    kwargs = dict(getattr(request, "param", {}))
+    set_global_manager(manager=SpillManager(**kwargs))
+    yield get_global_manager()
+    set_global_manager(manager=None)
+
+
+def test_is_spillable_object_when_cudf_spilling_disabled():
+    pdf = pandas.DataFrame({"a": [1, 2, 3]})
+    cdf = cudf.DataFrame({"a": [1, 2, 3]})
+    assert not is_spillable_object(pdf)
+    assert not is_spillable_object(cdf)
+
+
+def test_is_spillable_object_when_cudf_spilling_enabled(manager):
+    pdf = pandas.DataFrame({"a": [1, 2, 3]})
+    cdf = cudf.DataFrame({"a": [1, 2, 3]})
+    assert not is_spillable_object(pdf)
+    assert is_spillable_object(cdf)
+
+
+def test_device_host_file_when_cudf_spilling_is_disabled(tmp_path):
+    tmpdir = tmp_path / "storage"
+    tmpdir.mkdir()
+    dhf = DeviceHostFile(
+        device_memory_limit=1024 * 16,
+        memory_limit=1024 * 16,
+        worker_local_directory=tmpdir,
+    )
+    dhf["pandas"] = pandas.DataFrame({"a": [1, 2, 3]})
+    dhf["cudf"] = cudf.DataFrame({"a": [1, 2, 3]})
+
+    assert set(dhf.others.keys()) == set()
+    assert set(dhf.device.keys()) == set(["cudf"])
+    assert set(dhf.host.keys()) == set(["pandas"])
+    assert set(dhf.disk.keys()) == set()
+
+
+def test_device_host_file_step_by_step(tmp_path, manager: SpillManager):
+    tmpdir = tmp_path / "storage"
+    tmpdir.mkdir()
+    pdf = pandas.DataFrame({"a": [1, 2, 3]})
+    dhf = DeviceHostFile(
+        device_memory_limit=safe_sizeof(pdf),
+        memory_limit=safe_sizeof(pdf),
+        worker_local_directory=tmpdir,
+    )
+    dhf["pa1"] = pdf
+    dhf["cu1"] = cudf.DataFrame({"a": [1, 2, 3]})
+
+    assert set(dhf.others.keys()) == set(["cu1"])
+    assert set(dhf.device.keys()) == set()
+    assert set(dhf.host.keys()) == set(["pa1"])
+    assert set(dhf.disk.keys()) == set()
+    assert_eq(dhf["pa1"], dhf["cu1"])
+
+    dhf["pa2"] = pdf
+    assert set(dhf.others.keys()) == set(["cu1"])
+    assert set(dhf.device.keys()) == set()
+    assert set(dhf.host.keys()) == set(["pa2"])
+    assert set(dhf.disk.keys()) == set(["pa1"])
+
+    dhf["cu2"] = cudf.DataFrame({"a": [1, 2, 3]})
+    assert set(dhf.others.keys()) == set(["cu1", "cu2"])
+    assert set(dhf.device.keys()) == set()
+    assert set(dhf.host.keys()) == set(["pa2"])
+    assert set(dhf.disk.keys()) == set(["pa1"])

--- a/dask_cuda/tests/test_device_host_file.py
+++ b/dask_cuda/tests/test_device_host_file.py
@@ -64,6 +64,7 @@ def test_device_host_file_short(
     assert set(dhf.device.keys()) == set()
     assert set(dhf.host.keys()) == set()
     assert set(dhf.disk.keys()) == set()
+    assert set(dhf.others.keys()) == set()
 
 
 def test_device_host_file_step_by_step(tmp_path):
@@ -82,36 +83,43 @@ def test_device_host_file_step_by_step(tmp_path):
     assert set(dhf.device.keys()) == set()
     assert set(dhf.host.keys()) == set(["a1"])
     assert set(dhf.disk.keys()) == set()
+    assert set(dhf.others.keys()) == set()
 
     dhf["b1"] = b
     assert set(dhf.device.keys()) == set(["b1"])
     assert set(dhf.host.keys()) == set(["a1"])
     assert set(dhf.disk.keys()) == set()
+    assert set(dhf.others.keys()) == set()
 
     dhf["b2"] = b
     assert set(dhf.device.keys()) == set(["b1", "b2"])
     assert set(dhf.host.keys()) == set(["a1"])
     assert set(dhf.disk.keys()) == set()
+    assert set(dhf.others.keys()) == set()
 
     dhf["b3"] = b
     assert set(dhf.device.keys()) == set(["b2", "b3"])
     assert set(dhf.host.keys()) == set(["a1", "b1"])
     assert set(dhf.disk.keys()) == set()
+    assert set(dhf.others.keys()) == set()
 
     dhf["a2"] = a
     assert set(dhf.device.keys()) == set(["b2", "b3"])
     assert set(dhf.host.keys()) == set(["a2", "b1"])
     assert set(dhf.disk.keys()) == set(["a1"])
+    assert set(dhf.others.keys()) == set()
 
     dhf["b4"] = b
     assert set(dhf.device.keys()) == set(["b3", "b4"])
     assert set(dhf.host.keys()) == set(["a2", "b2"])
     assert set(dhf.disk.keys()) == set(["a1", "b1"])
+    assert set(dhf.others.keys()) == set()
 
     dhf["b4"] = b
     assert set(dhf.device.keys()) == set(["b3", "b4"])
     assert set(dhf.host.keys()) == set(["a2", "b2"])
     assert set(dhf.disk.keys()) == set(["a1", "b1"])
+    assert set(dhf.others.keys()) == set()
 
     assert_eq(dhf["a1"], a)
     del dhf["a1"]
@@ -129,11 +137,13 @@ def test_device_host_file_step_by_step(tmp_path):
     assert set(dhf.device.keys()) == set()
     assert set(dhf.host.keys()) == set()
     assert set(dhf.disk.keys()) == set()
+    assert set(dhf.others.keys()) == set()
 
     dhf["x"] = b
     dhf["x"] = a
     assert set(dhf.device.keys()) == set()
     assert set(dhf.host.keys()) == set(["x"])
+    assert set(dhf.others.keys()) == set()
 
 
 @pytest.mark.parametrize("collection", [dict, list, tuple])

--- a/dask_cuda/tests/test_device_host_file.py
+++ b/dask_cuda/tests/test_device_host_file.py
@@ -79,13 +79,11 @@ def test_device_host_file_step_by_step(tmp_path):
     b = cupy.random.random(1000)
 
     dhf["a1"] = a
-
     assert set(dhf.device.keys()) == set()
     assert set(dhf.host.keys()) == set(["a1"])
     assert set(dhf.disk.keys()) == set()
 
     dhf["b1"] = b
-
     assert set(dhf.device.keys()) == set(["b1"])
     assert set(dhf.host.keys()) == set(["a1"])
     assert set(dhf.disk.keys()) == set()

--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -45,7 +45,7 @@ def root_dir(tmp_path_factory):
     assert ProxifyHostFile._spill_to_disk is not None
 
     # In order to use the same tmp dir, we use `root_dir` for all
-    # ProxifyHostFile creations Notice, we use `..` to remove the
+    # ProxifyHostFile creations. Notice, we use `..` to remove the
     # `jit-unspill-disk-storage` part added by the
     # ProxifyHostFile implicitly.
     return str(ProxifyHostFile._spill_to_disk.root_dir / "..")

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 import os
 
-from setuptools import setup
-
 import versioneer
+from setuptools import setup
 
 if "GIT_DESCRIBE_TAG" in os.environ:
     # Disgusting hack. For pypi uploads we cannot use the


### PR DESCRIPTION
Support of the [new built-in spilling in cuDF](https://github.com/rapidsai/cudf/pull/12106) so that `device_memory_limit` and `memory_limit` ignores cuDF's device buffers.

This is only implemented for `DeviceHostFile`. Since jit-unspill also targets cuDF and libraries such as cupy isn't supported, I don't think it is important to support cuDF's built-in spilling in `ProxifyHostFile`.

For now, `DeviceHostFile` simply ignores cuDF's device buffers and let cuDF handle the spilling. This means that `DeviceHostFile` might estimate the device and host memory usage incorrectly ([or more incorrectly than usually](https://github.com/dask/distributed/issues/4568#issuecomment-805049321)).