### PR TITLE
Drop Python 3.7 handling for pickle protocol 4

### DIFF
--- a/dask_cuda/tests/test_device_host_file.py
+++ b/dask_cuda/tests/test_device_host_file.py
@@ -10,7 +10,6 @@ from distributed.protocol import (
     serialize,
     serialize_bytelist,
 )
-from distributed.protocol.pickle import HIGHEST_PROTOCOL
 
 from dask_cuda.device_host_file import DeviceHostFile, device_to_host, host_to_device
 
@@ -189,10 +188,7 @@ def test_serialize_cupy_collection(collection, length, value):
 
     header, frames = serialize(obj, serializers=["pickle"], on_error="raise")
 
-    if HIGHEST_PROTOCOL >= 5:
-        assert len(frames) == (1 + len(obj.frames))
-    else:
-        assert len(frames) == 1
+    assert len(frames) == (1 + len(obj.frames))
 
     obj2 = deserialize(header, frames)
     res = host_to_device(obj2)


### PR DESCRIPTION
Fixes https://github.com/rapidsai/dask-cuda/issues/1131

Now that Python 3.8 is the minimum supported version, drop the special casing for Python 3.7's `HIGHEST_PROTOCOL`, which was 4 (not 5). In Python 3.8+, `HIGHEST_PROTOCOL >= 5`. So none of these branches are needed any more.