### PR TITLE
Update rearrange_by_column patch for explicit comms

### DIFF
--- a/dask_cuda/__init__.py
+++ b/dask_cuda/__init__.py
@@ -10,7 +10,7 @@ import dask.dataframe.shuffle
 
 from ._version import get_versions
 from .cuda_worker import CUDAWorker
-from .explicit_comms.dataframe.shuffle import get_rearrange_by_column_tasks_wrapper
+from .explicit_comms.dataframe.shuffle import get_rearrange_by_column_wrapper
 from .local_cuda_cluster import LocalCUDACluster
 from .proxify_device_objects import proxify_decorator, unproxify_decorator
 
@@ -19,10 +19,8 @@ del get_versions
 
 
 # Monkey patching Dask to make use of explicit-comms when `DASK_EXPLICIT_COMMS=True`
-dask.dataframe.shuffle.rearrange_by_column_tasks = (
-    get_rearrange_by_column_tasks_wrapper(
-        dask.dataframe.shuffle.rearrange_by_column_tasks
-    )
+dask.dataframe.shuffle.rearrange_by_column = get_rearrange_by_column_wrapper(
+    dask.dataframe.shuffle.rearrange_by_column
 )
 
 

--- a/dask_cuda/explicit_comms/dataframe/shuffle.py
+++ b/dask_cuda/explicit_comms/dataframe/shuffle.py
@@ -344,7 +344,7 @@ def shuffle(
     return new_dd_object(dsk, name, meta, divs).persist()
 
 
-def get_rearrange_by_column_tasks_wrapper(func):
+def get_rearrange_by_column_wrapper(func):
     """Returns a function wrapper that dispatch the shuffle to explicit-comms.
 
     Notice, this is monkey patched into Dask at dask_cuda import
@@ -354,23 +354,29 @@ def get_rearrange_by_column_tasks_wrapper(func):
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        if dask.config.get("explicit-comms", False):
+        # Use explicit-comms shuffle if the shuffle kwarg is
+        # set to "explicit-comms", or if it is set to "tasks"
+        # and the `dask.config` specifies "explicit-comms"
+        shuffle_arg = kwargs.pop("shuffle", None) or dask.config.get("shuffle", "disk")
+        if shuffle_arg == "explicit-comms" or (
+            dask.config.get("explicit-comms", False) and shuffle_arg == "tasks"
+        ):
             try:
                 import distributed.worker
 
                 # Make sure we have an activate client.
                 distributed.worker.get_client()
             except (ImportError, ValueError):
-                pass
+                shuffle_arg = "tasks"  # Fall back to task-based shuffle
             else:
                 # Convert `*args, **kwargs` to a dict of `keyword -> values`
                 kw = func_sig.bind(*args, **kwargs)
                 kw.apply_defaults()
                 kw = kw.arguments
-                column = kw["column"]
+                column = kw["col"]
                 if isinstance(column, str):
                     column = [column]
                 return shuffle(kw["df"], column, kw["npartitions"], kw["ignore_index"])
-        return func(*args, **kwargs)
+        return func(*args, shuffle=shuffle_arg, **kwargs)
 
     return wrapper

--- a/dask_cuda/explicit_comms/dataframe/shuffle.py
+++ b/dask_cuda/explicit_comms/dataframe/shuffle.py
@@ -1,6 +1,7 @@
 import asyncio
 import functools
 import inspect
+import warnings
 from collections import defaultdict
 from operator import getitem
 from typing import Dict, List, Optional
@@ -355,12 +356,23 @@ def get_rearrange_by_column_wrapper(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         # Use explicit-comms shuffle if the shuffle kwarg is
-        # set to "explicit-comms", or if it is set to "tasks"
-        # and the `dask.config` specifies "explicit-comms"
+        # set to "explicit-comms". For now, we also use
+        # explicit-comms if the shuffle kwarg is set to "tasks"
+        # and the `dask.config` specifies "explicit-comms".
+        # However, this behavior should be deprecated in the
+        # next dask-cuda release (after 22.10)
         shuffle_arg = kwargs.pop("shuffle", None) or dask.config.get("shuffle", "disk")
-        if shuffle_arg == "explicit-comms" or (
-            dask.config.get("explicit-comms", False) and shuffle_arg == "tasks"
-        ):
+        if shuffle_arg == "tasks" and dask.config.get("explicit-comms", False):
+            shuffle_arg = "explicit-comms"
+            warnings.warn(
+                "The 'explicit-comms' config field is now deprecated and "
+                "will be removed in a future dask-cuda version. Please set "
+                "the 'shuffle' config to 'explicit-comms' instead, or pass "
+                "`shuffle='explicit-comms'` to the collection API.",
+                FutureWarning,
+            )
+
+        if shuffle_arg == "explicit-comms":
             try:
                 import distributed.worker
 

--- a/dask_cuda/tests/test_explicit_comms.py
+++ b/dask_cuda/tests/test_explicit_comms.py
@@ -19,7 +19,7 @@ from dask_cuda.initialize import initialize
 from dask_cuda.utils import get_ucx_config
 
 mp = mp.get_context("spawn")  # type: ignore
-# ucp = pytest.importorskip("ucp")
+ucp = pytest.importorskip("ucp")
 
 # Notice, all of the following tests is executed in a new process such
 # that UCX options of the different tests doesn't conflict.
@@ -177,6 +177,13 @@ def _test_dask_use_explicit_comms():
                 assert any(name in str(key) for key in res.dask)
             else:  # If not in cluster, we cannot use explicit comms
                 assert all(name not in str(key) for key in res.dask)
+
+        # Passing explicit `shuffle="explicit-comms"` argument
+        res = dd.shuffle.shuffle(ddf, "key", npartitions=4, shuffle="explicit-comms")
+        if in_cluster:
+            assert any(name in str(key) for key in res.dask)
+        else:  # If not in cluster, we cannot use explicit comms
+            assert all(name not in str(key) for key in res.dask)
 
     with LocalCluster(
         protocol="tcp",

--- a/dask_cuda/tests/test_explicit_comms.py
+++ b/dask_cuda/tests/test_explicit_comms.py
@@ -178,6 +178,13 @@ def _test_dask_use_explicit_comms():
             else:  # If not in cluster, we cannot use explicit comms
                 assert all(name not in str(key) for key in res.dask)
 
+        # Passing explicit `shuffle="explicit-comms"` argument
+        res = ddf.shuffle(on="key", npartitions=4, shuffle="explicit-comms")
+        if in_cluster:
+            assert any(name in str(key) for key in res.dask)
+        else:  # If not in cluster, we cannot use explicit comms
+            assert all(name not in str(key) for key in res.dask)
+
     with LocalCluster(
         protocol="tcp",
         dashboard_address=None,

--- a/dask_cuda/tests/test_explicit_comms.py
+++ b/dask_cuda/tests/test_explicit_comms.py
@@ -19,7 +19,7 @@ from dask_cuda.initialize import initialize
 from dask_cuda.utils import get_ucx_config
 
 mp = mp.get_context("spawn")  # type: ignore
-ucp = pytest.importorskip("ucp")
+# ucp = pytest.importorskip("ucp")
 
 # Notice, all of the following tests is executed in a new process such
 # that UCX options of the different tests doesn't conflict.
@@ -177,13 +177,6 @@ def _test_dask_use_explicit_comms():
                 assert any(name in str(key) for key in res.dask)
             else:  # If not in cluster, we cannot use explicit comms
                 assert all(name not in str(key) for key in res.dask)
-
-        # Passing explicit `shuffle="explicit-comms"` argument
-        res = ddf.shuffle(on="key", npartitions=4, shuffle="explicit-comms")
-        if in_cluster:
-            assert any(name in str(key) for key in res.dask)
-        else:  # If not in cluster, we cannot use explicit comms
-            assert all(name not in str(key) for key in res.dask)
 
     with LocalCluster(
         protocol="tcp",

--- a/docs/source/explicit_comms.rst
+++ b/docs/source/explicit_comms.rst
@@ -2,7 +2,7 @@ Explicit-comms
 ==============
 
 Communication and scheduling overhead can be a major bottleneck in Dask/Distributed. Dask-CUDA addresses this by introducing an API for explicit communication in Dask tasks.
-The idea is that Dask/Distributed spawns workers and distribute data as usuall while the user can submit tasks on the workers that communicate explicitly.
+The idea is that Dask/Distributed spawns workers and distribute data as usual while the user can submit tasks on the workers that communicate explicitly.
 
 This makes it possible to bypass Distributed's scheduler and write hand-tuned computation and communication patterns. Currently, Dask-CUDA includes an explicit-comms
 implementation of the Dataframe `shuffle <https://github.com/rapidsai/dask-cuda/blob/d3c723e2c556dfe18b47b392d0615624453406a5/dask_cuda/explicit_comms/dataframe/shuffle.py#L210>`_ operation used for merging and sorting.

--- a/docs/source/explicit_comms.rst
+++ b/docs/source/explicit_comms.rst
@@ -2,7 +2,7 @@ Explicit-comms
 ==============
 
 Communication and scheduling overhead can be a major bottleneck in Dask/Distributed. Dask-CUDA addresses this by introducing an API for explicit communication in Dask tasks.
-The idea is that Dask/Distributed spawns workers and distribute data as usual while the user can submit tasks on the workers that communicate explicitly.
+The idea is that Dask/Distributed spawns workers and distributes the data as usual while the user can submit tasks on the workers that communicate explicitly.
 
 This makes it possible to bypass Distributed's scheduler and write hand-tuned computation and communication patterns. Currently, Dask-CUDA includes an explicit-comms
 implementation of the Dataframe `shuffle <https://github.com/rapidsai/dask-cuda/blob/d3c723e2c556dfe18b47b392d0615624453406a5/dask_cuda/explicit_comms/dataframe/shuffle.py#L210>`_ operation used for merging and sorting.

--- a/docs/source/explicit_comms.rst
+++ b/docs/source/explicit_comms.rst
@@ -2,7 +2,7 @@ Explicit-comms
 ==============
 
 Communication and scheduling overhead can be a major bottleneck in Dask/Distributed. Dask-CUDA addresses this by introducing an API for explicit communication in Dask tasks.
-The idea is that Dask/Distributed spawns workers and distribute data as usually while the user can submit tasks on the workers that communicate explicitly.
+The idea is that Dask/Distributed spawns workers and distribute data as usuall while the user can submit tasks on the workers that communicate explicitly.
 
 This makes it possible to bypass Distributed's scheduler and write hand-tuned computation and communication patterns. Currently, Dask-CUDA includes an explicit-comms
 implementation of the Dataframe `shuffle <https://github.com/rapidsai/dask-cuda/blob/d3c723e2c556dfe18b47b392d0615624453406a5/dask_cuda/explicit_comms/dataframe/shuffle.py#L210>`_ operation used for merging and sorting.
@@ -11,7 +11,6 @@ implementation of the Dataframe `shuffle <https://github.com/rapidsai/dask-cuda/
 Usage
 -----
 
-In order to use explicit-comms in Dask/Distributed automatically, simply define the environment variable ``DASK_EXPLICIT_COMMS=True`` or setting the ``"explicit-comms"``
-key in the `Dask configuration <https://docs.dask.org/en/latest/configuration.html>`_.
+In order to use explicit-comms in Dask/Distributed for shuffle-based DataFrame operations, simply pass the ``shuffle="explicit-comms"`` key-word argument to the appropriate DataFrame API (e.g. ``ddf.sort_values(..., shuffle="explicit-comms")```). You can also change the default shuffle algorithm to explicit-comms by define the ``DASK_SHUFFLE=explicit-comms`` environment variable, or by setting the ``"shuffle"`` key to ``"explicit-comms"`` in the `Dask configuration <https://docs.dask.org/en/latest/configuration.html>`_.
 
 It is also possible to use explicit-comms in tasks manually, see the `API <api.html#explicit-comms>`_ and our `implementation of shuffle <https://github.com/rapidsai/dask-cuda/blob/branch-0.20/dask_cuda/explicit_comms/dataframe/shuffle.py>`_ for guidance.


### PR DESCRIPTION
Motivated by discussions in https://github.com/rapidsai/cudf/pull/11576 (primarilty [here](https://github.com/rapidsai/cudf/pull/11576#discussion_r977813158)). This PR updates the `rearrange_by_columns_tasks` wrapper to target `rearrange_by_columns` instead. The updated wrapper also handles the case that `shuffle="explicit-comms"`.