### PR TITLE
Prevent path conflict in builds

### DIFF
--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -22,6 +22,7 @@ echo "${version}" | tr -d '"' > VERSION
 sed -i "/^__git_commit__/ s/= .*/= \"${commit}\"/g" "${package_name}/_version.py"
 
 rapids-logger "Begin py build"
+conda config --set path_conflict prevent
 
 RAPIDS_PACKAGE_VERSION=${version} rapids-conda-retry mambabuild \
   conda/recipes/dask-cuda


### PR DESCRIPTION
This will make builds fail when there are path conflicts
