### PR TITLE
Reenable tests that were segfaulting

### DIFF
--- a/dask_cuda/tests/test_explicit_comms.py
+++ b/dask_cuda/tests/test_explicit_comms.py
@@ -164,8 +164,6 @@ def _test_dataframe_shuffle(backend, protocol, n_workers, _partitions):
 @pytest.mark.parametrize("_partitions", [True, False])
 def test_dataframe_shuffle(backend, protocol, nworkers, _partitions):
     if backend == "cudf":
-        pytest.skip("Temporarily disable due to segfaults in libaws-cpp-sdk-core.so")
-
         pytest.importorskip("cudf")
 
     p = mp.Process(
@@ -261,8 +259,6 @@ def _test_dataframe_shuffle_merge(backend, protocol, n_workers):
 @pytest.mark.parametrize("protocol", ["tcp", "ucx"])
 def test_dataframe_shuffle_merge(backend, protocol, nworkers):
     if backend == "cudf":
-        pytest.skip("Temporarily disable due to segfaults in libaws-cpp-sdk-core.so")
-
         pytest.importorskip("cudf")
     p = mp.Process(
         target=_test_dataframe_shuffle_merge, args=(backend, protocol, nworkers)


### PR DESCRIPTION
Some tests were previously disabled in https://github.com/rapidsai/dask-cuda/pull/1264 to prevent segfaults that should now be resolved after upgrading to Arrow 13.