### PR TITLE
Aggregate reads & writes in `disk_io`

### DIFF
--- a/dask_cuda/disk_io.py
+++ b/dask_cuda/disk_io.py
@@ -170,8 +170,8 @@ def disk_write(path: str, frames: Iterable, shared_filesystem: bool, gds=False) 
 
         with kvikio.CuFile(path, "w") as f:
             file_offset = 0
-            for frame, length in zip(frames, frame_lengths):
-                f.pwrite(buf=frame, count=length, file_offset=file_offset, buf_offset=0).get()
+            for b, length in zip(frames, frame_lengths):
+                f.pwrite(b, file_offset=file_offset).get()
                 file_offset += length
     else:
         with open(path, "wb") as f:
@@ -213,9 +213,7 @@ def disk_read(header: Mapping, gds=False) -> list:
                     buf = get_new_cuda_buffer()(length)
                 else:
                     buf = np.empty((length,), dtype="u1")
-                f.pread(
-                    buf=buf, count=length, file_offset=file_offset, buf_offset=0
-                ).get()
+                f.pread(buf, file_offset=file_offset).get()
                 file_offset += length
                 ret.append(buf)
     else:

--- a/dask_cuda/disk_io.py
+++ b/dask_cuda/disk_io.py
@@ -169,8 +169,10 @@ def disk_write(path: str, frames: Iterable, shared_filesystem: bool, gds=False) 
         import kvikio
 
         with kvikio.CuFile(path, "w") as f:
+            file_offset = 0
             for frame, length in zip(frames, frame_lengths):
-                f.pwrite(buf=frame, count=length, file_offset=0, buf_offset=0).get()
+                f.pwrite(buf=frame, count=length, file_offset=file_offset, buf_offset=0).get()
+                file_offset += length
     else:
         with open(path, "wb") as f:
             for frame in frames:

--- a/dask_cuda/disk_io.py
+++ b/dask_cuda/disk_io.py
@@ -206,20 +206,22 @@ def disk_read(header: Mapping, gds=False) -> list:
     if gds:
         import kvikio  # isort:skip
 
+        ret.extend(
+            get_new_cuda_buffer()(length)
+            if is_cuda
+            else np.empty((length,), dtype="u1")
+            for length, is_cuda in zip(header["frame-lengths"], header["cuda-frames"])
+        )
         with kvikio.CuFile(header["path"], "rb") as f:
             file_offset = 0
-            for length, is_cuda in zip(header["frame-lengths"], header["cuda-frames"]):
-                if is_cuda:
-                    buf = get_new_cuda_buffer()(length)
-                else:
-                    buf = np.empty((length,), dtype="u1")
-                f.pread(buf, file_offset=file_offset).get()
-                file_offset += length
-                ret.append(buf)
+            for b in ret:
+                f.pread(b, file_offset=file_offset).get()
+                file_offset += b.nbytes
     else:
+        ret.extend(
+            np.empty((length,), dtype="u1") for length in header["frame-lengths"]
+        )
         with open(str(header["path"]), "rb") as f:
-            for length in header["frame-lengths"]:
-                buf = np.empty((length,), dtype="u1")
-                f.readinto(buf)
-                ret.append(buf)
+            for b in ret:
+                f.readinto(b)
     return ret

--- a/dask_cuda/disk_io.py
+++ b/dask_cuda/disk_io.py
@@ -175,8 +175,7 @@ def disk_write(path: str, frames: Iterable, shared_filesystem: bool, gds=False) 
                 file_offset += length
     else:
         with open(path, "wb") as f:
-            for frame in frames:
-                f.write(frame)
+            f.writelines(frames)
     return {
         "method": "stdio",
         "path": SpillToDiskFile(path),

--- a/dask_cuda/disk_io.py
+++ b/dask_cuda/disk_io.py
@@ -175,7 +175,7 @@ def disk_write(path: str, frames: Iterable, shared_filesystem: bool, gds=False) 
                 file_offset += length
     else:
         with open(path, "wb") as f:
-            f.writelines(frames)
+            os.writev(f.fileno(), frames)  # type: ignore
     return {
         "method": "stdio",
         "path": SpillToDiskFile(path),
@@ -217,6 +217,5 @@ def disk_read(header: Mapping, gds=False) -> list:
                 file_offset += b.nbytes
     else:
         with open(str(header["path"]), "rb") as f:
-            for b in ret:
-                f.readinto(b)
+            os.readv(f.fileno(), ret)  # type: ignore
     return ret

--- a/dask_cuda/disk_io.py
+++ b/dask_cuda/disk_io.py
@@ -219,5 +219,7 @@ def disk_read(header: Mapping, gds=False) -> list:
     else:
         with open(str(header["path"]), "rb") as f:
             for length in header["frame-lengths"]:
-                ret.append(f.read(length))
+                buf = np.empty((length,), dtype="u1")
+                f.readinto(buf)
+                ret.append(buf)
     return ret

--- a/dask_cuda/disk_io.py
+++ b/dask_cuda/disk_io.py
@@ -204,7 +204,7 @@ def disk_read(header: Mapping, gds=False) -> list:
     frames: list
         List of read frames
     """
-    ret = [
+    ret: list = [
         get_new_cuda_buffer()(length)
         if gds and is_cuda
         else np.empty((length,), dtype="u1")

--- a/dask_cuda/disk_io.py
+++ b/dask_cuda/disk_io.py
@@ -171,7 +171,7 @@ def disk_write(path: str, frames: Iterable, shared_filesystem: bool, gds=False) 
 
         # Write each frame consecutively into `path` in parallel
         with kvikio.CuFile(path, "w") as f:
-            file_offsets = itertools.accumulate(map(nbytes, frames))
+            file_offsets = itertools.accumulate(map(nbytes, frames), initial=0)
             futures = [f.pwrite(b, file_offset=o) for b, o in zip(frames, file_offsets)]
             for each_fut in futures:
                 each_fut.get()
@@ -212,9 +212,9 @@ def disk_read(header: Mapping, gds=False) -> list:
     if gds:
         import kvikio  # isort:skip
 
-        with kvikio.CuFile(header["path"], "rb") as f:
+        with kvikio.CuFile(str(header["path"]), "r") as f:
             # Read each frame consecutively from `path` in parallel
-            file_offsets = itertools.accumulate(b.nbytes for b in ret)
+            file_offsets = itertools.accumulate((b.nbytes for b in ret), initial=0)
             futures = [f.pread(b, file_offset=o) for b, o in zip(ret, file_offsets)]
             for each_fut in futures:
                 each_fut.get()


### PR DESCRIPTION
Follow up to this discussion ( https://github.com/rapidsai/dask-cuda/pull/925#discussion_r1243178681 )

* Preallocates buffers before reading
* Uses NumPy `uint8` arrays for all host memory (benefits from hugepages on transfers)
* Handles IO asynchronously with KvikIO and waits at the end
* Uses vectorized IO for host reads & writes