### PR TITLE
Rectify `dask-core` pinning in pip requirements

### DIFF
--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -21,6 +21,7 @@ build:
   script:
     - {{ PYTHON }} -m pip install . -vv
   entry_points:
+    - dask-core ==2023.3.2
     {% for e in data.get("project", {}).get("scripts", {}).items() %}
     - {{ e|join(" = ") }}
     {% endfor %}

--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -21,7 +21,6 @@ build:
   script:
     - {{ PYTHON }} -m pip install . -vv
   entry_points:
-    - dask-core ==2023.3.2
     {% for e in data.get("project", {}).get("scripts", {}).items() %}
     - {{ e|join(" = ") }}
     {% endfor %}
@@ -34,6 +33,7 @@ requirements:
     - versioneer >=0.24
   run:
     - python
+    - dask-core ==2023.3.2
     {% for r in data.get("project", {}).get("dependencies", []) %}
     - {{ r }}
     {% endfor %}

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -221,6 +221,13 @@ def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]
         "since the workers are assumed to be started separately. Similarly the other "
         "cluster configuration options have no effect.",
     )
+    group.add_argument(
+        "--dashboard-address",
+        default=None,
+        type=str,
+        help="Address on which to listen for diagnostics dashboard, ignored if "
+        "either ``--scheduler-address`` or ``--scheduler-file`` is specified.",
+    )
     cluster_args.add_argument(
         "--shutdown-external-cluster-on-exit",
         default=False,
@@ -328,7 +335,11 @@ def get_cluster_options(args):
 
         cluster_kwargs = {
             "connect_options": {"known_hosts": None},
-            "scheduler_options": {"protocol": args.protocol, "port": 8786},
+            "scheduler_options": {
+                "protocol": args.protocol,
+                "port": 8786,
+                "dashboard_address": args.dashboard_address,
+            },
             "worker_class": "dask_cuda.CUDAWorker",
             "worker_options": {
                 "protocol": args.protocol,
@@ -345,12 +356,12 @@ def get_cluster_options(args):
         cluster_args = []
         cluster_kwargs = {
             "protocol": args.protocol,
+            "dashboard_address": args.dashboard_address,
             "n_workers": len(args.devs.split(",")),
             "threads_per_worker": args.threads_per_worker,
             "CUDA_VISIBLE_DEVICES": args.devs,
             "interface": args.interface,
             "device_memory_limit": args.device_memory_limit,
-            "dashboard_address": 18787,
             **ucx_options,
         }
         if args.no_silence_logs:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -95,8 +95,8 @@ dependencies:
     common:
       - output_types: [conda, requirements]
         packages:
-          - dask>=2023.1.1
-          - distributed>=2023.1.1
+          - dask==2023.3.2
+          - distributed==2023.3.2.1
           - numba>=0.54
           - numpy>=1.21
           - pandas>=1.3,<1.6.0dev0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -96,6 +96,7 @@ dependencies:
       - output_types: [conda, requirements]
         packages:
           - dask==2023.3.2
+          - dask-core==2023.3.2
           - distributed==2023.3.2.1
           - numba>=0.54
           - numpy>=1.21

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -96,13 +96,15 @@ dependencies:
       - output_types: [conda, requirements]
         packages:
           - dask==2023.3.2
-          - dask-core==2023.3.2
           - distributed==2023.3.2.1
           - numba>=0.54
           - numpy>=1.21
           - pandas>=1.3,<1.6.0dev0
           - pynvml>=11.0.0,<11.5
           - zict>=0.1.3
+      - output_types: [conda]
+        packages:
+          - dask-core==2023.3.2
   test_python:
     common:
       - output_types: [conda]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ license = { text = "Apache-2.0" }
 requires-python = ">=3.8"
 dependencies = [
     "dask ==2023.3.2",
-    "dask-core ==2023.3.2",
     "distributed ==2023.3.2.1",
     "pynvml >=11.0.0,<11.5",
     "numpy >=1.21",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ license = { text = "Apache-2.0" }
 requires-python = ">=3.8"
 dependencies = [
     "dask ==2023.3.2",
+    "dask-core ==2023.3.2",
     "distributed ==2023.3.2.1",
     "pynvml >=11.0.0,<11.5",
     "numpy >=1.21",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ authors = [
 license = { text = "Apache-2.0" }
 requires-python = ">=3.8"
 dependencies = [
-    "dask >=2023.1.1",
-    "distributed >=2023.1.1",
+    "dask ==2023.3.2",
+    "distributed ==2023.3.2.1",
     "pynvml >=11.0.0,<11.5",
     "numpy >=1.21",
     "numba >=0.54",


### PR DESCRIPTION
As part of https://github.com/rapidsai/dask-cuda/pull/1153 `dask-core` has been added to pip requirements, which is incorrect. This PR rectifies this issue.