### PR TITLE
Improve shuffle-benchmark

### DIFF
--- a/dask_cuda/benchmarks/common.py
+++ b/dask_cuda/benchmarks/common.py
@@ -85,7 +85,8 @@ class Config(NamedTuple):
 def run_benchmark(client: Client, args: Namespace, config: Config):
     """Run a benchmark a specified number of times
 
-    If ``args.profile`` is set, the final run is profiled."""
+    If ``args.profile`` is set, the final run is profiled.
+    """
     results = []
     for _ in range(max(1, args.runs) - 1):
         res = config.bench_once(client, args, write_profile=None)
@@ -110,8 +111,11 @@ def gather_bench_results(client: Client, args: Namespace, config: Config):
 def run(client: Client, args: Namespace, config: Config):
     """Run the full benchmark on the cluster
 
-    Waits for the cluster, sets up memory pools, prints and saves results"""
+    Waits for the cluster, sets up memory pools, prints and saves results
+    """
+
     wait_for_cluster(client, shutdown_on_failure=True)
+    assert len(client.scheduler_info()["workers"]) > 0
     setup_memory_pools(
         client,
         args.type == "gpu",
@@ -156,7 +160,8 @@ def run_client_from_existing_scheduler(args: Namespace, config: Config):
 def run_create_client(args: Namespace, config: Config):
     """Create a client + cluster and run
 
-    Shuts down the cluster at the end of the benchmark"""
+    Shuts down the cluster at the end of the benchmark
+    """
     cluster_options = get_cluster_options(args)
     Cluster = cluster_options["class"]
     cluster_args = cluster_options["args"]

--- a/dask_cuda/benchmarks/local_cudf_shuffle.py
+++ b/dask_cuda/benchmarks/local_cudf_shuffle.py
@@ -57,7 +57,8 @@ def create_df(nelem, df_type):
 def create_data(
     client: Client, args, name="balanced-df"
 ) -> Tuple[int, dask.dataframe.DataFrame]:
-    """Create evenly distributed a dask dataframe"""
+    """Create an evenly distributed dask dataframe"""
+
     workers = list(client.scheduler_info()["workers"].keys())
     assert len(workers) > 0
 

--- a/dask_cuda/benchmarks/local_cudf_shuffle.py
+++ b/dask_cuda/benchmarks/local_cudf_shuffle.py
@@ -57,7 +57,11 @@ def create_df(nelem, df_type):
 def create_data(
     client: Client, args, name="balanced-df"
 ) -> Tuple[int, dask.dataframe.DataFrame]:
-    """Create an evenly distributed dask dataframe"""
+    """Create an evenly distributed dask dataframe
+
+    The partitions are perfectly distributed across workers, if the number of
+    requested partitions is evenly divisible by the number of workers.
+    """
 
     workers = list(client.scheduler_info()["workers"].keys())
     assert len(workers) > 0

--- a/dask_cuda/benchmarks/local_cudf_shuffle.py
+++ b/dask_cuda/benchmarks/local_cudf_shuffle.py
@@ -57,8 +57,8 @@ def create_df(nelem, df_type):
 def create_data(
     client: Client, args, name="balanced-df"
 ) -> Tuple[int, dask.dataframe.DataFrame]:
-    """Create a dask dataframe that are distributed evenly"""
-    workers = list(client.run(lambda: 42).keys())
+    """Create evenly distributed a dask dataframe"""
+    workers = list(client.scheduler_info()["workers"].keys())
     assert len(workers) > 0
 
     chunksize = args.partition_size // np.float64().nbytes

--- a/dask_cuda/benchmarks/local_cudf_shuffle.py
+++ b/dask_cuda/benchmarks/local_cudf_shuffle.py
@@ -46,12 +46,12 @@ def shuffle_explicit_comms(df, args):
 def create_df(nelem, df_type):
     if df_type == "cpu":
         return pd.DataFrame({"data": np.random.random(nelem)})
+    else:
+        assert df_type == "gpu"
+        import cupy  # isort:skip
+        import cudf
 
-    assert df_type == "gpu"
-    import cupy  # isort:skip
-    import cudf  # isort:skip
-
-    return cudf.DataFrame({"data": cupy.random.random(nelem)})
+        return cudf.DataFrame({"data": cupy.random.random(nelem)})
 
 
 def create_data(

--- a/dask_cuda/benchmarks/local_cudf_shuffle.py
+++ b/dask_cuda/benchmarks/local_cudf_shuffle.py
@@ -23,6 +23,14 @@ from dask_cuda.benchmarks.utils import (
     print_throughput_bandwidth,
 )
 
+try:
+    import cupy
+
+    import cudf
+except ImportError:
+    cupy = None
+    cudf = None
+
 
 def shuffle_dask(df, args):
     result = shuffle(df, index="data", shuffle="tasks", ignore_index=args.ignore_index)
@@ -46,12 +54,12 @@ def shuffle_explicit_comms(df, args):
 def create_df(nelem, df_type):
     if df_type == "cpu":
         return pd.DataFrame({"data": np.random.random(nelem)})
-    else:
-        assert df_type == "gpu"
-        import cupy  # isort:skip
-        import cudf
-
+    elif df_type == "gpu":
+        if cudf is None or cupy is None:
+            raise RuntimeError("`--type=gpu` requires cudf and cupy ")
         return cudf.DataFrame({"data": cupy.random.random(nelem)})
+    else:
+        raise ValueError(f"Unknown type {df_type}")
 
 
 def create_data(

--- a/dask_cuda/benchmarks/local_cudf_shuffle.py
+++ b/dask_cuda/benchmarks/local_cudf_shuffle.py
@@ -62,7 +62,8 @@ def create_data(
     assert len(workers) > 0
 
     chunksize = args.partition_size // np.float64().nbytes
-    # Distribute the new partitions between worker by round robin
+    # Distribute the new partitions between workers by round robin.
+    # We use `client.submit` to control the distribution exactly.
     # TODO: support unbalanced partition distribution
     dsk = {}
     for i in range(args.in_parts):

--- a/dask_cuda/benchmarks/local_cudf_shuffle.py
+++ b/dask_cuda/benchmarks/local_cudf_shuffle.py
@@ -78,15 +78,14 @@ def create_data(
         )
     wait(dsk.values())
 
+    df_meta = create_df(0, args.type)
     divs = [None] * (len(dsk) + 1)
-    ret = new_dd_object(dsk, name, create_df(0, args.type), divs).persist()
+    ret = new_dd_object(dsk, name, df_meta, divs).persist()
     wait(ret)
 
     data_processed = args.in_parts * args.partition_size
     if not args.ignore_index:
-        data_processed += (
-            args.in_parts * chunksize * create_df(0, args.type).index.dtype.itemsize
-        )
+        data_processed += args.in_parts * chunksize * df_meta.index.dtype.itemsize
     return data_processed, ret
 
 

--- a/dask_cuda/benchmarks/local_cudf_shuffle.py
+++ b/dask_cuda/benchmarks/local_cudf_shuffle.py
@@ -75,7 +75,7 @@ def create_data(
     wait(dsk.values())
 
     divs = [None] * (len(dsk) + 1)
-    ret = new_dd_object(dsk, name, create_df(0, "cpu"), divs).persist()
+    ret = new_dd_object(dsk, name, create_df(0, args.type), divs).persist()
     wait(ret)
 
     data_processed = args.in_parts * args.partition_size

--- a/dask_cuda/explicit_comms/comms.py
+++ b/dask_cuda/explicit_comms/comms.py
@@ -180,7 +180,7 @@ class CommsContext:
         self.sessionId = uuid.uuid4().int
 
         # Get address of all workers (not Nanny addresses)
-        self.worker_addresses = list(self.client.run(lambda: 42).keys())
+        self.worker_addresses = list(client.scheduler_info()["workers"].keys())
 
         # Make all workers listen and get all listen addresses
         self.worker_direct_addresses = []

--- a/dask_cuda/explicit_comms/comms.py
+++ b/dask_cuda/explicit_comms/comms.py
@@ -180,7 +180,7 @@ class CommsContext:
         self.sessionId = uuid.uuid4().int
 
         # Get address of all workers (not Nanny addresses)
-        self.worker_addresses = list(client.scheduler_info()["workers"].keys())
+        self.worker_addresses = list(self.client.scheduler_info()["workers"].keys())
 
         # Make all workers listen and get all listen addresses
         self.worker_direct_addresses = []


### PR DESCRIPTION
Adding `--ignore-index` and balance the partition distribution between workers.

This should make the runs more consist and improve the data creation significantly. 