### PR TITLE
Pin to pynvml < 11.5

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -100,7 +100,7 @@ dependencies:
           - numba>=0.54
           - numpy>=1.18.0
           - pandas>=1.0
-          - pynvml>=11.0.0
+          - pynvml>=11.0.0,<11.5
           - zict>=0.1.3
   test_python:
     common:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ requires-python = ">=3.8"
 dependencies = [
     "dask ==2023.1.1",
     "distributed ==2023.1.1",
-    "pynvml >=11.0.0",
+    "pynvml >=11.0.0,<11.5",
     "numpy >=1.18.0",
     "numba >=0.54",
     "pandas >=1.0",


### PR DESCRIPTION
PyNVML 11.5 makes a API-breaking change to the return types of (at least) nvmlDeviceGetName (producing str rather than bytes). On the development branch this was fixed by #1118. To fix in 23.02, instead pin to the previously working version, rather than backporting.