### PR TITLE
Pin `dask` and `distributed` for `23.10` release

### DIFF
--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - tomli
   run:
     - python
-    - dask-core >=2023.7.1
+    - dask-core ==2023.9.2
     {% for r in data.get("project", {}).get("dependencies", []) %}
     - {{ r }}
     {% endfor %}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -101,8 +101,8 @@ dependencies:
     common:
       - output_types: [conda, requirements]
         packages:
-          - dask>=2023.7.1
-          - distributed>=2023.7.1
+          - dask==2023.9.2
+          - distributed==2023.9.2
           - numba>=0.57
           - numpy>=1.21
           - pandas>=1.3,<1.6.0dev0
@@ -110,7 +110,7 @@ dependencies:
           - zict>=2.0.0
       - output_types: [conda]
         packages:
-          - dask-core>=2023.7.1
+          - dask-core==2023.9.2
   test_python:
     common:
       - output_types: [conda]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ authors = [
 license = { text = "Apache-2.0" }
 requires-python = ">=3.9"
 dependencies = [
-    "dask >=2023.7.1",
-    "distributed >=2023.7.1",
+    "dask ==2023.9.2",
+    "distributed ==2023.9.2",
     "pynvml >=11.0.0,<11.5",
     "numpy >=1.21",
     "numba >=0.57",


### PR DESCRIPTION
This PR pins `dask` and `distributed` to `2023.9.2` for `23.10` release.


xref: https://github.com/rapidsai/cudf/pull/14225