### PR TITLE
Trap CI test errors with their original exit codes

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -35,7 +35,11 @@ rapids-logger "Check GPU usage"
 nvidia-smi
 
 EXITCODE=0
-trap "EXITCODE=1" ERR
+set_exit_code() {
+    EXITCODE=$?
+    rapids-logger "Test failed with error ${EXITCODE}"
+}
+trap set_exit_code ERR
 set +e
 
 rapids-logger "pytest dask-cuda"
@@ -71,5 +75,5 @@ python dask_cuda/benchmarks/local_cudf_shuffle.py \
   --runs 1 \
   --backend explicit-comms
 
-rapids-logger "Test script exiting with value: $EXITCODE"
+rapids-logger "Test script exiting with latest error code: $EXITCODE"
 exit ${EXITCODE}


### PR DESCRIPTION
Currently, each time an error occurs the CI test script will only trap the error code an switch it to a code `1` which is not representative of the underlying error that occurred. This makes it a bit difficult to identify the source of the error, particularly in cases where the test times out (exit code `124`) and there's no summary in the log.

This change captures and prints the last error code upon exit, but also logs all errors that may have occurred throughout execution where they occurred, thus facilitating debugging.