### PR TITLE
Use new `rapids-dask-dependency` metapackage for managing dask versions

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -39,6 +39,7 @@ sed_runner "s/cudf=.*/cudf=${NEXT_SHORT_TAG}/g" dependencies.yaml
 sed_runner "s/dask-cudf=.*/dask-cudf=${NEXT_SHORT_TAG}/g" dependencies.yaml
 sed_runner "s/kvikio=.*/kvikio=${NEXT_SHORT_TAG}/g" dependencies.yaml
 sed_runner "s/ucx-py=.*/ucx-py=${NEXT_UCXPY_VERSION}/g" dependencies.yaml
+sed_runner "s/rapids-dask-dependency=.*/rapids-dask-dependency=${NEXT_SHORT_TAG}.*/g" dependencies.yaml
 
 # CI files
 for FILE in .github/workflows/*.yaml; do

--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -32,7 +32,6 @@ requirements:
     - tomli
   run:
     - python
-    - dask-core >=2023.9.2
     {% for r in data.get("project", {}).get("dependencies", []) %}
     - {{ r }}
     {% endfor %}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -105,7 +105,7 @@ dependencies:
           - numpy>=1.21
           - pandas>=1.3,<1.6.0dev0
           - pynvml>=11.0.0,<11.5
-          - rapids-dask-dependency==23.12.00.*
+          - rapids-dask-dependency==23.12.*
           - zict>=2.0.0
   test_python:
     common:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -101,8 +101,6 @@ dependencies:
     common:
       - output_types: [conda, requirements]
         packages:
-          - dask>=2023.9.2
-          - distributed>=2023.9.2
           - numba>=0.57
           - numpy>=1.21
           - pandas>=1.3,<1.6.0dev0
@@ -110,7 +108,10 @@ dependencies:
           - zict>=2.0.0
       - output_types: [conda]
         packages:
-          - dask-core>=2023.9.2
+          - rapids-dask-dependency==23.12.00.*
+      - output_types: [requirements]
+        packages:
+          - rapids-dask-dependency==23.12.*
   test_python:
     common:
       - output_types: [conda]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -105,13 +105,8 @@ dependencies:
           - numpy>=1.21
           - pandas>=1.3,<1.6.0dev0
           - pynvml>=11.0.0,<11.5
-          - zict>=2.0.0
-      - output_types: [conda]
-        packages:
           - rapids-dask-dependency==23.12.00.*
-      - output_types: [requirements]
-        packages:
-          - rapids-dask-dependency==23.12.*
+          - zict>=2.0.0
   test_python:
     common:
       - output_types: [conda]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,11 @@ authors = [
 license = { text = "Apache-2.0" }
 requires-python = ">=3.9"
 dependencies = [
-    "dask >=2023.9.2",
-    "distributed >=2023.9.2",
     "pynvml >=11.0.0,<11.5",
     "numpy >=1.21",
     "numba >=0.57",
     "pandas >=1.3,<1.6.0dev0",
+    "rapids-dask-dependency==23.12.*",
     "zict >=2.0.0",
 ]
 classifiers = [


### PR DESCRIPTION
Currently dask versions are pinned as part of every release cycle and then unpinned for the next development cycle across all of RAPIDS. This introduces a great deal of churn. To centralize the dependency, we have created a metapackage to manage the required dask version and this PR introduces that metapackage as a dependency of dask-cuda.

xref: https://github.com/rapidsai/cudf/pull/14364