### PR TITLE
Update `rmm_cupy_allocator` usage

### DIFF
--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -386,7 +386,7 @@ def setup_memory_pool(
                 initial_pool_size=pool_size, release_threshold=release_threshold
             )
         )
-        cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)
+        cupy.cuda.set_allocator(rmm_cupy_allocator)
     else:
         rmm.reinitialize(
             pool_allocator=not disable_pool,

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -386,7 +386,6 @@ def setup_memory_pool(
                 initial_pool_size=pool_size, release_threshold=release_threshold
             )
         )
-        cupy.cuda.set_allocator(rmm_cupy_allocator)
     else:
         rmm.reinitialize(
             pool_allocator=not disable_pool,
@@ -395,7 +394,7 @@ def setup_memory_pool(
             logging=logging,
             log_file_name=get_rmm_log_file_name(dask_worker, logging, log_directory),
         )
-        cupy.cuda.set_allocator(rmm_cupy_allocator)
+    cupy.cuda.set_allocator(rmm_cupy_allocator)
     if statistics:
         rmm.mr.set_current_device_resource(
             rmm.mr.StatisticsResourceAdaptor(rmm.mr.get_current_device_resource())


### PR DESCRIPTION
Follow up to PR ( https://github.com/rapidsai/dask-cuda/pull/1129 ) and PR ( https://github.com/rapidsai/rmm/pull/1221 )

Uses `rmm_cupy_allocator` from `rmm.allocators.cupy` where it has been moved to recently.

cc @wence-