### PR TITLE
[REVIEW] Unpin `dask` and `distributed` for development

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -21,10 +21,10 @@ export GPUCI_CONDA_RETRY_SLEEP=30
 
 # Whether to keep `dask/label/dev` channel in the env. If INSTALL_DASK_MAIN=0,
 # `dask/label/dev` channel is removed.
-export INSTALL_DASK_MAIN=0
+export INSTALL_DASK_MAIN=1
 
 # Dask version to install when `INSTALL_DASK_MAIN=0`
-export DASK_STABLE_VERSION="2022.11.1"
+export DASK_STABLE_VERSION="2022.12.0"
 
 # Switch to project root; also root of repo checkout
 cd "$WORKSPACE"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -35,10 +35,10 @@ export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1
 
 # Install dask and distributed from main branch. Usually needed during
 # development time and disabled before a new dask-cuda release.
-export INSTALL_DASK_MAIN=0
+export INSTALL_DASK_MAIN=1
 
 # Dask version to install when `INSTALL_DASK_MAIN=0`
-export DASK_STABLE_VERSION="2022.11.1"
+export DASK_STABLE_VERSION="2022.12.0"
 
 # Temporary workaround for Jupyter errors.
 # See https://github.com/rapidsai/dask-cuda/issues/1040

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -16,7 +16,6 @@ from distributed.proctitle import (
     enable_proctitle_on_children,
     enable_proctitle_on_current,
 )
-from distributed.utils import has_arg
 from distributed.worker_memory import parse_memory_limit
 
 from .device_host_file import DeviceHostFile
@@ -86,16 +85,10 @@ class CUDAWorker(Server):
             raise ValueError("nthreads must be higher than 0.")
 
         # Set nthreads=1 when parsing mem_limit since it only depends on nprocs
-        if has_arg(parse_memory_limit, "logger"):
-            # TODO: Remove has_arg check after 2022.11.1 support is dropped
-            logger = logging.getLogger(__name__)
-            memory_limit = parse_memory_limit(
-                memory_limit=memory_limit, nthreads=1, total_cores=nprocs, logger=logger
-            )
-        else:
-            memory_limit = parse_memory_limit(
-                memory_limit=memory_limit, nthreads=1, total_cores=nprocs
-            )
+        logger = logging.getLogger(__name__)
+        memory_limit = parse_memory_limit(
+            memory_limit=memory_limit, nthreads=1, total_cores=nprocs, logger=logger
+        )
 
         if pid_file:
             with open(pid_file, "w") as f:

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -5,7 +5,6 @@ import warnings
 
 import dask
 from distributed import LocalCluster, Nanny, Worker
-from distributed.utils import has_arg
 from distributed.worker_memory import parse_memory_limit
 
 from .device_host_file import DeviceHostFile
@@ -233,19 +232,13 @@ class LocalCUDACluster(LocalCluster):
         if n_workers < 1:
             raise ValueError("Number of workers cannot be less than 1.")
         # Set nthreads=1 when parsing mem_limit since it only depends on n_workers
-        if has_arg(parse_memory_limit, "logger"):
-            # TODO: Remove has_arg check after 2022.11.1 support is dropped
-            logger = logging.getLogger(__name__)
-            self.memory_limit = parse_memory_limit(
-                memory_limit=memory_limit,
-                nthreads=1,
-                total_cores=n_workers,
-                logger=logger,
-            )
-        else:
-            self.memory_limit = parse_memory_limit(
-                memory_limit=memory_limit, nthreads=1, total_cores=n_workers
-            )
+        logger = logging.getLogger(__name__)
+        self.memory_limit = parse_memory_limit(
+            memory_limit=memory_limit,
+            nthreads=1,
+            total_cores=n_workers,
+            logger=logger,
+        )
         self.device_memory_limit = parse_device_memory_limit(
             device_memory_limit, device_index=nvml_device_index(0, CUDA_VISIBLE_DEVICES)
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ authors = [
 license= { text = "Apache-2.0" }
 requires-python = ">=3.8"
 dependencies = [
-    "dask ==2022.11.1",
-    "distributed ==2022.11.1",
+    "dask >=2022.12.0",
+    "distributed >=2022.12.0",
     "pynvml >=11.0.0",
     "numpy >=1.18.0",
     "numba >=0.54",


### PR DESCRIPTION
This PR unpins `dask` and `distributed` to `2022.12.0+` for `23.02` development.


xref: https://github.com/rapidsai/cudf/pull/12302