### PR TITLE
[REVIEW] Fix `parse_memory_limit` function call

### DIFF
--- a/dask_cuda/_compat.py
+++ b/dask_cuda/_compat.py
@@ -1,8 +1,0 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
-
-from packaging import version
-
-import distributed
-
-DISTRIBUTED_VERSION = version.parse(distributed.__version__)
-DISTRIBUTED_GT_2022_11_1 = DISTRIBUTED_VERSION > version.parse("2022.11.1")

--- a/dask_cuda/_compat.py
+++ b/dask_cuda/_compat.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.
+
+from packaging import version
+
+import distributed
+
+DISTRIBUTED_VERSION = version.parse(distributed.__version__)
+DISTRIBUTED_GT_2022_11_1 = DISTRIBUTED_VERSION > version.parse("2022.11.1")

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -16,9 +16,9 @@ from distributed.proctitle import (
     enable_proctitle_on_children,
     enable_proctitle_on_current,
 )
+from distributed.utils import has_arg
 from distributed.worker_memory import parse_memory_limit
 
-from ._compat import DISTRIBUTED_GT_2022_11_1
 from .device_host_file import DeviceHostFile
 from .initialize import initialize
 from .proxify_host_file import ProxifyHostFile
@@ -86,7 +86,8 @@ class CUDAWorker(Server):
             raise ValueError("nthreads must be higher than 0.")
 
         # Set nthreads=1 when parsing mem_limit since it only depends on nprocs
-        if DISTRIBUTED_GT_2022_11_1:
+        if has_arg(parse_memory_limit, "logger"):
+            # TODO: Remove has_arg check after 2022.11.1 support is dropped
             logger = logging.getLogger(__name__)
             memory_limit = parse_memory_limit(
                 memory_limit=memory_limit, nthreads=1, total_cores=nprocs, logger=logger

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import asyncio
 import atexit
+import logging
 import os
 import warnings
 
@@ -17,6 +18,7 @@ from distributed.proctitle import (
 )
 from distributed.worker_memory import parse_memory_limit
 
+from ._compat import DISTRIBUTED_GT_2022_11_1
 from .device_host_file import DeviceHostFile
 from .initialize import initialize
 from .proxify_host_file import ProxifyHostFile
@@ -84,9 +86,15 @@ class CUDAWorker(Server):
             raise ValueError("nthreads must be higher than 0.")
 
         # Set nthreads=1 when parsing mem_limit since it only depends on nprocs
-        memory_limit = parse_memory_limit(
-            memory_limit=memory_limit, nthreads=1, total_cores=nprocs
-        )
+        if DISTRIBUTED_GT_2022_11_1:
+            logger = logging.getLogger(__name__)
+            memory_limit = parse_memory_limit(
+                memory_limit=memory_limit, nthreads=1, total_cores=nprocs, logger=logger
+            )
+        else:
+            memory_limit = parse_memory_limit(
+                memory_limit=memory_limit, nthreads=1, total_cores=nprocs
+            )
 
         if pid_file:
             with open(pid_file, "w") as f:

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -5,9 +5,9 @@ import warnings
 
 import dask
 from distributed import LocalCluster, Nanny, Worker
+from distributed.utils import has_arg
 from distributed.worker_memory import parse_memory_limit
 
-from ._compat import DISTRIBUTED_GT_2022_11_1
 from .device_host_file import DeviceHostFile
 from .initialize import initialize
 from .proxify_host_file import ProxifyHostFile
@@ -233,7 +233,8 @@ class LocalCUDACluster(LocalCluster):
         if n_workers < 1:
             raise ValueError("Number of workers cannot be less than 1.")
         # Set nthreads=1 when parsing mem_limit since it only depends on n_workers
-        if DISTRIBUTED_GT_2022_11_1:
+        if has_arg(parse_memory_limit, "logger"):
+            # TODO: Remove has_arg check after 2022.11.1 support is dropped
             logger = logging.getLogger(__name__)
             self.memory_limit = parse_memory_limit(
                 memory_limit=memory_limit,


### PR DESCRIPTION
This PR addresses a breaking change that was made in upstream distributed: https://github.com/dask/distributed/pull/5669/

Error due to above change:
```
>       self.memory_limit = parse_memory_limit(
            memory_limit=memory_limit, nthreads=1, total_cores=n_workers
        )
E       TypeError: parse_memory_limit() missing 1 required keyword-only argument: 'logger'

```
Introduced a version-based function call because we haven't yet finalized the `dask` pinning for `22.12`, though as of now `2022.11.1` seems to be the most likely release pinning. Since the dask dev `2022.11.1` packages now contain this breaking change, this check will also help unblock any `22.12` CI jobs that are fetching `2022.11.1` dask dev packages.

Once `dask` is pinned to a specific version, this version-based check can be removed.