### PR TITLE
Prevent double UCX initialization in `test_dgx`

### DIFF
--- a/dask_cuda/tests/test_dgx.py
+++ b/dask_cuda/tests/test_dgx.py
@@ -144,6 +144,10 @@ def _test_ucx_infiniband_nvlink(
     else:
         skip_queue.put("ok")
 
+    # `ucp.get_active_transports()` call above initializes UCX, we must reset it
+    # so that Dask doesn't try to initialize it again and raise an exception.
+    ucp.reset()
+
     if enable_infiniband is None and enable_nvlink is None and enable_rdmacm is None:
         enable_tcp_over_ucx = None
         cm_tls = ["all"]


### PR DESCRIPTION
Double initialization of UCX context may raise exceptions and cause test failures, prevent that by reseting the context after doing some initial checks.