### PR TITLE
[gpuCI] Forward-merge branch-22.12 to branch-23.02 [skip gpuci]

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -21,10 +21,10 @@ export GPUCI_CONDA_RETRY_SLEEP=30
 
 # Whether to keep `dask/label/dev` channel in the env. If INSTALL_DASK_MAIN=0,
 # `dask/label/dev` channel is removed.
-export INSTALL_DASK_MAIN=1
+export INSTALL_DASK_MAIN=0
 
 # Dask version to install when `INSTALL_DASK_MAIN=0`
-export DASK_STABLE_VERSION="2022.9.2"
+export DASK_STABLE_VERSION="2022.11.1"
 
 # Switch to project root; also root of repo checkout
 cd "$WORKSPACE"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -35,10 +35,10 @@ export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1
 
 # Install dask and distributed from main branch. Usually needed during
 # development time and disabled before a new dask-cuda release.
-export INSTALL_DASK_MAIN=1
+export INSTALL_DASK_MAIN=0
 
 # Dask version to install when `INSTALL_DASK_MAIN=0`
-export DASK_STABLE_VERSION="2022.9.2"
+export DASK_STABLE_VERSION="2022.11.1"
 
 # Temporary workaround for Jupyter errors.
 # See https://github.com/rapidsai/dask-cuda/issues/1040

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ authors = [
 license= { text = "Apache-2.0" }
 requires-python = ">=3.8"
 dependencies = [
-    "dask >=2022.9.2",
-    "distributed >=2022.9.2",
+    "dask ==2022.11.1",
+    "distributed ==2022.11.1",
     "pynvml >=11.0.0",
     "numpy >=1.18.0",
     "numba >=0.54",


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.12` that creates a PR to keep `branch-23.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.