### PR TITLE
Fix GHAs Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,6 +67,8 @@ jobs:
           fetch-depth: 0
       - name: Build wheel
         run: ci/build_python_pypi.sh
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Publish distribution 📦 to PyPI
         if: inputs.build_type == 'nightly'
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -58,3 +58,5 @@ jobs:
           fetch-depth: 0
       - name: Build wheel
         run: ci/build_python_pypi.sh
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/ci/build_python_pypi.sh
+++ b/ci/build_python_pypi.sh
@@ -8,7 +8,7 @@ python -m pip install build --user
 export GIT_DESCRIBE_TAG=$(git describe --abbrev=0 --tags)
 export GIT_DESCRIBE_NUMBER=$(git rev-list ${GIT_DESCRIBE_TAG}..HEAD --count)
 
-# Compute/export VERSION_SUFFIX
+# Compute/export RAPIDS_DATE_STRING
 source rapids-env-update
 
 python -m build \

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if "GIT_DESCRIBE_TAG" in os.environ:
     # versioneer.get_versions.
 
     orig_get_versions = versioneer.get_versions
-    version = os.environ["GIT_DESCRIBE_TAG"] + os.environ.get("VERSION_SUFFIX", "")
+    version = os.environ["GIT_DESCRIBE_TAG"] + os.environ.get("RAPIDS_DATE_STRING", "")
 
     def get_versions():
         data = orig_get_versions()


### PR DESCRIPTION
The `rapids-env-update` command needs a `GH_TOKEN` environment for CI now due to the changes below:

- https://github.com/rapidsai/gha-tools/pull/53

Similar to: https://github.com/rapidsai/shared-action-workflows/pull/87