### PR TITLE
Template Conda recipe's `about` metadata

### DIFF
--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -55,3 +55,5 @@ about:
     - ../../../{{ e }}
     {% endfor %}
   summary: {{ data.get("project", {}).get("description", "") }}
+  dev_url: {{ data.get("project", {}).get("urls", {}).get("Source", "") }}
+  doc_url: {{ data.get("project", {}).get("urls", {}).get("Documentation", "") }}

--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -48,7 +48,10 @@ test:
     {% endfor %}
 
 about:
-  home: https://rapids.ai/
-  license: Apache-2.0
-  license_file: ../../../LICENSE
-  summary: dask-cuda library
+  home: {{ data.get("project", {}).get("urls", {}).get("Homepage", "") }}
+  license: {{ data.get("project", {}).get("license", {}).get("text", "") }}
+  license_file:
+    {% for e in data.get("tool", {}).get("setuptools", {}).get("license-files", []) %}
+    - ../../../{{ e }}
+    {% endfor %}
+  summary: {{ data.get("project", {}).get("description", "") }}


### PR DESCRIPTION
Pull in the Conda recipe's `about` metadata from `pyproject.toml` using templating. Follows more closely with DRY and move more towards using `pyproject.toml` as the single source of truth.