### PR TITLE
Use `pkgutil.iter_modules` to get un-imported module for `test_pre_import`

### DIFF
--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+import pkgutil
 import subprocess
 import sys
 from unittest.mock import patch
 
-import pkg_resources
 import pytest
 
 from distributed import Client, wait
@@ -194,9 +194,9 @@ def test_pre_import(loop):  # noqa: F811
     module = None
 
     # Pick a module that isn't currently loaded
-    for m in pkg_resources.working_set:
-        if m.key not in sys.modules.keys():
-            module = m.key
+    for m in pkgutil.iter_modules():
+        if m.ispkg and m.name not in sys.modules.keys():
+            module = m.name
             break
 
     if module is None:

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -1,9 +1,9 @@
 import asyncio
 import os
+import pkgutil
 import sys
 from unittest.mock import patch
 
-import pkg_resources
 import pytest
 
 from dask.distributed import Client
@@ -263,9 +263,9 @@ async def test_pre_import():
     module = None
 
     # Pick a module that isn't currently loaded
-    for m in pkg_resources.working_set:
-        if m.key not in sys.modules.keys():
-            module = m.key
+    for m in pkgutil.iter_modules():
+        if m.ispkg and m.name not in sys.modules.keys():
+            module = m.name
             break
 
     if module is None:


### PR DESCRIPTION
Changed this because IIUC `pkg_resources.working_set` is listing the installed distributions and not necessarily the importable modules; this becomes an issue if the distribution and module names aren't the same (e.g. one would `conda install pillow` and then `import PIL`), which was causing some failures in CI that seem unrelated to the changes here.

_Originally posted by @charlesbluca in https://github.com/rapidsai/dask-cuda/pull/981#discussion_r1072650294_
            