### PR TITLE
[skip gpuci] Build dask-cuda internally to use for RAPIDS CI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -42,6 +42,6 @@ jobs:
       # leave this empty to remove the default '-cu11' suffix
       python-package-cuda-suffix: ""
 
-      test-extras:  "test"
+      test-extras:  "test-cu11"
       test-unittest: "pytest -v ./dask_cuda/tests"
     secrets: inherit

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,47 @@
+name: dask-cuda wheels
+
+on:
+  workflow_call:
+    inputs:
+      versioneer-override:
+        type: string
+        default: ''
+      build-tag:
+        type: string
+        default: ''
+      branch:
+        required: true
+        type: string
+      date:
+        required: true
+        type: string
+      sha:
+        required: true
+        type: string
+      build-type:
+        type: string
+        default: nightly
+
+jobs:
+  dask-cuda-wheels:
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-pure.yml@main
+    with:
+      repo: rapidsai/dask-cuda
+
+      build-type: ${{ inputs.build-type }}
+      branch: ${{ inputs.branch }}
+      sha: ${{ inputs.sha }}
+      date: ${{ inputs.date }}
+
+      package-name: dask_cuda
+      package-dir: .
+
+      python-package-versioneer-override: ${{ inputs.versioneer-override }}
+      python-package-build-tag: ${{ inputs.build-tag }}
+
+      # leave this empty to remove the default '-cu11' suffix
+      python-package-cuda-suffix: ""
+
+      test-extras:  "test"
+      test-unittest: "pytest -v ./dask_cuda/tests"
+    secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,10 @@ docs = [
     "sphinx-click>=2.7.1",
     "sphinx-rtd-theme>=0.5.1",
 ]
-test = [
+test-cu11 = [
     "pytest",
+    "rmm-cu11",
+    "ucx-py-cu11",
 ]
 
 [project.urls]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,23 @@ from setuptools import setup
 
 import versioneer
 
-if "GIT_DESCRIBE_TAG" in os.environ:
+# dask-cuda uses GIT_DESCRIBE_TAG to override versioneer
+# In the RAPIDS pip wheel workflows, we use RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE
+# to achieve the same goal (in fact using code copied from this setup.py)
+#
+# To faciliate building RAPIDS pip wheels in the CI/nightly index, we need
+# a copy of dask-cuda available to install before it is released on PyPI.org
+#
+# We introduced a .github/workflows/wheels.yml workflow to dask-cuda
+# to build and upload an early copy of a dask-cuda wheel to the CI/nightly
+# index to unblock wheel CI for other RAPIDS projects
+version_env_var = (
+    "GIT_DESCRIBE_TAG"
+    if "GIT_DESCRIBE_TAG" in os.environ
+    else "RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE"
+)
+
+if version_env_var in os.environ:
     # Disgusting hack. For pypi uploads we cannot use the
     # versioneer-provided version for non-release builds, since they
     # strictly follow PEP440
@@ -16,7 +32,7 @@ if "GIT_DESCRIBE_TAG" in os.environ:
     # versioneer.get_versions.
 
     orig_get_versions = versioneer.get_versions
-    version = os.environ["GIT_DESCRIBE_TAG"] + os.environ.get("VERSION_SUFFIX", "")
+    version = os.environ[version_env_var] + os.environ.get("VERSION_SUFFIX", "")
 
     def get_versions():
         data = orig_get_versions()


### PR DESCRIPTION
During the pip wheel CI for RAPIDS projects (e.g. cudf/cugraph/cuml), we need to be able to install dask-cuda.

Dask-cuda is released to PyPI.org on a specific release schedule. 

This PR allows dask-cuda wheels to get built using the RAPIDS pip wheel workflows, published to the RAPIDS nightly index. That way, RAPIDS CI can have access to an installable `dask-cuda` pip wheel before the PyPI release.

This shouldn't affect external users, since our internal nightly index is not accessible to the public (yet).