### PR TITLE
Use minimal Numba dependencies for CUDA 12

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -67,7 +67,8 @@ dependencies:
               cuda: "12.0"
             packages:
               - cuda-version=12.0
-              - cuda-nvcc
+              - cuda-nvcc-impl
+              - cuda-nvrtc
   develop:
     common:
       - output_types: [conda, requirements]


### PR DESCRIPTION
As Numba doesn't need all of `cuda-nvcc` and only needs `cuda-nvcc-impl` & `cuda-nvrtc`, simplify the dependencies in the CUDA 12 case to make sure only the needed ones are installed.