### PR TITLE
Forward-merge branch-23.10 to branch-23.12

### DIFF
--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - tomli
   run:
     - python
-    - dask-core >=2023.7.1
+    - dask-core ==2023.9.2
     {% for r in data.get("project", {}).get("dependencies", []) %}
     - {{ r }}
     {% endfor %}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -101,8 +101,8 @@ dependencies:
     common:
       - output_types: [conda, requirements]
         packages:
-          - dask>=2023.7.1
-          - distributed>=2023.7.1
+          - dask==2023.9.2
+          - distributed==2023.9.2
           - numba>=0.57
           - numpy>=1.21
           - pandas>=1.3,<1.6.0dev0
@@ -110,7 +110,7 @@ dependencies:
           - zict>=2.0.0
       - output_types: [conda]
         packages:
-          - dask-core>=2023.7.1
+          - dask-core==2023.9.2
   test_python:
     common:
       - output_types: [conda]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ authors = [
 license = { text = "Apache-2.0" }
 requires-python = ">=3.9"
 dependencies = [
-    "dask >=2023.7.1",
-    "distributed >=2023.7.1",
+    "dask ==2023.9.2",
+    "distributed ==2023.9.2",
     "pynvml >=11.0.0,<11.5",
     "numpy >=1.21",
     "numba >=0.57",


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.10` that creates a PR to keep `branch-23.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.