### PR TITLE
refactor CUDA versions in dependencies.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
                 args: ["--module=dask_cuda", "--ignore-missing-imports"]
                 pass_filenames: false
       - repo: https://github.com/rapidsai/dependency-file-generator
-        rev: v1.5.1
+        rev: v1.8.0
         hooks:
             - id: rapids-dependency-file-generator
               args: ["--clean"]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -87,6 +87,10 @@ dependencies:
             packages:
               - cuda-version=11.4
           - matrix:
+              cuda: "11.5"
+            packages:
+              - cuda-version=11.5
+          - matrix:
               cuda: "11.8"
             packages:
               - cuda-version=11.8

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -7,7 +7,8 @@ files:
       arch: [x86_64]
     includes:
       - build_python
-      - cudatoolkit
+      - cuda
+      - cuda_version
       - develop
       - docs
       - py_version
@@ -16,7 +17,8 @@ files:
   test_python:
     output: none
     includes:
-      - cudatoolkit
+      - cuda
+      - cuda_version
       - py_version
       - test_python
   checks:
@@ -27,7 +29,8 @@ files:
   docs:
     output: none
     includes:
-      - cudatoolkit
+      - cuda
+      - cuda_version
       - docs
       - py_version
   py_build:
@@ -75,34 +78,33 @@ dependencies:
       - output_types: pyproject
         packages:
           - tomli ; python_version < '3.11'
-  cudatoolkit:
+  cuda_version:
     specific:
       - output_types: conda
         matrices:
           - matrix:
-              cuda: "11.2"
-            packages:
-              - cuda-version=11.2
-              - cudatoolkit
-          - matrix:
               cuda: "11.4"
             packages:
               - cuda-version=11.4
-              - cudatoolkit
-          - matrix:
-              cuda: "11.5"
-            packages:
-              - cuda-version=11.5
-              - cudatoolkit
           - matrix:
               cuda: "11.8"
             packages:
               - cuda-version=11.8
-              - cudatoolkit
           - matrix:
               cuda: "12.0"
             packages:
               - cuda-version=12.0
+  cuda:
+    specific:
+      - output_types: conda
+        matrices:
+          - matrix:
+              cuda: "11.*"
+            packages:
+              - cudatoolkit
+          - matrix:
+              cuda: "12.*"
+            packages:
               - cuda-nvcc-impl
               - cuda-nvrtc
   develop:


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/7.

Proposes splitting the `cuda-version` dependency in `dependencies.yaml` out to its own thing, separate from the bits of the CUDA Toolkit this project needs.

### Benefits of this change

* prevents accidental inclusion of multiple `cuda-version` version in environments
* reduces update effort (via enabling more use of globs like `"12.*"`)
* improves the chance that errors like "`conda` recipe is missing a dependency" are caught in CI