### PR TITLE
Add `__main__` entrypoint to dask-cuda-worker CLI

### DIFF
--- a/dask_cuda/cli.py
+++ b/dask_cuda/cli.py
@@ -499,3 +499,6 @@ def config(
     else:
         client = Client(scheduler, security=security)
     print_cluster_config(client)
+
+if __name__ == "__main__":
+    worker()

--- a/dask_cuda/cli.py
+++ b/dask_cuda/cli.py
@@ -500,5 +500,6 @@ def config(
         client = Client(scheduler, security=security)
     print_cluster_config(client)
 
+
 if __name__ == "__main__":
     worker()


### PR DESCRIPTION
Fixes #1180 

Making the CLI runnable with `python -m ` so that we can use the same call for both CLIs in `dask-jobqueue`