### PR TITLE
Address CI failures caused by upstream distributed and cupy changes

### DIFF
--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -334,19 +334,6 @@ class LocalCUDACluster(LocalCluster):
 
         self.pre_import = pre_import
 
-        # Update config settings
-        config = dask.config.config.copy()
-        config.update(
-            {
-                "distributed.comm.ucx": get_ucx_config(
-                    enable_tcp_over_ucx=enable_tcp_over_ucx,
-                    enable_nvlink=enable_nvlink,
-                    enable_infiniband=enable_infiniband,
-                    enable_rdmacm=enable_rdmacm,
-                )
-            }
-        )
-
         super().__init__(
             n_workers=0,
             threads_per_worker=threads_per_worker,
@@ -356,7 +343,14 @@ class LocalCUDACluster(LocalCluster):
             local_directory=local_directory,
             protocol=protocol,
             worker_class=worker_class,
-            config=config,
+            config={
+                "distributed.comm.ucx": get_ucx_config(
+                    enable_tcp_over_ucx=enable_tcp_over_ucx,
+                    enable_nvlink=enable_nvlink,
+                    enable_infiniband=enable_infiniband,
+                    enable_rdmacm=enable_rdmacm,
+                )
+            },
             **kwargs,
         )
 

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -2,6 +2,8 @@ import copy
 import os
 import warnings
 
+import tlz as toolz
+
 import dask
 from dask.utils import parse_bytes
 from distributed import LocalCluster, Nanny, Worker
@@ -343,14 +345,17 @@ class LocalCUDACluster(LocalCluster):
             local_directory=local_directory,
             protocol=protocol,
             worker_class=worker_class,
-            config={
-                "distributed.comm.ucx": get_ucx_config(
-                    enable_tcp_over_ucx=enable_tcp_over_ucx,
-                    enable_nvlink=enable_nvlink,
-                    enable_infiniband=enable_infiniband,
-                    enable_rdmacm=enable_rdmacm,
-                )
-            },
+            config=toolz.merge(
+                dask.config.config,
+                {
+                    "distributed.comm.ucx": get_ucx_config(
+                        enable_tcp_over_ucx=enable_tcp_over_ucx,
+                        enable_nvlink=enable_nvlink,
+                        enable_infiniband=enable_infiniband,
+                        enable_rdmacm=enable_rdmacm,
+                    )
+                },
+            ),
             **kwargs,
         )
 

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -2,8 +2,6 @@ import copy
 import os
 import warnings
 
-import tlz as toolz
-
 import dask
 from dask.utils import parse_bytes
 from distributed import LocalCluster, Nanny, Worker
@@ -336,6 +334,19 @@ class LocalCUDACluster(LocalCluster):
 
         self.pre_import = pre_import
 
+        # Update config settings
+        config = dask.config.config.copy()
+        config.update(
+            {
+                "distributed.comm.ucx": get_ucx_config(
+                    enable_tcp_over_ucx=enable_tcp_over_ucx,
+                    enable_nvlink=enable_nvlink,
+                    enable_infiniband=enable_infiniband,
+                    enable_rdmacm=enable_rdmacm,
+                )
+            }
+        )
+
         super().__init__(
             n_workers=0,
             threads_per_worker=threads_per_worker,
@@ -345,17 +356,7 @@ class LocalCUDACluster(LocalCluster):
             local_directory=local_directory,
             protocol=protocol,
             worker_class=worker_class,
-            config=toolz.merge(
-                dask.config.config,
-                {
-                    "distributed.comm.ucx": get_ucx_config(
-                        enable_tcp_over_ucx=enable_tcp_over_ucx,
-                        enable_nvlink=enable_nvlink,
-                        enable_infiniband=enable_infiniband,
-                        enable_rdmacm=enable_rdmacm,
-                    )
-                },
-            ),
+            config=config,
             **kwargs,
         )
 

--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import numpy as np
 import pandas
 import pytest
+from packaging import version
 from pandas.testing import assert_frame_equal, assert_series_equal
 
 import dask
@@ -649,6 +650,8 @@ def test_cupy_broadcast_to():
 
 def test_cupy_matmul():
     cupy = pytest.importorskip("cupy")
+    if version.parse(cupy.__version__) >= version.parse("11.0"):
+        pytest.xfail("See: https://github.com/rapidsai/dask-cuda/issues/995")
     a, b = cupy.arange(10), cupy.arange(10)
     c = a @ b
     assert c == proxy_object.asproxy(a) @ b
@@ -658,6 +661,8 @@ def test_cupy_matmul():
 
 def test_cupy_imatmul():
     cupy = pytest.importorskip("cupy")
+    if version.parse(cupy.__version__) >= version.parse("11.0"):
+        pytest.xfail("See: https://github.com/rapidsai/dask-cuda/issues/995")
     a = cupy.arange(9).reshape(3, 3)
     c = a.copy()
     c @= a

--- a/dask_cuda/tests/test_spill.py
+++ b/dask_cuda/tests/test_spill.py
@@ -1,6 +1,5 @@
 import os
 from time import sleep
-from unittest.mock import patch
 
 import pytest
 from zict.file import _safe_key as safe_key
@@ -210,54 +209,58 @@ async def test_cudf_cluster_device_spill(params):
     # Disabling compression via environment variable seems to be the only way
     # respected here. It is necessary to ensure spilled size matches the actual
     # data size.
-    with patch.dict(os.environ, {"DASK_DISTRIBUTED__COMM__COMPRESSION": "False"}):
-        with dask.config.set({"distributed.worker.memory.terminate": False}):
-            async with LocalCUDACluster(
-                n_workers=1,
-                device_memory_limit=params["device_memory_limit"],
-                memory_limit=params["memory_limit"],
-                memory_target_fraction=params["host_target"],
-                memory_spill_fraction=params["host_spill"],
-                memory_pause_fraction=params["host_pause"],
-                asynchronous=True,
-            ) as cluster:
-                async with Client(cluster, asynchronous=True) as client:
+    with dask.config.set(
+        {
+            "distributed.comm.compression": False,
+            "distributed.worker.memory.terminate": False,
+        }
+    ):
+        async with LocalCUDACluster(
+            n_workers=1,
+            device_memory_limit=params["device_memory_limit"],
+            memory_limit=params["memory_limit"],
+            memory_target_fraction=params["host_target"],
+            memory_spill_fraction=params["host_spill"],
+            memory_pause_fraction=params["host_pause"],
+            asynchronous=True,
+        ) as cluster:
+            async with Client(cluster, asynchronous=True) as client:
 
-                    # There's a known issue with datetime64:
-                    # https://github.com/numpy/numpy/issues/4983#issuecomment-441332940
-                    # The same error above happens when spilling datetime64 to disk
-                    cdf = (
-                        dask.datasets.timeseries(
-                            dtypes={"x": int, "y": float}, freq="400ms"
-                        )
-                        .reset_index(drop=True)
-                        .map_partitions(cudf.from_pandas)
+                # There's a known issue with datetime64:
+                # https://github.com/numpy/numpy/issues/4983#issuecomment-441332940
+                # The same error above happens when spilling datetime64 to disk
+                cdf = (
+                    dask.datasets.timeseries(
+                        dtypes={"x": int, "y": float}, freq="400ms"
                     )
+                    .reset_index(drop=True)
+                    .map_partitions(cudf.from_pandas)
+                )
 
-                    sizes = await client.compute(
-                        cdf.map_partitions(lambda df: df.memory_usage())
-                    )
-                    sizes = sizes.to_arrow().to_pylist()
-                    nbytes = sum(sizes)
+                sizes = await client.compute(
+                    cdf.map_partitions(lambda df: df.memory_usage())
+                )
+                sizes = sizes.to_arrow().to_pylist()
+                nbytes = sum(sizes)
 
-                    cdf2 = cdf.persist()
-                    await wait(cdf2)
+                cdf2 = cdf.persist()
+                await wait(cdf2)
 
-                    del cdf
+                del cdf
 
-                    host_chunks = await client.run(lambda: len(get_worker().data.host))
-                    disk_chunks = await client.run(
-                        lambda: len(get_worker().data.disk or list())
-                    )
-                    for hc, dc in zip(host_chunks.values(), disk_chunks.values()):
-                        if params["spills_to_disk"]:
-                            assert dc > 0
-                        else:
-                            assert hc > 0
-                            assert dc == 0
+                host_chunks = await client.run(lambda: len(get_worker().data.host))
+                disk_chunks = await client.run(
+                    lambda: len(get_worker().data.disk or list())
+                )
+                for hc, dc in zip(host_chunks.values(), disk_chunks.values()):
+                    if params["spills_to_disk"]:
+                        assert dc > 0
+                    else:
+                        assert hc > 0
+                        assert dc == 0
 
-                    await client.run(worker_assert, nbytes, 32, 2048)
+                await client.run(worker_assert, nbytes, 32, 2048)
 
-                    del cdf2
+                del cdf2
 
-                    await client.run(delayed_worker_assert, 0, 0, 0)
+                await client.run(delayed_worker_assert, 0, 0, 0)

--- a/dask_cuda/tests/test_spill.py
+++ b/dask_cuda/tests/test_spill.py
@@ -206,9 +206,6 @@ async def test_cupy_cluster_device_spill(params):
 async def test_cudf_cluster_device_spill(params):
     cudf = pytest.importorskip("cudf")
 
-    # Disabling compression via environment variable seems to be the only way
-    # respected here. It is necessary to ensure spilled size matches the actual
-    # data size.
     with dask.config.set(
         {
             "distributed.comm.compression": False,


### PR DESCRIPTION
~After https://github.com/dask/distributed/pull/7028, the "distributed.comm.ucx"-specific `config` options being passed down to the `LocalCluser` super class are no longer merged with the global options in `dask.config.config` on the worker. This means that the workers only inherit the "distributed.comm.ucx"-specific options.~

~This PR explicitly merges the "distributed.comm.ucx" options with `dask.config.config` within `LocalCUDACluster`.  Without this change, CI will fail.~

The original purpose of this PR has been resolved upstream (see: https://github.com/dask/distributed/pull/7069). This PR now only modifies the tests that are still failing in CI.