### PR TITLE
Filter dd deprecation

### DIFF
--- a/dask_cuda/__init__.py
+++ b/dask_cuda/__init__.py
@@ -4,7 +4,8 @@ import warnings
 if sys.platform != "linux":
     raise ImportError("Only Linux is supported by Dask-CUDA at this time")
 
-# This warning is not specific to dask-cuda
+# This warning must be filtered until dask-expr support
+# is enabled in both dask-cudf and dask-cuda.
 # See: https://github.com/rapidsai/dask-cuda/issues/1311
 warnings.filterwarnings(
     "ignore",

--- a/dask_cuda/__init__.py
+++ b/dask_cuda/__init__.py
@@ -1,16 +1,7 @@
 import sys
-import warnings
 
 if sys.platform != "linux":
     raise ImportError("Only Linux is supported by Dask-CUDA at this time")
-
-# This warning must be filtered until dask-expr support
-# is enabled in both dask-cudf and dask-cuda.
-# See: https://github.com/rapidsai/dask-cuda/issues/1311
-warnings.filterwarnings(
-    "ignore",
-    message="The current Dask DataFrame implementation is deprecated.",
-)
 
 import dask
 import dask.utils

--- a/dask_cuda/__init__.py
+++ b/dask_cuda/__init__.py
@@ -1,8 +1,15 @@
 import sys
+import warnings
 
 if sys.platform != "linux":
     raise ImportError("Only Linux is supported by Dask-CUDA at this time")
 
+# This warning is not specific to dask-cuda
+# See: https://github.com/rapidsai/dask-cuda/issues/1311
+warnings.filterwarnings(
+    "ignore",
+    message="The current Dask DataFrame implementation is deprecated.",
+)
 
 import dask
 import dask.utils

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,10 @@ filterwarnings = [
     "error::FutureWarning",
     # remove after https://github.com/rapidsai/dask-cuda/issues/1087 is closed
     "ignore:There is no current event loop:DeprecationWarning:tornado",
+    # This warning must be filtered until dask-expr support
+    # is enabled in both dask-cudf and dask-cuda.
+    # See: https://github.com/rapidsai/dask-cuda/issues/1311
+    "ignore:Dask DataFrame implementation is deprecated:DeprecationWarning",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
Dask CUDA must use the deprecated `dask.dataframe` API until https://github.com/rapidsai/dask-cuda/issues/1311 and https://github.com/rapidsai/cudf/issues/15027 are both closed. This means that we must explicitly filter the following deprecation warning to avoid nighlty CI failures:

```
DeprecationWarning: The current Dask DataFrame implementation is deprecated. 
In a future release, Dask DataFrame will use new implementation that
contains several improvements including a logical query planning.
The user-facing DataFrame API will remain unchanged.

The new implementation is already available and can be enabled by
installing the dask-expr library:

    $ pip install dask-expr

and turning the query planning option on:

    >>> import dask
    >>> dask.config.set({'dataframe.query-planning': True})
    >>> import dask.dataframe as dd

API documentation for the new implementation is available at
https://docs.dask.org/en/stable/dask-expr-api.html

Any feedback can be reported on the Dask issue tracker
https://github.com/dask/dask/issues 

  import dask.dataframe as dd
```

This PR adds the (temporarily) necessary warning filter.