### PR TITLE
Remove `matrix_filter` from workflows

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -33,9 +33,6 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@branch-23.06
     with:
-      # TODO: remove the `matrix_filter` line after `cudf` is publishing `3.9`
-      # packages. also remove the line in `test.yaml`
-      matrix_filter: map(select(.PY_VER == "3.10"))
       build_type: pull-request
   docs-build:
     needs: conda-python-build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,9 +18,6 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@branch-23.06
     with:
-      # TODO: remove the `matrix_filter` line after `cudf` is publishing `3.9`
-      # packages. also remove the line in `pr.yaml`
-      matrix_filter: map(select(.PY_VER == "3.10"))
       build_type: nightly
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}


### PR DESCRIPTION
Should be safe to do this now that cuDF 3.9 nightlies are being published