### PR TITLE
Clarify `memory_limit` docs

### DIFF
--- a/dask_cuda/cli.py
+++ b/dask_cuda/cli.py
@@ -87,9 +87,10 @@ def cuda():
     "--memory-limit",
     default="auto",
     show_default=True,
-    help="""Bytes of memory per process that the worker can use. Can be an integer
-    (bytes), float (fraction of total system memory), string (like ``"5GB"`` or
-    ``"5000M"``), or ``"auto"`` or 0 for no memory management.""",
+    help="""Size of the host LRU cache, which is used to determine when the worker
+    starts spilling to disk (not available if JIT-Unspill is enabled). Can be an
+    integer (bytes), float (fraction of total system memory), string (like ``"5GB"``
+    or ``"5000M"``), or ``"auto"``, 0, or ``None`` for no memory management.""",
 )
 @click.option(
     "--device-memory-limit",

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -65,9 +65,10 @@ class LocalCUDACluster(LocalCluster):
     threads_per_worker : int, default 1
         Number of threads to be used for each Dask worker process.
     memory_limit : int, float, str, or None, default "auto"
-        Bytes of memory per process that the worker can use. Can be an integer (bytes),
-        float (fraction of total system memory), string (like ``"5GB"`` or ``"5000M"``),
-        or ``"auto"``, 0, or ``None`` for no memory management.
+        Size of the host LRU cache, which is used to determine when the worker
+        starts spilling to disk (not available if JIT-Unspill is enabled). Can be an
+        integer (bytes), float (fraction of total system memory), string (like ``"5GB"``
+        or ``"5000M"``), or ``"auto"``, 0, or ``None`` for no memory management.
     device_memory_limit : int, float, str, or None, default 0.8
         Size of the CUDA device LRU cache, which is used to determine when the worker
         starts spilling to host memory. Can be an integer (bytes), float (fraction of


### PR DESCRIPTION
It's not currently clear what is the purpose of `memory_limit`/`--memory-limit`. This attempts to clarify it's used to spill from host memory to disk.