### PR TITLE
Fix rapids dask dependency version

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -105,7 +105,7 @@ dependencies:
           - numpy>=1.21
           - pandas>=1.3,<1.6.0dev0
           - pynvml>=11.0.0,<11.5
-          - rapids-dask-dependency==23.12.*
+          - rapids-dask-dependency=24.02.*
           - zict>=2.0.0
   test_python:
     common:


### PR DESCRIPTION
I tried running update-version.sh and it properly updated the version, so my guess is that there was some race condition between when the script was updated and when it was run causing the version in pyproject.toml to not be properly updated.