### PR TITLE
Update to Dask's `shuffle_method` kwarg

### DIFF
--- a/dask_cuda/explicit_comms/dataframe/shuffle.py
+++ b/dask_cuda/explicit_comms/dataframe/shuffle.py
@@ -577,7 +577,7 @@ def get_rearrange_by_column_wrapper(func):
             kw = kw.arguments
             # Notice, we only overwrite the default and the "tasks" shuffle
             # algorithm. The "disk" and "p2p" algorithm, we don't touch.
-            if kw["shuffle"] in ("tasks", None):
+            if kw["shuffle_method"] in ("tasks", None):
                 col = kw["col"]
                 if isinstance(col, str):
                     col = [col]

--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -403,7 +403,7 @@ async def test_compatibility_mode_dataframe_shuffle(compatibility_mode, npartiti
                 ddf = dask.dataframe.from_pandas(
                     cudf.DataFrame({"key": np.arange(10)}), npartitions=npartitions
                 )
-                res = ddf.shuffle(on="key", shuffle="tasks").persist()
+                res = ddf.shuffle(on="key", shuffle_method="tasks").persist()
 
                 # With compatibility mode on, we shouldn't encounter any proxy objects
                 if compatibility_mode:


### PR DESCRIPTION
https://github.com/dask/dask/pull/10738 has deprecated the `shuffle` kwarg in favor of `shuffle_method` which now raises a `FutureWarning`. This change transitions to the new kwarg.

Requires https://github.com/rapidsai/cudf/pull/14708 .