### PR TITLE
Temporarily relax Python constraint

### DIFF
--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -2,6 +2,7 @@ import functools
 import itertools
 import logging
 import os
+import sys
 import time
 
 import numpy
@@ -238,6 +239,34 @@ class DeviceHostFile(ZictBase):
 
         # Dict of objects that will not be spilled by DeviceHostFile.
         self.others = {}
+
+    if sys.version_info < (3, 9):
+
+        def __new__(
+            cls,
+            # So named such that dask will pass in the worker's local
+            # directory when constructing this through the "data" callback.
+            worker_local_directory,
+            *,
+            device_memory_limit=None,
+            memory_limit=None,
+            log_spilling=False,
+        ):
+            """
+            This is here to support Python 3.8. Right now (to support
+            3.8), ZictBase inherits from typing.MutableMapping through
+            which inspect.signature determines that the signature of
+            __init__ is just (*args, **kwargs). We need to advertise the
+            correct signature so that distributed will correctly figure
+            out that it needs to pass the worker's local directory. In
+            Python 3.9 and later, typing.MutableMapping is just an alias
+            for collections.abc.MutableMapping and we don't need to do
+            anything.
+
+            With this pass-through definition of __new__, the
+            signature of the constructor is correctly determined.
+            """
+            return super().__new__(cls)
 
     def __setitem__(self, key, value):
         if key in self.device_buffer:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
     { name = "NVIDIA Corporation" },
 ]
 license = { text = "Apache-2.0" }
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 dependencies = [
     "dask ==2023.3.2",
     "distributed ==2023.3.2.1",


### PR DESCRIPTION
This PR unblocks RAPIDS CI since many places attempt to install dask-cuda from source. We can undo this change once the rest of RAPIDS has moved to Python 3.9. We will also want to discuss better strategies for handling dask-cuda in CI as part of our ongoing discussions around improving latest dask usage in CI.