### PR TITLE
Fix license name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]
-license = { text = "Apache-2.0" }
+license = { text = "Apache 2.0" }
 requires-python = ">=3.9"
 dependencies = [
     "click >=8.1",


### PR DESCRIPTION
Just a small fix to the license name for our scanning tool and to [be consistent with other repositories](https://github.com/rapidsai/cudf/blob/branch-24.06/python/cudf/pyproject.toml#L23).