### PR TITLE
Add feature to get cluster configuration

### DIFF
--- a/dask_cuda/cli/dask_config.py
+++ b/dask_cuda/cli/dask_config.py
@@ -93,9 +93,5 @@ def main(
         sys.exit(0)
 
 
-def go():
-    main()
-
-
 if __name__ == "__main__":
-    go()
+    main()

--- a/dask_cuda/cli/dask_config.py
+++ b/dask_cuda/cli/dask_config.py
@@ -90,7 +90,6 @@ def main(
         else:
             client = Client(scheduler, security=security)
         print_cluster_config(client)
-        sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/dask_cuda/cli/dask_config.py
+++ b/dask_cuda/cli/dask_config.py
@@ -1,0 +1,101 @@
+from __future__ import absolute_import, division, print_function
+
+import logging
+import sys
+
+import click
+
+from distributed import Client
+from distributed.preloading import validate_preload_argv
+from distributed.security import Security
+
+from ..utils import print_cluster_config
+
+logger = logging.getLogger(__name__)
+
+
+pem_file_option_type = click.Path(exists=True, resolve_path=True)
+
+
+@click.command(context_settings=dict(ignore_unknown_options=True))
+@click.argument("scheduler", type=str, required=False)
+@click.argument(
+    "preload_argv", nargs=-1, type=click.UNPROCESSED, callback=validate_preload_argv
+)
+@click.option(
+    "--scheduler-file",
+    type=str,
+    default=None,
+    help="""Filename to JSON encoded scheduler information. To be used in conjunction
+    with the equivalent ``dask-scheduler`` option.""",
+)
+@click.option(
+    "--get-cluster-configuration",
+    "get_cluster_conf",
+    default=False,
+    is_flag=True,
+    required=False,
+    show_default=True,
+    help="""Print a table of the current cluster configuration""",
+)
+@click.option(
+    "--tls-ca-file",
+    type=pem_file_option_type,
+    default=None,
+    help="""CA certificate(s) file for TLS (in PEM format). Can be a string (like
+    ``"path/to/certs"``), or ``None`` for no certificate(s).""",
+)
+@click.option(
+    "--tls-cert",
+    type=pem_file_option_type,
+    default=None,
+    help="""Certificate file for TLS (in PEM format). Can be a string (like
+    ``"path/to/certs"``), or ``None`` for no certificate(s).""",
+)
+@click.option(
+    "--tls-key",
+    type=pem_file_option_type,
+    default=None,
+    help="""Private key file for TLS (in PEM format). Can be a string (like
+    ``"path/to/certs"``), or ``None`` for no private key.""",
+)
+def main(
+    scheduler,
+    scheduler_file,
+    get_cluster_conf,
+    tls_ca_file,
+    tls_cert,
+    tls_key,
+    **kwargs,
+):
+    if tls_ca_file and tls_cert and tls_key:
+        security = Security(
+            tls_ca_file=tls_ca_file,
+            tls_worker_cert=tls_cert,
+            tls_worker_key=tls_key,
+        )
+    else:
+        security = None
+
+    if isinstance(scheduler, str) and scheduler.startswith("-"):
+        raise ValueError(
+            "The scheduler address can't start with '-'. Please check "
+            "your command line arguments, you probably attempted to use "
+            "unsupported one. Scheduler address: %s" % scheduler
+        )
+
+    if get_cluster_conf:
+        if scheduler_file is not None:
+            client = Client(scheduler_file=scheduler_file, security=security)
+        else:
+            client = Client(scheduler, security=security)
+        print_cluster_config(client)
+        sys.exit(0)
+
+
+def go():
+    main()
+
+
+if __name__ == "__main__":
+    go()

--- a/dask_cuda/cli/dask_config.py
+++ b/dask_cuda/cli/dask_config.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
-import sys
 
 import click
 

--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -179,7 +179,7 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 @click.option(
     "--scheduler-file",
     type=str,
-    default="",
+    default=None,
     help="""Filename to JSON encoded scheduler information. To be used in conjunction
     with the equivalent ``dask-scheduler`` option.""",
 )
@@ -336,11 +336,6 @@ def main(
     get_cluster_conf,
     **kwargs,
 ):
-    if get_cluster_conf:
-        client = Client(scheduler)
-        print_cluster_config(client)
-        sys.exit(0)
-
     if multiprocessing_method == "forkserver":
         import multiprocessing.forkserver as f
 
@@ -360,6 +355,14 @@ def main(
             "your command line arguments, you probably attempted to use "
             "unsupported one. Scheduler address: %s" % scheduler
         )
+
+    if get_cluster_conf:
+        if scheduler_file is not None:
+            client = Client(scheduler_file=scheduler_file, security=security)
+        else:
+            client = Client(scheduler, security=security)
+        print_cluster_config(client)
+        sys.exit(0)
 
     if worker_class is not None:
         worker_class = import_term(worker_class)

--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -14,7 +14,7 @@ from distributed.security import Security
 from distributed.utils import import_term
 
 from ..cuda_worker import CUDAWorker
-from ..utils import get_cluster_configuration
+from ..utils import print_cluster_config
 
 logger = logging.getLogger(__name__)
 
@@ -338,7 +338,7 @@ def main(
 ):
     if get_cluster_conf:
         client = Client(scheduler)
-        get_cluster_configuration(client, table=True)
+        print_cluster_config(client)
         sys.exit(0)
 
     if multiprocessing_method == "forkserver":

--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -1,20 +1,17 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
-import sys
 
 import click
 from tornado.ioloop import IOLoop, TimeoutError
 
 from dask import config
-from distributed import Client
 from distributed.cli.utils import install_signal_handlers
 from distributed.preloading import validate_preload_argv
 from distributed.security import Security
 from distributed.utils import import_term
 
 from ..cuda_worker import CUDAWorker
-from ..utils import print_cluster_config
 
 logger = logging.getLogger(__name__)
 
@@ -290,15 +287,6 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     type=click.Choice(["spawn", "fork", "forkserver"]),
     help="""Method used to start new processes with multiprocessing""",
 )
-@click.option(
-    "--get-cluster-configuration",
-    "get_cluster_conf",
-    default=False,
-    is_flag=True,
-    required=False,
-    show_default=True,
-    help="""Print a table of the current cluster configuration""",
-)
 def main(
     scheduler,
     host,
@@ -333,7 +321,6 @@ def main(
     worker_class,
     pre_import,
     multiprocessing_method,
-    get_cluster_conf,
     **kwargs,
 ):
     if multiprocessing_method == "forkserver":
@@ -355,14 +342,6 @@ def main(
             "your command line arguments, you probably attempted to use "
             "unsupported one. Scheduler address: %s" % scheduler
         )
-
-    if get_cluster_conf:
-        if scheduler_file is not None:
-            client = Client(scheduler_file=scheduler_file, security=security)
-        else:
-            client = Client(scheduler, security=security)
-        print_cluster_config(client)
-        sys.exit(0)
 
     if worker_class is not None:
         worker_class = import_term(worker_class)

--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -180,8 +180,6 @@ class DeviceHostFile(ZictBase):
         local_directory=None,
         log_spilling=False,
     ):
-        # can now access value within dask-worker / client.run
-        self.device_memory_limit = device_memory_limit
         self.disk_func_path = os.path.join(
             local_directory or dask.config.get("temporary-directory") or os.getcwd(),
             "dask-worker-space",

--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -180,6 +180,8 @@ class DeviceHostFile(ZictBase):
         local_directory=None,
         log_spilling=False,
     ):
+        # can now access value within dask-worker / client.run
+        self.device_memory_limit = device_memory_limit
         self.disk_func_path = os.path.join(
             local_directory or dask.config.get("temporary-directory") or os.getcwd(),
             "dask-worker-space",

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -385,7 +385,7 @@ async def test_get_cluster_configuration():
     ) as cluster:
         async with Client(cluster, asynchronous=True) as client:
             ret = await get_cluster_configuration(client)
-            assert ret["RMMSetup"]["initial_pool_size"] == 2000000000
+            assert ret["[plugin] RMMSetup"]["initial_pool_size"] == 2000000000
             assert ret["jit-unspill"] is False
             assert ret["device-memory-limit"] == 30
 
@@ -400,3 +400,4 @@ def test_print_cluster_config(capsys):
             assert "Dask Cluster Configuration" in captured.out
             assert "ucx" in captured.out
             assert "1 B" in captured.out
+            assert "[plugin]" in captured.out

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -385,7 +385,7 @@ async def test_get_cluster_configuration():
     ) as cluster:
         async with Client(cluster, asynchronous=True) as client:
             ret = await get_cluster_configuration(client)
-            assert ret["RMMSetup.initial_pool_size"] == 2000000000
+            assert ret["RMMSetup"]["initial_pool_size"] == 2000000000
             assert ret["jit-unspill"] is False
             assert ret["device-memory-limit"] == 30
 

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -355,7 +355,10 @@ async def test_gpu_uuid():
 async def test_rmm_track_allocations():
     rmm = pytest.importorskip("rmm")
     async with LocalCUDACluster(
-        rmm_pool_size="2GB", asynchronous=True, rmm_track_allocations=True
+        rmm_pool_size="2GB",
+        asynchronous=True,
+        rmm_track_allocations=True,
+        device_memory_limit="30B",
     ) as cluster:
         async with Client(cluster, asynchronous=True) as client:
             memory_resource_type = await client.run(
@@ -375,6 +378,7 @@ async def test_rmm_track_allocations():
 async def test_get_cluster_configuration():
     async with LocalCUDACluster(
         rmm_pool_size="2GB",
+        device_memory_limit="30B",
         CUDA_VISIBLE_DEVICES="0",
         scheduler_port=0,
         asynchronous=True,
@@ -382,6 +386,8 @@ async def test_get_cluster_configuration():
         async with Client(cluster, asynchronous=True) as client:
             ret = await get_cluster_configuration(client)
             assert ret["initial_pool_size"] == 2000000000
+            assert ret["jit-unspill"] is False
+            assert ret["device-memory-limit"] == 30
 
 
 def test_get_cluster_config_sync(capsys):
@@ -390,6 +396,6 @@ def test_get_cluster_config_sync(capsys):
     ) as cluster:
         with Client(cluster) as client:
             get_cluster_configuration(client, table=True)
-            captured = capsys.readouterr()
-            assert "Dask Cluster Configuration" in captured.out
-            assert "ucx" in captured.out
+            # captured = capsys.readouterr()
+            # assert "Dask Cluster Configuration" in captured.out
+            # assert "ucx" in captured.out

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -1,6 +1,7 @@
 import importlib
 import math
 import os
+import sys
 import time
 import warnings
 from contextlib import suppress
@@ -735,8 +736,15 @@ def get_cluster_configuration(client, table=False):
     if not table:
         return ret
     else:
-        from rich.console import Console
-        from rich.table import Table
+        try:
+            from rich.console import Console
+            from rich.table import Table
+        except ImportError:
+            print(
+                "Please install rich `python -m pip install rich`"
+                / "to print a table of the current Dask Cluster Configuration"
+            )
+            sys.exit(1)
 
         table = Table(title="Dask Cluster Configuration")
         table.add_column("Parameter", justify="left", style="red")

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -753,5 +753,4 @@ def get_cluster_configuration(client, table=False):
         params = sorted(ret.keys())
         for p in params:
             table.add_row(p, str(ret[p]))
-        console = Console()
-        console.print(table)
+        Console().print(table)

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -743,7 +743,8 @@ def pretty_print(obj, toplevel):
 
 @pretty_print.register(str)
 def pretty_print_str(obj, toplevel):
-    return obj
+    from rich.markup import escape
+    return escape(obj)
 
 
 @pretty_print.register(dict)

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -744,6 +744,7 @@ def pretty_print(obj, toplevel):
 @pretty_print.register(str)
 def pretty_print_str(obj, toplevel):
     from rich.markup import escape
+
     return escape(obj)
 
 

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -769,7 +769,7 @@ def pretty_print_dict(obj, toplevel):
             v = format_bytes(v)
         # need to escape tags: []
         # https://rich.readthedocs.io/en/stable/markup.html?highlight=escape#escaping
-        t.add_row(escape(pretty_print(k, False)), pretty_print(v, False))
+        t.add_row(pretty_print(k, False), pretty_print(v, False))
     return t
 
 

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -749,7 +749,6 @@ def pretty_print_str(obj, toplevel):
 
 @pretty_print.register(dict)
 def pretty_print_dict(obj, toplevel):
-    from rich.markup import escape
     from rich.table import Table
 
     if not obj:

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -698,7 +698,6 @@ def get_worker_config(dask_worker):
 
     # comm timeouts
     ret["distributed.comm.timeouts"] = dask.config.get("distributed.comm.timeouts")
-    # ret.update(plugin_config)
 
     return ret
 

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -663,7 +663,7 @@ def get_worker_config(dask_worker):
 
     # device and host memory configuration
     for p in plugin_vals:
-        ret[type(p).__name__] = {
+        ret[f"[plugin] {type(p).__name__}"] = {
             v: getattr(p, v)
             for v in dir(p)
             if not (v.startswith("_") or v in {"setup", "cores"})
@@ -749,6 +749,7 @@ def pretty_print_str(obj, toplevel):
 
 @pretty_print.register(dict)
 def pretty_print_dict(obj, toplevel):
+    from rich.markup import escape
     from rich.table import Table
 
     if not obj:
@@ -767,7 +768,9 @@ def pretty_print_dict(obj, toplevel):
     for k, v in sorted(obj.items(), key=operator.itemgetter(0)):
         if k in formatted_byte_keys and v is not None:
             v = format_bytes(v)
-        t.add_row(pretty_print(k, False), pretty_print(v, False))
+        # need to escape tags: []
+        # https://rich.readthedocs.io/en/stable/markup.html?highlight=escape#escaping
+        t.add_row(escape(pretty_print(k, False)), pretty_print(v, False))
     return t
 
 

--- a/setup.py
+++ b/setup.py
@@ -58,5 +58,6 @@ setup(
     entry_points="""
         [console_scripts]
         dask-cuda-worker=dask_cuda.cli.dask_cuda_worker:go
+        dask-config=dask_cuda.cli.dask_config:go
       """,
 )


### PR DESCRIPTION
Early attempt at resolving https://github.com/rapidsai/dask-cuda/issues/989

<img width="1374" alt="Screen Shot 2022-10-04 at 6 37 20 PM" src="https://user-images.githubusercontent.com/1403768/193943590-5ac4e20a-4dbc-46ec-aefa-3f74ce7c6d17.png">

In an ideal world, we could call `dask.config.config` or `dask.config.get(...)` and that will have been updated with live values.   Unfortunately, that is not the case.  Config options are set in all manner of places: cli, env, yaml, kwargs, etc and we are not consistent about storing them.  For example, in this PR `self.device_memory_limit = device_memory_limit` is added to `device_host_file.py` just so `client.run` could be accessed from within the worker.

This change employs a hodge-podge of techniques to get at options we _think_ may be potentially useful for debugging but in no way is this exhaustive.