### PR TITLE
[REVIEW] Pin `dask` and `distributed` for release

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -21,10 +21,10 @@ export GPUCI_CONDA_RETRY_SLEEP=30
 
 # Whether to keep `dask/label/dev` channel in the env. If INSTALL_DASK_MAIN=0,
 # `dask/label/dev` channel is removed.
-export INSTALL_DASK_MAIN=1
+export INSTALL_DASK_MAIN=0
 
 # Dask version to install when `INSTALL_DASK_MAIN=0`
-export DASK_STABLE_VERSION="2022.12.0"
+export DASK_STABLE_VERSION="2023.1.1"
 
 # Switch to project root; also root of repo checkout
 cd "$WORKSPACE"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -35,10 +35,10 @@ export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1
 
 # Install dask and distributed from main branch. Usually needed during
 # development time and disabled before a new dask-cuda release.
-export INSTALL_DASK_MAIN=1
+export INSTALL_DASK_MAIN=0
 
 # Dask version to install when `INSTALL_DASK_MAIN=0`
-export DASK_STABLE_VERSION="2022.12.0"
+export DASK_STABLE_VERSION="2023.1.1"
 
 # Temporary workaround for Jupyter errors.
 # See https://github.com/rapidsai/dask-cuda/issues/1040

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -95,8 +95,8 @@ dependencies:
     common:
       - output_types: [conda, requirements]
         packages:
-          - dask>=2022.12.0
-          - distributed>=2022.12.0
+          - dask==2023.1.1
+          - distributed==2023.1.1
           - numba>=0.54
           - numpy>=1.18.0
           - pandas>=1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ authors = [
 license = { text = "Apache-2.0" }
 requires-python = ">=3.8"
 dependencies = [
-    "dask >=2022.12.0",
-    "distributed >=2022.12.0",
+    "dask ==2023.1.1",
+    "distributed ==2023.1.1",
     "pynvml >=11.0.0",
     "numpy >=1.18.0",
     "numba >=0.54",


### PR DESCRIPTION
This PR pins `dask` and `distributed` to `2023.1.1` for `23.02` release.

xref: https://github.com/rapidsai/cudf/pull/12695

