### PR TITLE
Add argument to enable RMM alloaction tracking in benchmarks

### DIFF
--- a/dask_cuda/benchmarks/common.py
+++ b/dask_cuda/benchmarks/common.py
@@ -126,6 +126,7 @@ def run(client: Client, args: Namespace, config: Config):
         args.rmm_release_threshold,
         args.rmm_log_directory,
         args.enable_rmm_statistics,
+        args.enable_rmm_track_allocations,
     )
     address_to_index, results, message_data = gather_bench_results(client, args, config)
     p2p_bw = peer_to_peer_bandwidths(message_data, address_to_index)


### PR DESCRIPTION
Tracking RMM allocation will be useful together with https://github.com/dask/distributed/pull/5740 , and will help with the analysis of memory fragmentation when comparing regular pool and the async memory allocator.