### PR TITLE
Pull `requirements/host` from `pyproject.toml`

### DIFF
--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -29,8 +29,9 @@ requirements:
   host:
     - python
     - pip
-    - tomli
-    - versioneer >=0.24
+    {% for r in data.get("build-system", {}).get("requires", []) %}
+    - {{ r }}
+    {% endfor %}
   run:
     - python
     {% for r in data.get("project", {}).get("dependencies", []) %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-    "setuptools>=64.0.0",
-    "tomli  ; python_version < '3.11'",
-    "versioneer>=0.24",
+    "setuptools >=64.0.0",
+    "tomli",                # Unneeded for Python 3.11+
+    "versioneer >=0.24",
 ]
 
 [project]


### PR DESCRIPTION
In addition to pulling the Conda recipe's `requirements/run` from `pyproject.toml`, pull `requirements/host` from `pyproject.toml`. This should help solidify around `pyproject.toml` being the single source of truth.