### PR TITLE
Ensure linting checks for whole repo in CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
       - repo: https://github.com/pycqa/isort
-        rev: 5.6.4
+        rev: 5.10.1
         hooks:
               - id: isort
       - repo: https://github.com/ambv/black
         rev: 22.3.0
         hooks:
               - id: black
-      - repo: https://gitlab.com/pycqa/flake8
+      - repo: https://github.com/PyCQA/flake8
         rev: 3.8.3
         hooks:
               - id: flake8

--- a/ci/checks/style.sh
+++ b/ci/checks/style.sh
@@ -12,50 +12,5 @@ PATH=/opt/conda/bin:$PATH
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids
 
-# Print versions
-echo -e "\nVersions:"
-black --version
-echo "isort, `isort --vn`"
-echo "flake8, `flake8 --version`"
-
-# Run isort and get results/return code
-ISORT=`isort --check-only . 2>&1`
-ISORT_RETVAL=$?
-
-# Run black and get results/return code
-BLACK=`black --check . 2>&1`
-BLACK_RETVAL=$?
-
-# Run flake8 and get results/return code
-FLAKE=`flake8 . 2>&1`
-FLAKE_RETVAL=$?
-
-# Output results if failure otherwise show pass
-if [ "$ISORT_RETVAL" != "0" ]; then
-  echo -e "\n\n>>>> FAILED: isort style check; begin output\n\n"
-  echo -e "$ISORT"
-  echo -e "\n\n>>>> FAILED: isort style check; end output\n\n"
-else
-  echo -e "\n\n>>>> PASSED: isort style check\n\n"
-fi
-
-if [ "$BLACK_RETVAL" != "0" ]; then
-  echo -e "\n\n>>>> FAILED: black style check; begin output\n\n"
-  echo -e "$BLACK"
-  echo -e "\n\n>>>> FAILED: black style check; end output\n\n"
-else
-  echo -e "\n\n>>>> PASSED: black style check\n\n"
-fi
-
-if [ "$FLAKE_RETVAL" != "0" ]; then
-  echo -e "\n\n>>>> FAILED: flake8 style check; begin output\n\n"
-  echo -e "$FLAKE"
-  echo -e "\n\n>>>> FAILED: flake8 style check; end output\n\n"
-else
-  echo -e "\n\n>>>> PASSED: flake8 style check\n\n"
-fi
-
-RETVALS=($ISORT_RETVAL $BLACK_RETVAL $FLAKE_RETVAL)
-IFS=$'\n'
-RETVAL=`echo "${RETVALS[*]}" | sort -nr | head -n1`
-exit $RETVAL
+# Run pre-commit checks
+pre-commit run --hook-stage manual --all-files

--- a/ci/checks/style.sh
+++ b/ci/checks/style.sh
@@ -19,15 +19,15 @@ echo "isort, `isort --vn`"
 echo "flake8, `flake8 --version`"
 
 # Run isort and get results/return code
-ISORT=`isort --check-only dask_cuda 2>&1`
+ISORT=`isort --check-only . 2>&1`
 ISORT_RETVAL=$?
 
 # Run black and get results/return code
-BLACK=`black --check dask_cuda 2>&1`
+BLACK=`black --check . 2>&1`
 BLACK_RETVAL=$?
 
 # Run flake8 and get results/return code
-FLAKE=`flake8 dask_cuda 2>&1`
+FLAKE=`flake8 . 2>&1`
 FLAKE_RETVAL=$?
 
 # Output results if failure otherwise show pass


### PR DESCRIPTION
It often happens that `pre-commit` finds improperly formatted files that are not in the `dask_cuda` directory, therefore it is sensible to check the entire repo.