### PR TITLE
Add timeout to `pytest` command

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -28,6 +28,7 @@ jobs:
     with:
       build_type: pull-request
   conda-python-tests:
+    timeout-minutes: 45
     needs: conda-python-build
     secrets: inherit
     # TODO: Switch this testing branch to "cuda-118" after `cudf` `3.10` builds are out.

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -28,7 +28,6 @@ jobs:
     with:
       build_type: pull-request
   conda-python-tests:
-    timeout-minutes: 45
     needs: conda-python-build
     secrets: inherit
     # TODO: Switch this testing branch to "cuda-118" after `cudf` `3.10` builds are out.

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -43,7 +43,7 @@ DASK_CUDA_TEST_SINGLE_GPU=1 \
 UCXPY_IFNAME=eth0 \
 UCX_WARN_UNUSED_ENV_VARS=n \
 UCX_MEMTYPE_CACHE=n \
-timeout 45m pytest \
+timeout 30m pytest \
   -vv \
   --capture=no \
   --cache-clear \

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -43,7 +43,7 @@ DASK_CUDA_TEST_SINGLE_GPU=1 \
 UCXPY_IFNAME=eth0 \
 UCX_WARN_UNUSED_ENV_VARS=n \
 UCX_MEMTYPE_CACHE=n \
-pytest \
+timeout 45m pytest \
   --capture=no \
   --cache-clear \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-dask-cuda.xml" \

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -44,6 +44,7 @@ UCXPY_IFNAME=eth0 \
 UCX_WARN_UNUSED_ENV_VARS=n \
 UCX_MEMTYPE_CACHE=n \
 timeout 45m pytest \
+  -vv \
   --capture=no \
   --cache-clear \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-dask-cuda.xml" \


### PR DESCRIPTION
There were two instances recently (below) where some Python test errors caused the `conda-python-tests` job to run/hang for ~4 hours.

- https://github.com/rapidsai/dask-cuda/pull/981#issuecomment-1382289752
- https://github.com/rapidsai/dask-cuda/pull/1081#issuecomment-1382288016

To prevent this from happening again in the future, I've added a reasonable timeout of ~~45 minutes to that particular job~~ 30 minutes to the `pytest` command.

The job usually takes ~25 minutes to complete entirely, so 30 minutes just for `pytest` should be plenty.

This timeout will help prevent jobs from hanging and thus help preserve our finite GPU capacity for CI (particularly for `arm` nodes).