### PR TITLE
handle more RAPIDS version formats in update-version.sh

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -35,13 +35,21 @@ function sed_runner() {
 # Centralized version file update
 echo "${NEXT_FULL_TAG}" | tr -d '"' > VERSION
 
-# Bump cudf and dask-cudf testing dependencies
-sed_runner "s/cudf==.*/cudf==${NEXT_SHORT_TAG_PEP440}.*/g" dependencies.yaml
-sed_runner "s/dask-cudf==.*/dask-cudf==${NEXT_SHORT_TAG_PEP440}.*/g" dependencies.yaml
-sed_runner "s/kvikio==.*/kvikio==${NEXT_SHORT_TAG_PEP440}.*/g" dependencies.yaml
+# Bump testing dependencies
 sed_runner "s/ucx-py==.*/ucx-py==${NEXT_UCXPY_VERSION}.*/g" dependencies.yaml
 sed_runner "s/ucxx==.*/ucxx==${NEXT_UCXPY_VERSION}.*/g" dependencies.yaml
-sed_runner "s/rapids-dask-dependency==.*/rapids-dask-dependency==${NEXT_SHORT_TAG_PEP440}.*/g" dependencies.yaml
+
+DEPENDENCIES=(
+  cudf
+  dask-cudf
+  kvikio
+  rapids-dask-dependency
+)
+for FILE in dependencies.yaml conda/environments/*.yaml; do
+  for DEP in "${DEPENDENCIES[@]}"; do
+    sed_runner "/-.* ${DEP}\(-cu[[:digit:]]\{2\}\)\{0,1\}==/ s/==.*/==${NEXT_SHORT_TAG_PEP440}.*/g" "${FILE}"
+  done
+done
 
 # CI files
 for FILE in .github/workflows/*.yaml; do


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/13.

Updates `update-version.sh` to correctly handle RAPIDS dependencies like `cudf-cu12==24.2.*`.

This project doesn't appear to have any of those right now, but might in the future.

### How I tested this

The portability of this updated `sed` command was tested here: https://github.com/rapidsai/cudf/pull/14825#issuecomment-1904735849.

In this repo, I ran the following:

```shell
./ci/release/update-version.sh '23.10.00'
git diff

./ci/release/update-version.sh '24.04.00'
git diff
```

Confirmed that that first `git diff` changed all the things I expected, and that second one showed 0 changes.