### PR TITLE
Explicit-comms: update monkey patching of Dask 

### DIFF
--- a/dask_cuda/__init__.py
+++ b/dask_cuda/__init__.py
@@ -7,10 +7,14 @@ if sys.platform != "linux":
 import dask
 import dask.dataframe.core
 import dask.dataframe.shuffle
+import dask.dataframe.multi
 
 from ._version import get_versions
 from .cuda_worker import CUDAWorker
-from .explicit_comms.dataframe.shuffle import get_rearrange_by_column_wrapper
+from .explicit_comms.dataframe.shuffle import (
+    get_rearrange_by_column_wrapper,
+    get_default_shuffle_algorithm,
+)
 from .local_cuda_cluster import LocalCUDACluster
 from .proxify_device_objects import proxify_decorator, unproxify_decorator
 
@@ -22,7 +26,7 @@ del get_versions
 dask.dataframe.shuffle.rearrange_by_column = get_rearrange_by_column_wrapper(
     dask.dataframe.shuffle.rearrange_by_column
 )
-
+dask.dataframe.multi.get_default_shuffle_algorithm = get_default_shuffle_algorithm
 
 # Monkey patching Dask to make use of proxify and unproxify in compatibility mode
 dask.dataframe.shuffle.shuffle_group = proxify_decorator(

--- a/dask_cuda/__init__.py
+++ b/dask_cuda/__init__.py
@@ -10,7 +10,7 @@ import dask.dataframe.shuffle
 
 from ._version import get_versions
 from .cuda_worker import CUDAWorker
-from .explicit_comms.dataframe.shuffle import get_rearrange_by_column_tasks_wrapper
+from .explicit_comms.dataframe.shuffle import get_rearrange_by_column_wrapper
 from .local_cuda_cluster import LocalCUDACluster
 from .proxify_device_objects import proxify_decorator, unproxify_decorator
 
@@ -19,10 +19,8 @@ del get_versions
 
 
 # Monkey patching Dask to make use of explicit-comms when `DASK_EXPLICIT_COMMS=True`
-dask.dataframe.shuffle.rearrange_by_column_tasks = (
-    get_rearrange_by_column_tasks_wrapper(
-        dask.dataframe.shuffle.rearrange_by_column_tasks
-    )
+dask.dataframe.shuffle.rearrange_by_column = get_rearrange_by_column_wrapper(
+    dask.dataframe.shuffle.rearrange_by_column
 )
 
 

--- a/dask_cuda/explicit_comms/dataframe/shuffle.py
+++ b/dask_cuda/explicit_comms/dataframe/shuffle.py
@@ -470,7 +470,7 @@ def shuffle(
 
     # Step (a):
     df = df.persist()  # Make sure optimizations are apply on the existing graph
-    wait(df)  # Make sure all keys has been materialized on workers
+    wait([df])  # Make sure all keys has been materialized on workers
     name = (
         "explicit-comms-shuffle-"
         f"{tokenize(df, column_names, npartitions, ignore_index)}"
@@ -537,7 +537,7 @@ def shuffle(
     # Create a distributed Dataframe from all the pieces
     divs = [None] * (len(dsk) + 1)
     ret = new_dd_object(dsk, name, df_meta, divs).persist()
-    wait(ret)
+    wait([ret])
 
     # Release all temporary dataframes
     for fut in [*shuffle_result.values(), *dsk.values()]:

--- a/dask_cuda/explicit_comms/dataframe/shuffle.py
+++ b/dask_cuda/explicit_comms/dataframe/shuffle.py
@@ -9,6 +9,7 @@ from operator import getitem
 from typing import Any, Callable, Dict, List, Optional, Set, TypeVar
 
 import dask
+import dask.config
 import dask.dataframe
 from dask.base import tokenize
 from dask.dataframe.core import DataFrame, Series, _concat as dd_concat, new_dd_object
@@ -543,7 +544,7 @@ def shuffle(
 
 
 def _use_explicit_comms() -> bool:
-    """Is explicit-comms and available"""
+    """Is explicit-comms and available?"""
     if dask.config.get("explicit-comms", False):
         try:
             import distributed.worker
@@ -590,7 +591,9 @@ def get_default_shuffle_algorithm() -> str:
     This changes the default shuffle algorithm from "p2p" to "tasks"
     when explicit comms is enabled.
     """
+    import dask.utils
+
     ret = dask.config.get("dataframe.shuffle.algorithm", None)
-    if ret is None:
-        return "tasks" if _use_explicit_comms() else "p2p"
-    return ret
+    if ret is None and _use_explicit_comms():
+        return "tasks"
+    return dask.utils.get_default_shuffle_algorithm()

--- a/dask_cuda/explicit_comms/dataframe/shuffle.py
+++ b/dask_cuda/explicit_comms/dataframe/shuffle.py
@@ -11,6 +11,8 @@ from typing import Any, Callable, Dict, List, Optional, Set, TypeVar
 import dask
 import dask.config
 import dask.dataframe
+import dask.utils
+import distributed.worker
 from dask.base import tokenize
 from dask.dataframe.core import DataFrame, Series, _concat as dd_concat, new_dd_object
 from dask.dataframe.shuffle import group_split_dispatch, hash_object_dispatch
@@ -547,8 +549,6 @@ def _use_explicit_comms() -> bool:
     """Is explicit-comms and available?"""
     if dask.config.get("explicit-comms", False):
         try:
-            import distributed.worker
-
             # Make sure we have an activate client.
             distributed.worker.get_client()
         except (ImportError, ValueError):
@@ -591,8 +591,6 @@ def get_default_shuffle_algorithm() -> str:
     This changes the default shuffle algorithm from "p2p" to "tasks"
     when explicit comms is enabled.
     """
-    import dask.utils
-
     ret = dask.config.get("dataframe.shuffle.algorithm", None)
     if ret is None and _use_explicit_comms():
         return "tasks"

--- a/dask_cuda/tests/test_explicit_comms.py
+++ b/dask_cuda/tests/test_explicit_comms.py
@@ -183,10 +183,10 @@ def test_dask_use_explicit_comms(in_cluster):
         name = "explicit-comms-shuffle"
         ddf = dd.from_pandas(pd.DataFrame({"key": np.arange(10)}), npartitions=2)
         with dask.config.set(explicit_comms=False):
-            res = ddf.shuffle(on="key", npartitions=4, shuffle="tasks")
+            res = ddf.shuffle(on="key", npartitions=4)
             assert all(name not in str(key) for key in res.dask)
         with dask.config.set(explicit_comms=True):
-            res = ddf.shuffle(on="key", npartitions=4, shuffle="tasks")
+            res = ddf.shuffle(on="key", npartitions=4)
             if in_cluster:
                 assert any(name in str(key) for key in res.dask)
             else:  # If not in cluster, we cannot use explicit comms
@@ -200,7 +200,7 @@ def test_dask_use_explicit_comms(in_cluster):
             ):
                 dask.config.refresh()  # Trigger re-read of the environment variables
                 with pytest.raises(ValueError, match="explicit-comms-batchsize"):
-                    ddf.shuffle(on="key", npartitions=4, shuffle="tasks")
+                    ddf.shuffle(on="key", npartitions=4)
 
     if in_cluster:
         with LocalCluster(


### PR DESCRIPTION
Closes #1134 by wrapping `rearrange_by_column()` instead of `rearrange_by_column_tasks()`.  

This also has the bonus that we avoid a re-partition when the shuffle changes number of partitions: https://github.com/dask/dask/blob/945f4e8b7646228aff34da07ffaa52f1b73aa1e0/dask/dataframe/shuffle.py#L510