### PR TITLE
Increase pytest CI timeout

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -44,7 +44,7 @@ DASK_CUDA_TEST_SINGLE_GPU=1 \
 UCXPY_IFNAME=eth0 \
 UCX_WARN_UNUSED_ENV_VARS=n \
 UCX_MEMTYPE_CACHE=n \
-timeout 30m pytest \
+timeout 40m pytest \
   -vv \
   --capture=no \
   --cache-clear \


### PR DESCRIPTION
Rather than individual tests hanging, the primary nightly problem seems to be that the `pytest` timeout is too short, increase it by 10 minutes to check if that is sufficient.