### PR TITLE
Allow using pandas 2

### DIFF
--- a/conda/environments/all_cuda-114_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-114_arch-x86_64.yaml
@@ -18,7 +18,7 @@ dependencies:
 - numba>=0.57
 - numpy>=1.21
 - numpydoc>=1.1.0
-- pandas>=1.3,<1.6.0.dev0
+- pandas>=1.3
 - pre-commit
 - pynvml>=11.0.0,<11.5
 - pytest

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -18,7 +18,7 @@ dependencies:
 - numba>=0.57
 - numpy>=1.21
 - numpydoc>=1.1.0
-- pandas>=1.3,<1.6.0.dev0
+- pandas>=1.3
 - pre-commit
 - pynvml>=11.0.0,<11.5
 - pytest

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -19,7 +19,7 @@ dependencies:
 - numba>=0.57
 - numpy>=1.21
 - numpydoc>=1.1.0
-- pandas>=1.3,<1.6.0.dev0
+- pandas>=1.3
 - pre-commit
 - pynvml>=11.0.0,<11.5
 - pytest

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -146,7 +146,7 @@ dependencies:
           - click >=8.1
           - numba>=0.57
           - numpy>=1.21
-          - pandas>=1.3,<1.6.0.dev0
+          - pandas>=1.3
           - pynvml>=11.0.0,<11.5
           - rapids-dask-dependency==24.4.*
           - zict>=2.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "click >=8.1",
     "numba>=0.57",
     "numpy>=1.21",
-    "pandas>=1.3,<1.6.0.dev0",
+    "pandas>=1.3",
     "pynvml>=11.0.0,<11.5",
     "rapids-dask-dependency==24.4.*",
     "zict>=2.0.0",


### PR DESCRIPTION
dask-cuda uses pandas for some tests, but the main reason for the pinning is that it is inherited from RAPIDS libraries (mainly cudf) that do not yet support pandas 2.0 and are the primary use case for dask-cuda. However, there is no reason dask-cuda cannot be used in other contexts, so relaxing this constraint makes sense.

Resolves #1306 