### PR TITLE
Add strings udf to build setup

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -65,6 +65,7 @@ conda list --show-channel-urls
 # Installing cucim in order to test GDS spilling
 gpuci_mamba_retry install "cudf=${MINOR_VERSION}" \
               "dask-cudf=${MINOR_VERSION}" \
+              "strings_udf=${MINOR_VERSION}" \
               "ucx-py=${UCXPY_VERSION}" \
               "ucx-proc=*=gpu" \
               "cucim"


### PR DESCRIPTION
We recently ran into trouble with strings-udf inadvertently calling cuInit: https://github.com/rapidsai/cudf/issues/12340 .  By adding `strings-udf` to the build env for dask-cuda we can properly test in CI and catch any more errors around cuda context creation/cuInit calls

cc @pentschev @wence- 