### PR TITLE
Update `test_worker_timeout`

### DIFF
--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -450,5 +450,6 @@ def test_worker_timeout():
     )
 
     assert "closing nanny at" in ret.stderr.lower()
-    assert "reason: nanny-close" in ret.stderr.lower()
+    assert "reason: failure-to-start-" in ret.stderr.lower()
+    assert "timeouterror" in ret.stderr.lower()
     assert ret.returncode == 0

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -450,6 +450,12 @@ def test_worker_timeout():
     )
 
     assert "closing nanny at" in ret.stderr.lower()
-    assert "reason: failure-to-start-" in ret.stderr.lower()
-    assert "timeouterror" in ret.stderr.lower()
+
+    # Depending on the environment, the error raised may be different
+    try:
+        assert "reason: failure-to-start-" in ret.stderr.lower()
+        assert "timeouterror" in ret.stderr.lower()
+    except AssertionError:
+        assert "reason: nanny-close" in ret.stderr.lower()
+
     assert ret.returncode == 0


### PR DESCRIPTION
`test_worker_timeout` is currently failing because the error message has changed, updating to match the new error message.