### PR TITLE
remove .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-dask_cuda/_version.py export-subst


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/31

Removes `.gitattributes` file.

That was added in #88 for use with `versioneer`. Per the `git` docs ([link](https://git-scm.com/docs/gitattributes#_export_subst)), setting the attribute `export-subst` on a file via a `.gitattributes` tell `git` to replace placeholders in the file with some `git` information.

This is no longer done in `_version.py` files in this project, and this project no longer uses `versioneer`. `rapids-build-backend` handles storing git commit information in the published packages.

## Notes for Reviewers

Created based on this conversation: https://github.com/rapidsai/kvikio/pull/369#discussion_r1644861520