### PR TITLE
pre-commit: Update isort version to 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
               - id: trailing-whitespace
               - id: end-of-file-fixer
       - repo: https://github.com/pycqa/isort
-        rev: 5.10.1
+        rev: 5.12.0
         hooks:
               - id: isort
       - repo: https://github.com/ambv/black


### PR DESCRIPTION
poetry version 1.5.0 broke installs of isort prior to 5.11.5 (see pycqa/isort#2077 and pycqa/isort#2078), so we need to upgrade.