### PR TITLE
Add upper bound to prevent usage of NumPy 2

### DIFF
--- a/conda/environments/all_cuda-114_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-114_arch-x86_64.yaml
@@ -16,7 +16,7 @@ dependencies:
 - kvikio==24.4.*
 - numactl-devel-cos7-x86_64
 - numba>=0.57
-- numpy>=1.23
+- numpy>=1.23,<2.0a0
 - numpydoc>=1.1.0
 - pandas>=1.3
 - pre-commit

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -16,7 +16,7 @@ dependencies:
 - kvikio==24.4.*
 - numactl-devel-cos7-x86_64
 - numba>=0.57
-- numpy>=1.23
+- numpy>=1.23,<2.0a0
 - numpydoc>=1.1.0
 - pandas>=1.3
 - pre-commit

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - kvikio==24.4.*
 - numactl-devel-cos7-x86_64
 - numba>=0.57
-- numpy>=1.23
+- numpy>=1.23,<2.0a0
 - numpydoc>=1.1.0
 - pandas>=1.3
 - pre-commit

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -153,7 +153,7 @@ dependencies:
         packages:
           - click >=8.1
           - numba>=0.57
-          - numpy>=1.23
+          - numpy>=1.23,<2.0a0
           - pandas>=1.3
           - pynvml>=11.0.0,<11.5
           - rapids-dask-dependency==24.4.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ requires-python = ">=3.9"
 dependencies = [
     "click >=8.1",
     "numba>=0.57",
-    "numpy>=1.23",
+    "numpy>=1.23,<2.0a0",
     "pandas>=1.3",
     "pynvml>=11.0.0,<11.5",
     "rapids-dask-dependency==24.4.*",


### PR DESCRIPTION
NumPy 2 is expected to be released in the near future. For the RAPIDS 24.04 release, we will pin to `numpy>=1.23,<2.0a0`. This PR adds an upper bound to affected RAPIDS repositories.

xref: https://github.com/rapidsai/build-planning/issues/29
