### PR TITLE
Generalize GHA selectors for pure Python testing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,7 +67,8 @@ jobs:
       date: ${{ inputs.date }}
       script: ci/build_wheel.sh
       # Package is pure Python and only ever requires one build.
-      matrix_filter: map(select(.ARCH == "amd64" and .PY_VER == "3.11" and .CUDA_VER == "12.2.2"))
+      # This selects "ARCH=amd64 + the latest supported Python + CUDA".
+      matrix_filter: map(select(.ARCH == "amd64")) | max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]) | [.]
   wheel-publish:
     needs: wheel-build
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -50,5 +50,6 @@ jobs:
     with:
       build_type: pull-request
       # Package is pure Python and only ever requires one build.
-      matrix_filter: map(select(.ARCH == "amd64" and .PY_VER == "3.11" and .CUDA_VER == "12.2.2"))
+      # This selects "ARCH=amd64 + the latest supported Python + CUDA".
+      matrix_filter: map(select(.ARCH == "amd64")) | max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]) | [.]
       script: "ci/build_wheel.sh"


### PR DESCRIPTION
To eliminate hard-coding, generalize the GHA workflow logic to select one build for testing. This should simplify future Dask-CUDA updates.

xref: https://github.com/rapidsai/build-planning/issues/25