### PR TITLE
Make local_directory a required argument for spilling impls

### DIFF
--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -175,7 +175,6 @@ class CUDAWorker(Server):
                         device_memory_limit, device_index=i
                     ),
                     "memory_limit": memory_limit,
-                    "local_directory": local_directory,
                     "shared_filesystem": shared_filesystem,
                 },
             )
@@ -187,7 +186,6 @@ class CUDAWorker(Server):
                         device_memory_limit, device_index=i
                     ),
                     "memory_limit": memory_limit,
-                    "local_directory": local_directory,
                 },
             )
 

--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -1,6 +1,7 @@
 import functools
 import logging
 import os
+import sys
 import time
 
 import numpy
@@ -233,6 +234,34 @@ class DeviceHostFile(ZictBase):
 
         # For Worker compatibility only, where `fast` is host memory buffer
         self.fast = self.host_buffer if memory_limit is None else self.host_buffer.fast
+
+    if sys.version_info > (3, 8):
+
+        def __new__(
+            cls,
+            # So named such that dask will pass in the worker's local
+            # directory when constructing this through the "data" callback.
+            worker_local_directory,
+            *,
+            device_memory_limit=None,
+            memory_limit=None,
+            log_spilling=False,
+        ):
+            """
+            This is here to support Python 3.8. Right now (to support
+            3.8), ZictBase inherits from typing.MutableMapping through
+            which inspect.signature determines that the signature of
+            __init__ is just (*args, **kwargs). We need to advertise the
+            correct signature so that distributed will correctly figure
+            out that it needs to pass the worker's local directory. In
+            Python 3.9 and later, typing.MutableMapping is just an alias
+            for collections.abc.MutableMapping and we don't need to do
+            anything.
+
+            With this pass-through definition of __new__, the
+            signature of the constructor is correctly determined.
+            """
+            return super().__new__(cls)
 
     def __setitem__(self, key, value):
         if key in self.device_buffer:

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -289,7 +289,6 @@ class LocalCUDACluster(LocalCluster):
                     {
                         "device_memory_limit": self.device_memory_limit,
                         "memory_limit": self.memory_limit,
-                        "local_directory": local_directory,
                         "shared_filesystem": shared_filesystem,
                     },
                 )
@@ -299,7 +298,6 @@ class LocalCUDACluster(LocalCluster):
                     {
                         "device_memory_limit": self.device_memory_limit,
                         "memory_limit": self.memory_limit,
-                        "local_directory": local_directory,
                         "log_spilling": log_spilling,
                     },
                 )

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -11,6 +11,7 @@ import traceback
 import warnings
 import weakref
 from collections import defaultdict
+from collections.abc import MutableMapping
 from typing import (
     Any,
     Callable,
@@ -19,7 +20,6 @@ from typing import (
     Hashable,
     Iterable,
     List,
-    MutableMapping,
     Optional,
     Set,
     Tuple,

--- a/dask_cuda/tests/test_device_host_file.py
+++ b/dask_cuda/tests/test_device_host_file.py
@@ -1,4 +1,3 @@
-import os
 from random import randint
 
 import numpy as np
@@ -24,14 +23,6 @@ def assert_eq(x, y):
     return dask.array.assert_eq(cupy.asnumpy(x), cupy.asnumpy(y))
 
 
-def test_device_host_file_config(tmp_path):
-    dhf_disk_path = str(tmp_path / "dask-worker-space" / "storage")
-    with dask.config.set(temporary_directory=str(tmp_path)):
-        dhf = DeviceHostFile()
-        assert os.path.exists(dhf_disk_path)
-        assert dhf.disk_func_path == dhf_disk_path
-
-
 @pytest.mark.parametrize("num_host_arrays", [1, 10, 100])
 @pytest.mark.parametrize("num_device_arrays", [1, 10, 100])
 @pytest.mark.parametrize("array_size_range", [(1, 1000), (100, 100), (1000, 1000)])
@@ -43,7 +34,7 @@ def test_device_host_file_short(
     dhf = DeviceHostFile(
         device_memory_limit=1024 * 16,
         memory_limit=1024 * 16,
-        local_directory=tmpdir,
+        worker_local_directory=tmpdir,
     )
 
     host = [
@@ -81,7 +72,7 @@ def test_device_host_file_step_by_step(tmp_path):
     dhf = DeviceHostFile(
         device_memory_limit=1024 * 16,
         memory_limit=1024 * 16,
-        local_directory=tmpdir,
+        worker_local_directory=tmpdir,
     )
 
     a = np.random.random(1000)

--- a/dask_cuda/tests/test_gds.py
+++ b/dask_cuda/tests/test_gds.py
@@ -11,7 +11,7 @@ from dask_cuda.proxify_host_file import ProxifyHostFile
 if ProxifyHostFile._spill_to_disk is None:
     tmpdir = tempfile.TemporaryDirectory()
     ProxifyHostFile(
-        local_directory=tmpdir.name,
+        worker_local_directory=tmpdir.name,
         device_memory_limit=1024,
         memory_limit=1024,
     )

--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -1,5 +1,4 @@
 import re
-import tempfile
 from typing import Iterable
 from unittest.mock import patch
 
@@ -32,21 +31,24 @@ one_item_nbytes = one_item_array().nbytes
 dask_cuda.proxify_device_objects.dispatch.dispatch(cupy.ndarray)
 dask_cuda.proxify_device_objects.incompatible_types = ()  # type: ignore
 
-# Make the "disk" serializer available and use a tmp directory
-if ProxifyHostFile._spill_to_disk is None:
-    # Hold on to `tmpdir` to keep dir alive until exit
-    tmpdir = tempfile.TemporaryDirectory()
-    ProxifyHostFile(
-        worker_local_directory=tmpdir.name,
-        device_memory_limit=1024,
-        memory_limit=1024,
-    )
-assert ProxifyHostFile._spill_to_disk is not None
 
-# In order to use the same tmp dir, we use `root_dir` for all ProxifyHostFile creations
-# Notice, we use `..` to remove the `jit-unspill-disk-storage` part
-# added by the ProxifyHostFile implicitly.
-root_dir = str(ProxifyHostFile._spill_to_disk.root_dir / "..")
+@pytest.fixture(scope="module")
+def root_dir(tmp_path_factory):
+    tmpdir = tmp_path_factory.mktemp("jit-unspill")
+    # Make the "disk" serializer available and use a tmp directory
+    if ProxifyHostFile._spill_to_disk is None:
+        ProxifyHostFile(
+            worker_local_directory=tmpdir.name,
+            device_memory_limit=1024,
+            memory_limit=1024,
+        )
+    assert ProxifyHostFile._spill_to_disk is not None
+
+    # In order to use the same tmp dir, we use `root_dir` for all
+    # ProxifyHostFile creations Notice, we use `..` to remove the
+    # `jit-unspill-disk-storage` part added by the
+    # ProxifyHostFile implicitly.
+    return str(ProxifyHostFile._spill_to_disk.root_dir / "..")
 
 
 def is_proxies_equal(p1: Iterable[ProxyObject], p2: Iterable[ProxyObject]):
@@ -61,7 +63,7 @@ def is_proxies_equal(p1: Iterable[ProxyObject], p2: Iterable[ProxyObject]):
     return ids1 == ids2
 
 
-def test_one_dev_item_limit():
+def test_one_dev_item_limit(root_dir):
     dhf = ProxifyHostFile(
         worker_local_directory=root_dir,
         device_memory_limit=one_item_nbytes,
@@ -152,7 +154,7 @@ def test_one_dev_item_limit():
     assert len(dhf.manager) == 0
 
 
-def test_one_item_host_limit(capsys):
+def test_one_item_host_limit(capsys, root_dir):
     memory_limit = sizeof(asproxy(one_item_array(), serializers=("dask", "pickle")))
     dhf = ProxifyHostFile(
         worker_local_directory=root_dir,
@@ -215,7 +217,7 @@ def test_one_item_host_limit(capsys):
     assert len(dhf.manager) == 0
 
 
-def test_spill_on_demand():
+def test_spill_on_demand(root_dir):
     """
     Test spilling on demand by disabling the device_memory_limit
     and allocating two large buffers that will otherwise fail because
@@ -265,7 +267,7 @@ def test_local_cuda_cluster(jit_unspill):
             assert_frame_equal(got.to_pandas(), df.to_pandas())
 
 
-def test_dataframes_share_dev_mem():
+def test_dataframes_share_dev_mem(root_dir):
     cudf = pytest.importorskip("cudf")
 
     df = cudf.DataFrame({"a": range(10)})
@@ -305,7 +307,7 @@ def test_cudf_get_device_memory_objects():
     assert len(res) == 4, "We expect four buffer objects"
 
 
-def test_externals():
+def test_externals(root_dir):
     """Test adding objects directly to the manager
 
     Add an object directly to the manager makes it count against the
@@ -357,7 +359,7 @@ def test_externals():
 
 
 @patch("dask_cuda.proxify_device_objects.incompatible_types", (cupy.ndarray,))
-def test_incompatible_types():
+def test_incompatible_types(root_dir):
     """Check that ProxifyHostFile unproxifies `cupy.ndarray` on retrieval
 
     Notice, in this test we add `cupy.ndarray` to the incompatible_types temporarily.

--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -28,7 +28,7 @@ from dask_cuda.proxify_host_file import ProxifyHostFile
 if ProxifyHostFile._spill_to_disk is None:
     tmpdir = tempfile.TemporaryDirectory()
     ProxifyHostFile(
-        local_directory=tmpdir.name,
+        worker_local_directory=tmpdir.name,
         device_memory_limit=1024,
         memory_limit=1024,
     )


### PR DESCRIPTION
For automated cleanup when the cluster exits, the on-disk spilling directory needs to live inside the relevant worker's local_directory. Since we do not have a handle on the worker when constructing the keyword arguments to DeviceHostFile or ProxifyHostFile, instead take advantage of dask/distributed#7153 and request that we are called with the worker_local_directory as an argument. Closes #1018.