### PR TITLE
Forward-merge branch-23.12 to branch-24.02

### DIFF
--- a/ci/build_python_pypi.sh
+++ b/ci/build_python_pypi.sh
@@ -17,6 +17,16 @@ if ! rapids-is-release-build; then
   export PACKAGE_VERSION_NUMBER="${version}"
 fi
 
+# For nightlies we want to ensure that we're pulling in alphas as well. The
+# easiest way to do so is to augment the spec with a constraint containing a
+# min alpha version that doesn't affect the version bounds but does allow usage
+# of alpha versions for that dependency without --pre
+alpha_spec=''
+if ! rapids-is-release-build; then
+    alpha_spec=',>=0.0.0a0'
+fi
+
+sed -r -i "s/rapids-dask-dependency==(.*)\"/rapids-dask-dependency==\1${alpha_spec}\"/g" pyproject.toml
 
 echo "${version}" | tr -d '"' > VERSION
 sed -i "/^__git_commit__/ s/= .*/= \"${commit}\"/g" "${package_name}/_version.py"

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -39,6 +39,7 @@ sed_runner "s/cudf=.*/cudf=${NEXT_SHORT_TAG}/g" dependencies.yaml
 sed_runner "s/dask-cudf=.*/dask-cudf=${NEXT_SHORT_TAG}/g" dependencies.yaml
 sed_runner "s/kvikio=.*/kvikio=${NEXT_SHORT_TAG}/g" dependencies.yaml
 sed_runner "s/ucx-py=.*/ucx-py=${NEXT_UCXPY_VERSION}/g" dependencies.yaml
+sed_runner "s/rapids-dask-dependency=.*/rapids-dask-dependency=${NEXT_SHORT_TAG}.*/g" dependencies.yaml
 
 # CI files
 for FILE in .github/workflows/*.yaml; do

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -55,7 +55,7 @@ timeout 60m pytest \
   --cov=dask_cuda \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/dask-cuda-coverage.xml" \
   --cov-report=term \
-  tests
+  tests -k "not ucxx"
 popd
 
 rapids-logger "Run local benchmark"

--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -32,7 +32,6 @@ requirements:
     - tomli
   run:
     - python
-    - dask-core >=2023.9.2
     {% for r in data.get("project", {}).get("dependencies", []) %}
     - {{ r }}
     {% endfor %}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -101,16 +101,12 @@ dependencies:
     common:
       - output_types: [conda, requirements]
         packages:
-          - dask>=2023.9.2
-          - distributed>=2023.9.2
           - numba>=0.57
           - numpy>=1.21
           - pandas>=1.3,<1.6.0dev0
           - pynvml>=11.0.0,<11.5
+          - rapids-dask-dependency==23.12.*
           - zict>=2.0.0
-      - output_types: [conda]
-        packages:
-          - dask-core>=2023.9.2
   test_python:
     common:
       - output_types: [conda]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,11 @@ authors = [
 license = { text = "Apache-2.0" }
 requires-python = ">=3.9"
 dependencies = [
-    "dask >=2023.9.2",
-    "distributed >=2023.9.2",
     "pynvml >=11.0.0,<11.5",
     "numpy >=1.21",
     "numba >=0.57",
     "pandas >=1.3,<1.6.0dev0",
+    "rapids-dask-dependency==23.12.*",
     "zict >=2.0.0",
 ]
 classifiers = [


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.12` that creates a PR to keep `branch-24.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.