### PR TITLE
Update `cudf.Buffer` pointer access method

### DIFF
--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -281,7 +281,7 @@ def test_dataframes_share_dev_mem(root_dir):
     # Even though the two dataframe doesn't point to the same cudf.Buffer object
     assert view1["a"].data is not view2["a"].data
     # They still share the same underlying device memory
-    view1["a"].data.ptr == view2["a"].data.ptr
+    view1["a"].data.get_ptr(mode="read") == view2["a"].data.get_ptr(mode="read")
 
     dhf = ProxifyHostFile(
         worker_local_directory=root_dir, device_memory_limit=160, memory_limit=1000


### PR DESCRIPTION
Fix test that reads directly from `cudf.Buffer` pointer to new `get_ptr(mode="read")`, in accordance with changes from https://github.com/rapidsai/cudf/pull/12587 .