### PR TITLE
Ensure tests run for Python `3.10`

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -33,7 +33,7 @@ jobs:
     # TODO: Switch this testing branch to "cuda-118" after `cudf` `3.10` builds are out.
     # There is a circular testing dependency between `dask-cuda` and `cudf` right now, which
     # prevents us from running `3.10` tests for `dask-cuda` until `3.10` `cudf` packages are published.
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@cuda-118
     with:
       build_type: pull-request
   wheel-build:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -30,9 +30,6 @@ jobs:
   conda-python-tests:
     needs: conda-python-build
     secrets: inherit
-    # TODO: Switch this testing branch to "cuda-118" after `cudf` `3.10` builds are out.
-    # There is a circular testing dependency between `dask-cuda` and `cudf` right now, which
-    # prevents us from running `3.10` tests for `dask-cuda` until `3.10` `cudf` packages are published.
     uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@cuda-118
     with:
       build_type: pull-request

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -37,4 +37,5 @@ sed_runner "s/export UCXPY_VERSION=.*/export UCXPY_VERSION="${NEXT_UCXPY_VERSION
 # Bump cudf and dask-cudf testing dependencies
 sed_runner "s/cudf=.*/cudf=${NEXT_SHORT_TAG}/g" dependencies.yaml
 sed_runner "s/dask-cudf=.*/dask-cudf=${NEXT_SHORT_TAG}/g" dependencies.yaml
+sed_runner "s/cucim=.*/cucim=${NEXT_SHORT_TAG}/g" dependencies.yaml
 sed_runner "s/ucx-py=.*/ucx-py=${NEXT_UCXPY_VERSION}/g" dependencies.yaml

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -91,7 +91,7 @@ dependencies:
     common:
       - output_types: [conda]
         packages:
-          - cucim
+          - cucim=23.02
           - cudf=23.02
           - dask-cudf=23.02
           - pytest


### PR DESCRIPTION
Previously we had disabled `cucim` testing for Python `3.10` because the tests depended on `3.10` packages of `cudf`, which weren't previously available.

Now that `3.10` packages of `cudf` are available, we can enable `3.10` testing for `cucim`.