### PR TITLE
Require Numba 0.57.0+

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -93,7 +93,7 @@ dependencies:
         packages:
           - dask==2023.3.2
           - distributed==2023.3.2.1
-          - numba>=0.54
+          - numba>=0.57
           - numpy>=1.21
           - pandas>=1.3,<1.6.0dev0
           - pynvml>=11.0.0,<11.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "distributed ==2023.3.2.1",
     "pynvml >=11.0.0,<11.5",
     "numpy >=1.21",
-    "numba >=0.54",
+    "numba >=0.57",
     "pandas >=1.3,<1.6.0dev0",
     "zict >=2.0.0",
 ]


### PR DESCRIPTION
Aligns with the rest of RAPIDS. Also needed for CUDA 12 support.