### PR TITLE
[skip gpuci] Create pure-wheel workflow for dask-cuda

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,19 @@
+name: dask-cuda wheels
+
+on: pull_request
+
+jobs:
+  dask_cuda-wheels:
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-pure.yml@feat/wheel-ci-actions-2
+    with:
+      package-name: dask_cuda
+      package-dir: .
+      python-package-cuda-suffix: ""
+      python-package-versioneer-override: "22.10.0"
+      python-package-build-tag: ""
+
+      test-before: "" # pip install rmm-cu11 cudf-cu11 --index-url https://pypi.k8s.rapids.ai/simple"
+      test-extras:  "test"
+      test-unittest: "pytest -v ./python/dask_cudf/dask_cudf/tests"
+      test-smoketest: "import dask_cudf; print(dask_cudf)"
+    secrets: inherit

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ if "GIT_DESCRIBE_TAG" in os.environ:
 
 setup(
     name="dask-cuda",
-    version=versioneer.get_version(),
+    version=os.getenv("RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE", default=versioneer.get_version()),
     cmdclass=versioneer.get_cmdclass(),
     description="Utilities for Dask and CUDA interactions",
     long_description=long_description,


### PR DESCRIPTION
This adds dask-cuda to our internal pypi index to help smooth over different release timelines for CI.