### PR TITLE
Allow specifying fractions as RMM pool initial/maximum size

### DIFF
--- a/dask_cuda/cli/dask_cuda_worker.py
+++ b/dask_cuda/cli/dask_cuda_worker.py
@@ -67,7 +67,8 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     "--rmm-pool-size",
     default=None,
     help="""RMM pool size to initialize each worker with. Can be an integer (bytes),
-    string (like ``"5GB"`` or ``"5000M"``), or ``None`` to disable RMM pools.
+    float (fraction of total device memory), string (like ``"5GB"`` or ``"5000M"``), or
+    ``None`` to disable RMM pools.
 
     .. note::
         This size is a per-worker configuration, and not cluster-wide.""",
@@ -75,14 +76,14 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 @click.option(
     "--rmm-maximum-pool-size",
     default=None,
-    help="""When ``--rmm-pool-size`` is specified, this argument indicates the maximum pool size.
-        Can be an integer (bytes), string (like ``"5GB"`` or ``"5000M"``) or ``None``.
-        By default, the total available memory on the GPU is used.
-        ``rmm_pool_size`` must be specified to use RMM pool and
-        to set the maximum pool size.
+    help="""When ``--rmm-pool-size`` is specified, this argument indicates the maximum
+    pool size.  Can be an integer (bytes), float (fraction of total device memory),
+    string (like ``"5GB"`` or ``"5000M"``) or ``None``. By default, the total available
+    memory on the GPU is used. ``rmm_pool_size`` must be specified to use RMM pool and
+    to set the maximum pool size.
 
-        .. note::
-            This size is a per-worker configuration, and not cluster-wide.""",
+    .. note::
+        This size is a per-worker configuration, and not cluster-wide.""",
 )
 @click.option(
     "--rmm-managed-memory/--no-rmm-managed-memory",

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -8,7 +8,6 @@ import warnings
 from toolz import valmap
 
 import dask
-from dask.utils import parse_bytes
 from distributed import Nanny
 from distributed.core import Server
 from distributed.deploy.cluster import Cluster
@@ -139,10 +138,6 @@ class CUDAWorker(Server):
                     "RMM pool and managed memory are incompatible with asynchronous "
                     "allocator"
                 )
-            if rmm_pool_size is not None:
-                rmm_pool_size = parse_bytes(rmm_pool_size)
-                if rmm_maximum_pool_size is not None:
-                    rmm_maximum_pool_size = parse_bytes(rmm_maximum_pool_size)
 
         else:
             if enable_nvlink:

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -3,7 +3,6 @@ import os
 import warnings
 
 import dask
-from dask.utils import parse_bytes
 from distributed import LocalCluster, Nanny, Worker
 from distributed.worker_memory import parse_memory_limit
 
@@ -100,18 +99,19 @@ class LocalCUDACluster(LocalCluster):
         Set environment variables to enable UCX RDMA connection manager support,
         requires ``protocol="ucx"`` and ``enable_infiniband=True``.
     rmm_pool_size : int, str or None, default None
-        RMM pool size to initialize each worker with. Can be an integer (bytes), string
-        (like ``"5GB"`` or ``"5000M"``), or ``None`` to disable RMM pools.
+        RMM pool size to initialize each worker with. Can be an integer (bytes), float
+        (fraction of total device memory), string (like ``"5GB"`` or ``"5000M"``), or
+        ``None`` to disable RMM pools.
 
         .. note::
             This size is a per-worker configuration, and not cluster-wide.
     rmm_maximum_pool_size : int, str or None, default None
         When ``rmm_pool_size`` is set, this argument indicates
         the maximum pool size.
-        Can be an integer (bytes), string (like ``"5GB"`` or ``"5000M"``) or ``None``.
-        By default, the total available memory on the GPU is used.
-        ``rmm_pool_size`` must be specified to use RMM pool and
-        to set the maximum pool size.
+        Can be an integer (bytes), float (fraction of total device memory), string
+        (like ``"5GB"`` or ``"5000M"``) or ``None``. By default, the total available
+        memory on the GPU is used. ``rmm_pool_size`` must be specified to use RMM pool
+        and to set the maximum pool size.
 
         .. note::
             This size is a per-worker configuration, and not cluster-wide.
@@ -256,10 +256,6 @@ class LocalCUDACluster(LocalCluster):
                     "RMM pool and managed memory are incompatible with asynchronous "
                     "allocator"
                 )
-            if self.rmm_pool_size is not None:
-                self.rmm_pool_size = parse_bytes(self.rmm_pool_size)
-                if self.rmm_maximum_pool_size is not None:
-                    self.rmm_maximum_pool_size = parse_bytes(self.rmm_maximum_pool_size)
         else:
             if enable_nvlink:
                 warnings.warn(

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -13,6 +13,8 @@ from distributed.system import MEMORY_LIMIT
 from distributed.utils_test import cleanup, loop, loop_in_thread, popen  # noqa: F401
 
 from dask_cuda.utils import (
+    get_cluster_configuration,
+    get_device_total_memory,
     get_gpu_count_mig,
     get_gpu_uuid_from_index,
     get_n_gpus,
@@ -323,3 +325,75 @@ def test_rmm_track_allocations(loop):  # noqa: F811
                 )
                 for v in memory_resource_upstream_type.values():
                     assert v is rmm.mr.PoolMemoryResource
+
+
+@patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0"})
+def test_get_cluster_configuration(loop):  # noqa: F811
+    pytest.importorskip("rmm")
+    with popen(["dask-scheduler", "--port", "9369", "--no-dashboard"]):
+        with popen(
+            [
+                "dask-cuda-worker",
+                "127.0.0.1:9369",
+                "--host",
+                "127.0.0.1",
+                "--device-memory-limit",
+                "30 B",
+                "--rmm-pool-size",
+                "2 GB",
+                "--rmm-maximum-pool-size",
+                "3 GB",
+                "--no-dashboard",
+                "--rmm-track-allocations",
+            ]
+        ):
+            with Client("127.0.0.1:9369", loop=loop) as client:
+                assert wait_workers(client, n_gpus=get_n_gpus())
+
+                ret = get_cluster_configuration(client)
+                wait(ret)
+                assert ret["[plugin] RMMSetup"]["initial_pool_size"] == 2000000000
+                assert ret["[plugin] RMMSetup"]["maximum_pool_size"] == 3000000000
+                assert ret["jit-unspill"] is False
+                assert ret["device-memory-limit"] == 30
+
+
+@patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0"})
+def test_worker_fraction_limits(loop):  # noqa: F811
+    pytest.importorskip("rmm")
+    with popen(["dask-scheduler", "--port", "9369", "--no-dashboard"]):
+        with popen(
+            [
+                "dask-cuda-worker",
+                "127.0.0.1:9369",
+                "--host",
+                "127.0.0.1",
+                "--device-memory-limit",
+                "0.1",
+                "--rmm-pool-size",
+                "0.2",
+                "--rmm-maximum-pool-size",
+                "0.3",
+                "--no-dashboard",
+                "--rmm-track-allocations",
+            ]
+        ):
+            with Client("127.0.0.1:9369", loop=loop) as client:
+                assert wait_workers(client, n_gpus=get_n_gpus())
+
+                device_total_memory = client.run(get_device_total_memory)
+                wait(device_total_memory)
+                _, device_total_memory = device_total_memory.popitem()
+
+                ret = get_cluster_configuration(client)
+                wait(ret)
+
+                assert ret["device-memory-limit"] == int(device_total_memory * 0.1)
+                assert (
+                    ret["[plugin] RMMSetup"]["initial_pool_size"]
+                    == (device_total_memory * 0.2) // 256 * 256
+                )
+                assert (
+                    ret["[plugin] RMMSetup"]["maximum_pool_size"]
+                    == (device_total_memory * 0.3) // 256 * 256
+                )

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -419,6 +419,7 @@ async def test_worker_fraction_limits():
 
 
 def test_print_cluster_config(capsys):
+    pytest.importorskip("rich")
     with LocalCUDACluster(
         n_workers=1, device_memory_limit="1B", jit_unspill=True, protocol="ucx"
     ) as cluster:

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -15,6 +15,7 @@ from dask_cuda.initialize import initialize
 from dask_cuda.utils import (
     MockWorker,
     get_cluster_configuration,
+    get_device_total_memory,
     get_gpu_count_mig,
     get_gpu_uuid_from_index,
     print_cluster_config,
@@ -378,6 +379,7 @@ async def test_rmm_track_allocations():
 async def test_get_cluster_configuration():
     async with LocalCUDACluster(
         rmm_pool_size="2GB",
+        rmm_maximum_pool_size="3GB",
         device_memory_limit="30B",
         CUDA_VISIBLE_DEVICES="0",
         scheduler_port=0,
@@ -386,8 +388,34 @@ async def test_get_cluster_configuration():
         async with Client(cluster, asynchronous=True) as client:
             ret = await get_cluster_configuration(client)
             assert ret["[plugin] RMMSetup"]["initial_pool_size"] == 2000000000
+            assert ret["[plugin] RMMSetup"]["maximum_pool_size"] == 3000000000
             assert ret["jit-unspill"] is False
             assert ret["device-memory-limit"] == 30
+
+
+@gen_test(timeout=20)
+async def test_worker_fraction_limits():
+    async with LocalCUDACluster(
+        device_memory_limit=0.1,
+        rmm_pool_size=0.2,
+        rmm_maximum_pool_size=0.3,
+        CUDA_VISIBLE_DEVICES="0",
+        scheduler_port=0,
+        asynchronous=True,
+    ) as cluster:
+        async with Client(cluster, asynchronous=True) as client:
+            device_total_memory = await client.run(get_device_total_memory)
+            _, device_total_memory = device_total_memory.popitem()
+            ret = await get_cluster_configuration(client)
+            assert ret["device-memory-limit"] == int(device_total_memory * 0.1)
+            assert (
+                ret["[plugin] RMMSetup"]["initial_pool_size"]
+                == (device_total_memory * 0.2) // 256 * 256
+            )
+            assert (
+                ret["[plugin] RMMSetup"]["maximum_pool_size"]
+                == (device_total_memory * 0.3) // 256 * 256
+            )
 
 
 def test_print_cluster_config(capsys):

--- a/dask_cuda/tests/test_utils.py
+++ b/dask_cuda/tests/test_utils.py
@@ -225,6 +225,9 @@ def test_parse_device_memory_limit():
     assert parse_device_memory_limit("auto") == total
 
     assert parse_device_memory_limit(0.8) == int(total * 0.8)
+    assert parse_device_memory_limit(0.8, alignment_size=256) == int(
+        total * 0.8 // 256 * 256
+    )
     assert parse_device_memory_limit(1000000000) == 1000000000
     assert parse_device_memory_limit("1GB") == 1000000000
 

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -614,7 +614,7 @@ def parse_device_memory_limit(device_memory_limit, device_index=0, alignment_siz
     def _align(size, alignment_size):
         return size // alignment_size * alignment_size
 
-    if any(device_memory_limit == v for v in [0, "0", None, "auto"]):
+    if device_memory_limit in {0, "0", None, "auto"}:
         return _align(get_device_total_memory(device_index), alignment_size)
 
     with suppress(ValueError, TypeError):


### PR DESCRIPTION
This is already supported by `memory_limit`/`device_memory_limit`, and this has been raised in https://github.com/rapidsai/dask-cuda/issues/1020 during discussions on how to make Dask Profiles usable in Dask-CUDA.