### PR TITLE
Shuffle by partition to reduce memory usage significantly

### DIFF
--- a/dask_cuda/benchmarks/local_cudf_shuffle.py
+++ b/dask_cuda/benchmarks/local_cudf_shuffle.py
@@ -46,7 +46,7 @@ def bench_once(client, args, write_profile=None):
     nchunks = args.in_parts
     totalsize = chunksize * nchunks
     x = da.random.random((totalsize,), chunks=(chunksize,))
-    df = dask.dataframe.from_dask_array(x, columns="data").to_frame()
+    df = dask.dataframe.from_dask_array(x, columns=["data"])
 
     if args.type == "gpu":
         import cudf


### PR DESCRIPTION
In order to reduce peak memory usage, this PR implements _rounds_ in explicit-comms shuffle.
The idea is that each worker handles a number of dataframe partitions in each round instead of doing everything at once.
The number of partitions handled in each round can be controlled by setting `DASK_XCOMM_BATCHSIZE` or directly when calling `shuffle()`. 

By default, each worker handles one partition per round. 
Set `DASK_XCOMM_BATCHSIZE=-1`, to handle all partitions in a single round (the previous behavior).


