### PR TITLE
Remove `pytest-asyncio` dependency

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -63,14 +63,11 @@ conda config --show-sources
 conda list --show-channel-urls
 
 # Installing cucim in order to test GDS spilling
-# Pin pytest-asyncio because latest versions modify the default asyncio
-# `event_loop_policy`. See https://github.com/dask/distributed/pull/4212 .
 gpuci_mamba_retry install "cudf=${MINOR_VERSION}" \
               "dask-cudf=${MINOR_VERSION}" \
               "ucx-py=${UCXPY_VERSION}" \
               "ucx-proc=*=gpu" \
-              "cucim" \
-              "pytest-asyncio=<0.14.0"
+              "cucim"
 
 
 gpuci_logger "Check versions"

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -89,7 +89,6 @@ async def test_with_subset_of_cuda_visible_devices():
 
 
 @pytest.mark.parametrize("protocol", ["ucx", None])
-@pytest.mark.asyncio
 @gen_test(timeout=20)
 async def test_ucx_protocol(protocol):
     pytest.importorskip("ucp")
@@ -103,7 +102,6 @@ async def test_ucx_protocol(protocol):
         )
 
 
-@pytest.mark.asyncio
 @pytest.mark.filterwarnings("ignore:Exception ignored in")
 @gen_test(timeout=20)
 async def test_ucx_protocol_type_error():


### PR DESCRIPTION
All requirements towards `pytest-asyncio` should have been removed, dropping all remains.

Closes #1044 