### PR TITLE
Add benchmark option to use dask-noop

### DIFF
--- a/dask_cuda/benchmarks/common.py
+++ b/dask_cuda/benchmarks/common.py
@@ -153,7 +153,7 @@ def run_client_from_existing_scheduler(args: Namespace, config: Config):
             client.shutdown()
 
 
-def run_create_client(args, config):
+def run_create_client(args: Namespace, config: Config):
     """Create a client + cluster and run
 
     Shuts down the cluster at the end of the benchmark"""

--- a/dask_cuda/benchmarks/local_cudf_merge.py
+++ b/dask_cuda/benchmarks/local_cudf_merge.py
@@ -14,6 +14,7 @@ from dask.utils import format_bytes, parse_bytes
 
 from dask_cuda.benchmarks.common import Config, execute_benchmark
 from dask_cuda.benchmarks.utils import (
+    as_noop,
     parse_benchmark_args,
     print_key_value,
     print_separator,
@@ -147,12 +148,6 @@ def merge(args, ddf1, ddf2):
     if args.set_index:
         ddf_join = ddf_join.set_index("key")
     if args.backend == "dask-noop":
-        try:
-            from dask_noop import as_noop
-        except ImportError:
-            raise RuntimeError(
-                "Requested noop computation but dask-noop not installed."
-            )
         ddf_join = as_noop(ddf_join)
     t1 = perf_counter()
     wait(ddf_join.persist())

--- a/dask_cuda/benchmarks/local_cudf_merge.py
+++ b/dask_cuda/benchmarks/local_cudf_merge.py
@@ -146,7 +146,17 @@ def merge(args, ddf1, ddf2):
     ddf_join = ddf1.merge(ddf2, on=["key"], how="inner", broadcast=broadcast)
     if args.set_index:
         ddf_join = ddf_join.set_index("key")
+    if args.backend == "dask-noop":
+        try:
+            from dask_noop import as_noop
+        except ImportError:
+            raise RuntimeError(
+                "Requested noop computation but dask-noop not installed."
+            )
+        ddf_join = as_noop(ddf_join)
+    t1 = perf_counter()
     wait(ddf_join.persist())
+    return perf_counter() - t1
 
 
 def bench_once(client, args, write_profile=None):
@@ -179,11 +189,9 @@ def bench_once(client, args, write_profile=None):
 
     with ctx1:
         with ctx2:
-            t1 = perf_counter()
-            merge(args, ddf_base, ddf_other)
-            t2 = perf_counter()
+            duration = merge(args, ddf_base, ddf_other)
 
-    return (data_processed, t2 - t1)
+    return (data_processed, duration)
 
 
 def pretty_print_results(args, address_to_index, p2p_bw, results):
@@ -273,7 +281,7 @@ def parse_args():
                 "-b",
                 "--backend",
             ],
-            "choices": ["dask", "explicit-comms"],
+            "choices": ["dask", "explicit-comms", "dask-noop"],
             "default": "dask",
             "type": str,
             "help": "The backend to use.",

--- a/dask_cuda/benchmarks/local_cudf_shuffle.py
+++ b/dask_cuda/benchmarks/local_cudf_shuffle.py
@@ -13,6 +13,7 @@ from dask.utils import format_bytes, parse_bytes
 import dask_cuda.explicit_comms.dataframe.shuffle
 from dask_cuda.benchmarks.common import Config, execute_benchmark
 from dask_cuda.benchmarks.utils import (
+    as_noop,
     parse_benchmark_args,
     print_key_value,
     print_separator,
@@ -23,12 +24,6 @@ from dask_cuda.benchmarks.utils import (
 def shuffle_dask(df, *, noop=False):
     result = shuffle(df, index="data", shuffle="tasks")
     if noop:
-        try:
-            from dask_noop import as_noop
-        except ImportError:
-            raise RuntimeError(
-                "Requested noop computation but dask-noop not installed."
-            )
         result = as_noop(result)
     t1 = perf_counter()
     wait(result.persist())

--- a/dask_cuda/benchmarks/local_cupy.py
+++ b/dask_cuda/benchmarks/local_cupy.py
@@ -12,6 +12,7 @@ from dask.utils import format_bytes, parse_bytes
 
 from dask_cuda.benchmarks.common import Config, execute_benchmark
 from dask_cuda.benchmarks.utils import (
+    as_noop,
     parse_benchmark_args,
     print_key_value,
     print_separator,
@@ -150,12 +151,6 @@ def bench_once(client, args, write_profile=None):
         rng = start_range(message=args.operation, color="purple")
         result = func(*func_args)
         if args.backend == "dask-noop":
-            try:
-                from dask_noop import as_noop
-            except ImportError:
-                raise RuntimeError(
-                    "Requested noop computation but dask-noop not installed."
-                )
             result = as_noop(result)
         t1 = clock()
         wait(client.persist(result))

--- a/dask_cuda/benchmarks/local_cupy_map_overlap.py
+++ b/dask_cuda/benchmarks/local_cupy_map_overlap.py
@@ -14,6 +14,7 @@ from dask.utils import format_bytes, parse_bytes
 
 from dask_cuda.benchmarks.common import Config, execute_benchmark
 from dask_cuda.benchmarks.utils import (
+    as_noop,
     parse_benchmark_args,
     print_key_value,
     print_separator,
@@ -50,12 +51,6 @@ def bench_once(client, args, write_profile=None):
     with ctx:
         result = x.map_overlap(mean_filter, args.kernel_size, shape=ks)
         if args.backend == "dask-noop":
-            try:
-                from dask_noop import as_noop
-            except ImportError:
-                raise RuntimeError(
-                    "Requested noop computation but dask-noop not installed."
-                )
             result = as_noop(result)
         t1 = clock()
         wait(client.persist(result))

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -18,6 +18,35 @@ from distributed.comm.addressing import get_address_host
 from dask_cuda.local_cuda_cluster import LocalCUDACluster
 
 
+def as_noop(dsk):
+    """
+    Turn the given dask computation into a noop.
+
+    Uses dask-noop (https://github.com/gjoseph92/dask-noop/)
+
+    Parameters
+    ----------
+    dsk
+        Dask object (on which one could call compute)
+
+    Returns
+    -------
+    New dask object representing the same task graph with no
+    computation/data attached.
+
+    Raises
+    ------
+    RuntimeError
+        If dask_noop is not importable
+    """
+    try:
+        from dask_noop import as_noop
+
+        return as_noop(dsk)
+    except ImportError:
+        raise RuntimeError("Requested noop computation but dask-noop not installed.")
+
+
 def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]):
     parser = argparse.ArgumentParser(description=description)
     worker_args = parser.add_argument_group(description="Worker configuration")

--- a/dask_cuda/explicit_comms/dataframe/shuffle.py
+++ b/dask_cuda/explicit_comms/dataframe/shuffle.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import functools
 import inspect
@@ -204,7 +206,7 @@ async def local_shuffle(
 
 def shuffle(
     df: DataFrame,
-    column_names: List[str],
+    column_names: str | List[str],
     npartitions: Optional[int] = None,
     ignore_index: bool = False,
 ) -> DataFrame:


### PR DESCRIPTION
To add some metrics on distributed overheads to our benchmark suite, I propose using https://github.com/gjoseph92/dask-noop/ to rewrite the compute graphs into no-ops. Now we just measure the scheduler and worker-to-worker performance on zero-sized work (or something close thereto).

Interestingly the cupy-based transpose runs take _longer_ if I noopify (cc @gjoseph92 any insight here?), but I haven't done anything systematic yet.