### PR TITLE
[REVIEW] Pin `dask` and `distributed` for release

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -95,8 +95,8 @@ dependencies:
     common:
       - output_types: [conda, requirements]
         packages:
-          - dask>=2023.1.1
-          - distributed>=2023.1.1
+          - dask==2023.3.2
+          - distributed==2023.3.2.1
           - numba>=0.54
           - numpy>=1.21
           - pandas>=1.3,<1.6.0dev0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -96,6 +96,7 @@ dependencies:
       - output_types: [conda, requirements]
         packages:
           - dask==2023.3.2
+          - dask-core==2023.3.2
           - distributed==2023.3.2.1
           - numba>=0.54
           - numpy>=1.21

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ license = { text = "Apache-2.0" }
 requires-python = ">=3.8"
 dependencies = [
     "dask ==2023.3.2",
+    "dask-core ==2023.3.2",
     "distributed ==2023.3.2.1",
     "pynvml >=11.0.0,<11.5",
     "numpy >=1.21",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ authors = [
 license = { text = "Apache-2.0" }
 requires-python = ">=3.8"
 dependencies = [
-    "dask >=2023.1.1",
-    "distributed >=2023.1.1",
+    "dask ==2023.3.2",
+    "distributed ==2023.3.2.1",
     "pynvml >=11.0.0,<11.5",
     "numpy >=1.21",
     "numba >=0.54",


### PR DESCRIPTION
This PR pins `dask` and `distributed` to `2023.3.2` and `2023.3.2.1` respectively for `23.04` release.

xref: https://github.com/rapidsai/cudf/pull/13070