### PR TITLE
Proxify: make duplicate check optional

### DIFF
--- a/dask_cuda/explicit_comms/dataframe/shuffle.py
+++ b/dask_cuda/explicit_comms/dataframe/shuffle.py
@@ -31,12 +31,12 @@ def get_proxify(worker: Worker) -> Proxify:
 
     if isinstance(worker.data, ProxifyHostFile):
         data = worker.data
-        return lambda x: data.manager.proxify(x)[0]
+        return lambda x: data.manager.proxify(x, duplicate_check=False)[0]
     return lambda x: x  # no-op
 
 
 def get_no_comm_postprocess(
-    stage: Dict[str, Any], num_rounds: int, batchsize: int
+    stage: Dict[str, Any], num_rounds: int, batchsize: int, proxify: Proxify
 ) -> Callable[[DataFrame], DataFrame]:
     """Get function for post-processing partitions not communicated
 
@@ -75,9 +75,11 @@ def get_no_comm_postprocess(
 
     # Deep copying a cuDF dataframe doesn't deep copy its index hence
     # we have to do it explicitly.
-    return lambda x: x._from_data(
-        x._data.copy(deep=True),
-        x._index.copy(deep=True),
+    return lambda x: proxify(
+        x._from_data(
+            x._data.copy(deep=True),
+            x._index.copy(deep=True),
+        )
     )
 
 
@@ -246,7 +248,7 @@ def create_partitions(
         t = [df_grouped[i] for df_grouped in dfs_grouped]
         assert len(t) > 0
         if len(t) == 1:
-            ret[i] = proxify(t[0])
+            ret[i] = t[0]
         elif len(t) > 1:
             ret[i] = proxify(dd_concat(t, ignore_index=ignore_index))
     return ret
@@ -305,7 +307,7 @@ async def send_recv_partitions(
     # We can now add them to the output dataframes.
     for out_part_id, dataframe in out_part_id_to_dataframe.items():
         out_part_id_to_dataframe_list[out_part_id].append(
-            no_comm_postprocess(proxify(dataframe))
+            no_comm_postprocess(dataframe)
         )
     out_part_id_to_dataframe.clear()
 
@@ -361,7 +363,7 @@ async def shuffle_task(
     myrank: int = s["rank"]
     stage = comms.pop_staging_area(s, stage_name)
     assert stage.keys() == rank_to_inkeys[myrank]
-    no_comm_postprocess = get_no_comm_postprocess(stage, num_rounds, batchsize)
+    no_comm_postprocess = get_no_comm_postprocess(stage, num_rounds, batchsize, proxify)
 
     out_part_id_to_dataframe_list: Dict[int, List[DataFrame]] = defaultdict(list)
     for _ in range(num_rounds):

--- a/dask_cuda/explicit_comms/dataframe/shuffle.py
+++ b/dask_cuda/explicit_comms/dataframe/shuffle.py
@@ -53,10 +53,12 @@ def get_no_comm_postprocess(
     ----------
     stage
         The staged input dataframes.
-    num_rounds: int
+    num_rounds
         Number of rounds of dataframe partitioning and all-to-all communication.
-    batchsize: int
+    batchsize
         Number of partitions each worker will handle in each round.
+    proxify
+        Function to proxify object.
 
     Returns
     -------

--- a/dask_cuda/explicit_comms/dataframe/shuffle.py
+++ b/dask_cuda/explicit_comms/dataframe/shuffle.py
@@ -31,6 +31,8 @@ def get_proxify(worker: Worker) -> Proxify:
 
     if isinstance(worker.data, ProxifyHostFile):
         data = worker.data
+        # Notice, we know that we never call proxify() on the same proxied
+        # object thus we can speedup the call by setting `duplicate_check=False`
         return lambda x: data.manager.proxify(x, duplicate_check=False)[0]
     return lambda x: x  # no-op
 

--- a/dask_cuda/explicit_comms/dataframe/shuffle.py
+++ b/dask_cuda/explicit_comms/dataframe/shuffle.py
@@ -30,10 +30,9 @@ def get_proxify(worker: Worker) -> Proxify:
     from dask_cuda.proxify_host_file import ProxifyHostFile
 
     if isinstance(worker.data, ProxifyHostFile):
-        data = worker.data
         # Notice, we know that we never call proxify() on the same proxied
         # object thus we can speedup the call by setting `duplicate_check=False`
-        return lambda x: data.manager.proxify(x, duplicate_check=False)[0]
+        return lambda x: worker.data.manager.proxify(x, duplicate_check=False)[0]
     return lambda x: x  # no-op
 
 

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -322,7 +322,7 @@ class ProxyManager:
                         header, _ = pxy.obj
                         assert header["serializer"] == pxy.serializer
 
-    def proxify(self, obj: T) -> Tuple[T, bool]:
+    def proxify(self, obj: T, duplicate_check=True) -> Tuple[T, bool]:
         """Proxify `obj` and add found proxies to the `Proxies` collections
 
         Returns the proxified object and a boolean, which is `True` when one or
@@ -333,9 +333,12 @@ class ProxyManager:
             found_proxies: List[ProxyObject] = []
             # In order detect already proxied object, proxify_device_objects()
             # needs a mapping from proxied objects to their proxy objects.
-            proxied_id_to_proxy = {
-                id(p._pxy_get().obj): p for p in self._dev.get_proxies()
-            }
+            if duplicate_check:
+                proxied_id_to_proxy = {
+                    id(p._pxy_get().obj): p for p in self._dev.get_proxies()
+                }
+            else:
+                proxied_id_to_proxy = None
             ret = proxify_device_objects(obj, proxied_id_to_proxy, found_proxies)
             last_access = time.monotonic()
             for p in found_proxies:

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -353,7 +353,7 @@ class ProxyManager:
         with self.lock:
             found_proxies: List[ProxyObject] = []
             if duplicate_check:
-                # In order detect already proxied object, proxify_device_objects()
+                # In order to detect already proxied object, proxify_device_objects()
                 # needs a mapping from proxied objects to their proxy objects.
                 proxied_id_to_proxy = {
                     id(p._pxy_get().obj): p for p in self._dev.get_proxies()

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -325,15 +325,36 @@ class ProxyManager:
     def proxify(self, obj: T, duplicate_check=True) -> Tuple[T, bool]:
         """Proxify `obj` and add found proxies to the `Proxies` collections
 
+        Search through `obj` and wraps all CUDA device objects in ProxyObject.
+        If duplicate_check is True, identical CUDA device objects found in
+        `obj` are wrapped by the same ProxyObject.
+
         Returns the proxified object and a boolean, which is `True` when one or
         more incompatible-types were found.
+
+        Parameters
+        ----------
+        obj
+            Object to search through or wrap in a ProxyObject.
+        duplicate_check
+            Make sure that identical CUDA device objects found in `obj` are
+            wrapped by the same ProxyObject. This check comes with a significate
+            overhead hence set to False when it is known that no duplicate exist.
+
+        Return
+        ------
+        obj
+            The proxified object.
+        bool
+            Whether an incompatible-types were found or not.
         """
+
         incompatible_type_found = False
         with self.lock:
             found_proxies: List[ProxyObject] = []
-            # In order detect already proxied object, proxify_device_objects()
-            # needs a mapping from proxied objects to their proxy objects.
             if duplicate_check:
+                # In order detect already proxied object, proxify_device_objects()
+                # needs a mapping from proxied objects to their proxy objects.
                 proxied_id_to_proxy = {
                     id(p._pxy_get().obj): p for p in self._dev.get_proxies()
                 }

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -325,7 +325,7 @@ class ProxyManager:
     def proxify(self, obj: T, duplicate_check=True) -> Tuple[T, bool]:
         """Proxify `obj` and add found proxies to the `Proxies` collections
 
-        Search through `obj` and wraps all CUDA device objects in ProxyObject.
+        Search through `obj` and wrap all CUDA device objects in ProxyObject.
         If duplicate_check is True, identical CUDA device objects found in
         `obj` are wrapped by the same ProxyObject.
 
@@ -338,8 +338,9 @@ class ProxyManager:
             Object to search through or wrap in a ProxyObject.
         duplicate_check
             Make sure that identical CUDA device objects found in `obj` are
-            wrapped by the same ProxyObject. This check comes with a significate
-            overhead hence set to False when it is known that no duplicate exist.
+            wrapped by the same ProxyObject. This check comes with a significant
+            overhead hence it is recommended setting to False when it is known
+            that no duplicate exist.
 
         Return
         ------

--- a/dask_cuda/proxify_host_file.py
+++ b/dask_cuda/proxify_host_file.py
@@ -346,7 +346,7 @@ class ProxyManager:
         obj
             The proxified object.
         bool
-            Whether an incompatible-types were found or not.
+            Whether incompatible-types were found or not.
         """
 
         incompatible_type_found = False


### PR DESCRIPTION
In order to improve performance, it is now possible to skip the duplication check in `ProxyManager.proxify()`.

We use this in explicit-comms shuffle.