### PR TITLE
shuffle: use cuDF's `partition_by_hash()` when available

### DIFF
--- a/dask_cuda/benchmarks/local_cudf_shuffle.py
+++ b/dask_cuda/benchmarks/local_cudf_shuffle.py
@@ -45,7 +45,7 @@ def shuffle_explicit_comms(df, args):
     t1 = perf_counter()
     wait(
         dask_cuda.explicit_comms.dataframe.shuffle.shuffle(
-            df, column_names="data", ignore_index=args.ignore_index
+            df, column_names=["data"], ignore_index=args.ignore_index
         ).persist()
     )
     return perf_counter() - t1

--- a/dask_cuda/explicit_comms/dataframe/shuffle.py
+++ b/dask_cuda/explicit_comms/dataframe/shuffle.py
@@ -174,10 +174,18 @@ def partition_dataframe(
 
     Returns
     -------
-    partitions: list of DataFrames
-        List of dataframe-partitions
+    partitions
+        Dict of dataframe-partitions, mapping partition-ID to dataframe
     """
-    # TODO: use cuDF's partition_by_hash() when `column_names[0] != "_partitions"`
+    if column_names[0] != "_partitions" and hasattr(df, "partition_by_hash"):
+        return dict(
+            zip(
+                range(npartitions),
+                df.partition_by_hash(
+                    column_names, npartitions, keep_index=not ignore_index
+                ),
+            )
+        )
     map_index = compute_map_index(df, column_names, npartitions)
     return group_split_dispatch(df, map_index, npartitions, ignore_index=ignore_index)
 


### PR DESCRIPTION
cuDF's `partition_by_hash()` is faster than calling `compute_map_index()` followed by `scatter_by_map()`.

Depend on https://github.com/rapidsai/cudf/pull/12554