### PR TITLE
[REVIEW] Pin `dask` and `distributed` for release

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -51,10 +51,8 @@ conda activate rapids
 if [ "$SOURCE_BRANCH" = "main" ]; then
   conda config --system --remove channels rapidsai-nightly
   conda config --system --remove channels dask/label/dev
-fi
-
+elif [[ "${INSTALL_DASK_MAIN}" == 0 ]]; then
 # Remove `dask/label/dev` channel if INSTALL_DASK_MAIN=0
-if [[ "${INSTALL_DASK_MAIN}" == 0 ]]; then
   conda config --system --remove channels dask/label/dev
 fi
 

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -43,9 +43,10 @@ gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids
 
-# Remove rapidsai-nightly channel if we are building main branch
+# Remove `rapidsai-nightly` & `dask/label/dev` channel if we are building main branch
 if [ "$SOURCE_BRANCH" = "main" ]; then
   conda config --system --remove channels rapidsai-nightly
+  conda config --system --remove channels dask/label/dev
 fi
 
 gpuci_logger "Check compiler versions"
@@ -61,8 +62,8 @@ conda list --show-channel-urls
 # FIX Added to deal with Anancoda SSL verification issues during conda builds
 conda config --set ssl_verify False
 
-pip install git+https://github.com/dask/dask.git@main
-pip install git+https://github.com/dask/distributed.git@main
+pip install git+https://github.com/dask/dask.git@2022.9.1
+pip install git+https://github.com/dask/distributed.git@2022.9.1
 
 ################################################################################
 # BUILD - Package builds

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -53,6 +53,11 @@ if [ "$SOURCE_BRANCH" = "main" ]; then
   conda config --system --remove channels dask/label/dev
 fi
 
+# Remove `dask/label/dev` channel if INSTALL_DASK_MAIN=0
+if [[ "${INSTALL_DASK_MAIN}" == 0 ]]; then
+  conda config --system --remove channels dask/label/dev
+fi
+
 gpuci_logger "Check compiler versions"
 python --version
 $CC --version

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -19,6 +19,10 @@ export CUDA_REL=${CUDA_VERSION%.*}
 export GPUCI_CONDA_RETRY_MAX=1
 export GPUCI_CONDA_RETRY_SLEEP=30
 
+# Whethere to keep `dask/label/dev` channel in the env. If INSTALL_DASK_MAIN=0,
+# `dask/label/dev` channel is removed.
+export INSTALL_DASK_MAIN=0
+
 # Switch to project root; also root of repo checkout
 cd "$WORKSPACE"
 

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -71,8 +71,8 @@ conda list --show-channel-urls
 # FIX Added to deal with Anancoda SSL verification issues during conda builds
 conda config --set ssl_verify False
 
-pip install git+https://github.com/dask/dask.git@2022.9.1
-pip install git+https://github.com/dask/distributed.git@2022.9.1
+pip install git+https://github.com/dask/dask.git@2022.9.2
+pip install git+https://github.com/dask/distributed.git@2022.9.2
 
 ################################################################################
 # BUILD - Package builds

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -19,7 +19,7 @@ export CUDA_REL=${CUDA_VERSION%.*}
 export GPUCI_CONDA_RETRY_MAX=1
 export GPUCI_CONDA_RETRY_SLEEP=30
 
-# Whethere to keep `dask/label/dev` channel in the env. If INSTALL_DASK_MAIN=0,
+# Whether to keep `dask/label/dev` channel in the env. If INSTALL_DASK_MAIN=0,
 # `dask/label/dev` channel is removed.
 export INSTALL_DASK_MAIN=0
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -38,7 +38,7 @@ export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1
 export INSTALL_DASK_MAIN=0
 
 # Dask version to install when `INSTALL_DASK_MAIN=0`
-export DASK_STABLE_VERSION="2022.9.1"
+export DASK_STABLE_VERSION="2022.9.2"
 
 ################################################################################
 # SETUP - Check environment

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -77,6 +77,7 @@ if [[ "${INSTALL_DASK_MAIN}" == 1 ]]; then
 else
   gpuci_logger "gpuci_mamba_retry install conda-forge::dask==${DASK_STABLE_VERSION} conda-forge::distributed==${DASK_STABLE_VERSION} conda-forge::dask-core==${DASK_STABLE_VERSION} --force-reinstall"
   gpuci_mamba_retry install conda-forge::dask==${DASK_STABLE_VERSION} conda-forge::distributed==${DASK_STABLE_VERSION} conda-forge::dask-core==${DASK_STABLE_VERSION} --force-reinstall
+  conda config --system --remove channels dask/label/dev
 fi
 
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -35,10 +35,10 @@ export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1
 
 # Install dask and distributed from main branch. Usually needed during
 # development time and disabled before a new dask-cuda release.
-export INSTALL_DASK_MAIN=1
+export INSTALL_DASK_MAIN=0
 
 # Dask version to install when `INSTALL_DASK_MAIN=0`
-export DASK_STABLE_VERSION="2022.7.1"
+export DASK_STABLE_VERSION="2022.9.1"
 
 ################################################################################
 # SETUP - Check environment

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-dask>=2022.7.1
-distributed>=2022.7.1
+dask==2022.9.1
+distributed==2022.9.1
 pynvml>=11.0.0
 numpy>=1.16.0
 numba>=0.54

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-dask==2022.9.1
-distributed==2022.9.1
+dask==2022.9.2
+distributed==2022.9.2
 pynvml>=11.0.0
 numpy>=1.16.0
 numba>=0.54


### PR DESCRIPTION
This PR pins `dask` and `distributed` to `2022.9.2` for `22.10` release.


xref: https://github.com/rapidsai/cudf/pull/11822