### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,7 +67,7 @@ jobs:
       date: ${{ inputs.date }}
       script: ci/build_wheel.sh
       # Package is pure Python and only ever requires one build.
-      matrix_filter: map(select(.ARCH == "amd64" and .PY_VER == "3.10" and .CUDA_VER == "12.2.2"))
+      matrix_filter: map(select(.ARCH == "amd64" and .PY_VER == "3.11" and .CUDA_VER == "12.2.2"))
   wheel-publish:
     needs: wheel-build
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -50,5 +50,5 @@ jobs:
     with:
       build_type: pull-request
       # Package is pure Python and only ever requires one build.
-      matrix_filter: map(select(.ARCH == "amd64" and .PY_VER == "3.10" and .CUDA_VER == "12.2.2"))
+      matrix_filter: map(select(.ARCH == "amd64" and .PY_VER == "3.11" and .CUDA_VER == "12.2.2"))
       script: "ci/build_wheel.sh"

--- a/conda/environments/all_cuda-114_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-114_arch-x86_64.yaml
@@ -23,7 +23,7 @@ dependencies:
 - pynvml>=11.0.0,<11.5
 - pytest
 - pytest-cov
-- python>=3.9,<3.11
+- python>=3.9,<3.12
 - rapids-dask-dependency==24.4.*
 - setuptools>=64.0.0
 - sphinx

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -23,7 +23,7 @@ dependencies:
 - pynvml>=11.0.0,<11.5
 - pytest
 - pytest-cov
-- python>=3.9,<3.11
+- python>=3.9,<3.12
 - rapids-dask-dependency==24.4.*
 - setuptools>=64.0.0
 - sphinx

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -24,7 +24,7 @@ dependencies:
 - pynvml>=11.0.0,<11.5
 - pytest
 - pytest-cov
-- python>=3.9,<3.11
+- python>=3.9,<3.12
 - rapids-dask-dependency==24.4.*
 - setuptools>=64.0.0
 - sphinx

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -141,8 +141,12 @@ dependencies:
             packages:
               - python=3.10
           - matrix:
+              py: "3.11"
             packages:
-              - python>=3.9,<3.11
+              - python=3.11
+          - matrix:
+            packages:
+              - python>=3.9,<3.12
   run_python:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/3

This PR adds support for Python 3.11.

## Notes for Reviewers

This is part of ongoing work to add Python 3.11 support across RAPIDS.

The Python 3.11 CI workflows introduced in https://github.com/rapidsai/shared-workflows/pull/176 are *optional*... they are not yet required to run successfully for PRs to be merged.

This PR can be merged once all jobs are running successfully (including the non-required jobs for Python 3.11). The CI logs should be verified that the jobs are building and testing with Python 3.11.

See https://github.com/rapidsai/shared-workflows/pull/176 for more details.
