### PR TITLE
Unpin `dask` and `distributed` for development

### DIFF
--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - versioneer >=0.24
   run:
     - python
-    - dask-core ==2023.3.2
+    - dask-core >=2023.5.1
     {% for r in data.get("project", {}).get("dependencies", []) %}
     - {{ r }}
     {% endfor %}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -91,8 +91,8 @@ dependencies:
     common:
       - output_types: [conda, requirements]
         packages:
-          - dask==2023.3.2
-          - distributed==2023.3.2.1
+          - dask>=2023.5.1
+          - distributed>=2023.5.1
           - numba>=0.57
           - numpy>=1.21
           - pandas>=1.3,<1.6.0dev0
@@ -100,7 +100,7 @@ dependencies:
           - zict>=2.0.0
       - output_types: [conda]
         packages:
-          - dask-core==2023.3.2
+          - dask-core>=2023.5.1
   test_python:
     common:
       - output_types: [conda]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ authors = [
 license = { text = "Apache-2.0" }
 requires-python = ">=3.9"
 dependencies = [
-    "dask ==2023.3.2",
-    "distributed ==2023.3.2.1",
+    "dask >=2023.5.1",
+    "distributed >=2023.5.1",
     "pynvml >=11.0.0,<11.5",
     "numpy >=1.21",
     "numba >=0.57",


### PR DESCRIPTION
This PR unpins `dask` and `distributed` to `>=2023.5.1` for `23.08` development.


xref: https://github.com/rapidsai/cudf/pull/13508

