### PR TITLE
Add arguments to enable cuDF spilling and set statistics

### DIFF
--- a/dask_cuda/cli.py
+++ b/dask_cuda/cli.py
@@ -113,7 +113,7 @@ def cuda():
     type=int,
     default=0,
     help="""Set the cuDF spilling statistics level. This option has no effect if
-    `--enable-cudf-spill` is not specified."""
+    `--enable-cudf-spill` is not specified.""",
 )
 @click.option(
     "--rmm-pool-size",

--- a/dask_cuda/cli.py
+++ b/dask_cuda/cli.py
@@ -102,6 +102,20 @@ def cuda():
     disable spilling to host (i.e. allow full device memory usage).""",
 )
 @click.option(
+    "--enable-cudf-spill/--disable-cudf-spill",
+    default=False,
+    show_default=True,
+    help="""Enable automatic cuDF spilling. WARNING: This should NOT be used with
+    JIT-Unspill.""",
+)
+@click.option(
+    "--cudf-spill-stats",
+    type=int,
+    default=0,
+    help="""Set the cuDF spilling statistics level. This option has no effect if
+    `--enable-cudf-spill` is not specified."""
+)
+@click.option(
     "--rmm-pool-size",
     default=None,
     help="""RMM pool size to initialize each worker with. Can be an integer (bytes),
@@ -330,6 +344,8 @@ def worker(
     name,
     memory_limit,
     device_memory_limit,
+    enable_cudf_spill,
+    cudf_spill_stats,
     rmm_pool_size,
     rmm_maximum_pool_size,
     rmm_managed_memory,
@@ -402,6 +418,8 @@ def worker(
             name,
             memory_limit,
             device_memory_limit,
+            enable_cudf_spill,
+            cudf_spill_stats,
             rmm_pool_size,
             rmm_maximum_pool_size,
             rmm_managed_memory,

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -168,6 +168,12 @@ class CUDAWorker(Server):
         if device_memory_limit is None and memory_limit is None:
             data = lambda _: {}
         elif jit_unspill:
+            if enable_cudf_spill:
+                warnings.warn(
+                    "Enabling cuDF spilling and JIT-Unspill together is not "
+                    "safe, consider disabling JIT-Unspill."
+                )
+
             data = lambda i: (
                 ProxifyHostFile,
                 {

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -20,7 +20,7 @@ from distributed.worker_memory import parse_memory_limit
 
 from .device_host_file import DeviceHostFile
 from .initialize import initialize
-from .plugins import CPUAffinity, PreImport, RMMSetup
+from .plugins import CPUAffinity, CUDFSetup, PreImport, RMMSetup
 from .proxify_host_file import ProxifyHostFile
 from .utils import (
     cuda_visible_devices,
@@ -41,6 +41,8 @@ class CUDAWorker(Server):
         name=None,
         memory_limit="auto",
         device_memory_limit="auto",
+        enable_cudf_spill=False,
+        cudf_spill_stats=0,
         rmm_pool_size=None,
         rmm_maximum_pool_size=None,
         rmm_managed_memory=False,
@@ -217,6 +219,7 @@ class CUDAWorker(Server):
                         track_allocations=rmm_track_allocations,
                     ),
                     PreImport(pre_import),
+                    CUDFSetup(spill=enable_cudf_spill, spill_stats=cudf_spill_stats),
                 },
                 name=name if nprocs == 1 or name is None else str(name) + "-" + str(i),
                 local_directory=local_directory,

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -314,6 +314,12 @@ class LocalCUDACluster(LocalCluster):
             if device_memory_limit is None and memory_limit is None:
                 data = {}
             elif jit_unspill:
+                if enable_cudf_spill:
+                    warnings.warn(
+                        "Enabling cuDF spilling and JIT-Unspill together is not "
+                        "safe, consider disabling JIT-Unspill."
+                    )
+
                 data = (
                     ProxifyHostFile,
                     {

--- a/dask_cuda/plugins.py
+++ b/dask_cuda/plugins.py
@@ -22,6 +22,7 @@ class CUDFSetup(WorkerPlugin):
     def setup(self, worker=None):
         try:
             import cudf
+
             cudf.set_option("spill", self.spill)
             cudf.set_option("spill_stats", self.spill_stats)
         except ImportError:

--- a/dask_cuda/plugins.py
+++ b/dask_cuda/plugins.py
@@ -14,6 +14,20 @@ class CPUAffinity(WorkerPlugin):
         os.sched_setaffinity(0, self.cores)
 
 
+class CUDFSetup(WorkerPlugin):
+    def __init__(self, spill, spill_stats):
+        self.spill = spill
+        self.spill_stats = spill_stats
+
+    def setup(self, worker=None):
+        try:
+            import cudf
+            cudf.set_option("spill", self.spill)
+            cudf.set_option("spill_stats", self.spill_stats)
+        except ImportError:
+            pass
+
+
 class RMMSetup(WorkerPlugin):
     def __init__(
         self,

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -249,14 +249,13 @@ def test_cudf_spill_disabled(loop):  # noqa: F811
                 assert wait_workers(client, n_gpus=get_n_gpus())
 
                 cudf_spill = client.run(
-                    cudf.get_option, "spill",
+                    cudf.get_option,
+                    "spill",
                 )
                 for v in cudf_spill.values():
                     assert v is False
 
-                cudf_spill_stats = client.run(
-                    cudf.get_option, "spill_stats"
-                )
+                cudf_spill_stats = client.run(cudf.get_option, "spill_stats")
                 for v in cudf_spill_stats.values():
                     assert v == 0
 
@@ -281,15 +280,11 @@ def test_cudf_spill(loop):  # noqa: F811
             with Client("127.0.0.1:9369", loop=loop) as client:
                 assert wait_workers(client, n_gpus=get_n_gpus())
 
-                cudf_spill = client.run(
-                    cudf.get_option, "spill"
-                )
+                cudf_spill = client.run(cudf.get_option, "spill")
                 for v in cudf_spill.values():
                     assert v is True
 
-                cudf_spill_stats = client.run(
-                    cudf.get_option, "spill_stats"
-                )
+                cudf_spill_stats = client.run(cudf.get_option, "spill_stats")
                 for v in cudf_spill_stats.values():
                     assert v == 2
 

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -231,6 +231,69 @@ def test_rmm_logging(loop):  # noqa: F811
                     assert v is rmm.mr.LoggingResourceAdaptor
 
 
+def test_cudf_spill_disabled(loop):  # noqa: F811
+    cudf = pytest.importorskip("cudf")
+    with popen(["dask", "scheduler", "--port", "9369", "--no-dashboard"]):
+        with popen(
+            [
+                "dask",
+                "cuda",
+                "worker",
+                "127.0.0.1:9369",
+                "--host",
+                "127.0.0.1",
+                "--no-dashboard",
+            ]
+        ):
+            with Client("127.0.0.1:9369", loop=loop) as client:
+                assert wait_workers(client, n_gpus=get_n_gpus())
+
+                cudf_spill = client.run(
+                    cudf.get_option, "spill",
+                )
+                for v in cudf_spill.values():
+                    assert v is False
+
+                cudf_spill_stats = client.run(
+                    cudf.get_option, "spill_stats"
+                )
+                for v in cudf_spill_stats.values():
+                    assert v == 0
+
+
+def test_cudf_spill(loop):  # noqa: F811
+    cudf = pytest.importorskip("cudf")
+    with popen(["dask", "scheduler", "--port", "9369", "--no-dashboard"]):
+        with popen(
+            [
+                "dask",
+                "cuda",
+                "worker",
+                "127.0.0.1:9369",
+                "--host",
+                "127.0.0.1",
+                "--no-dashboard",
+                "--enable-cudf-spill",
+                "--cudf-spill-stats",
+                "2",
+            ]
+        ):
+            with Client("127.0.0.1:9369", loop=loop) as client:
+                assert wait_workers(client, n_gpus=get_n_gpus())
+
+                cudf_spill = client.run(
+                    cudf.get_option, "spill"
+                )
+                for v in cudf_spill.values():
+                    assert v is True
+
+                cudf_spill_stats = client.run(
+                    cudf.get_option, "spill_stats"
+                )
+                for v in cudf_spill_stats.values():
+                    assert v == 2
+
+
 @patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0"})
 def test_dashboard_address(loop):  # noqa: F811
     with popen(["dask", "scheduler", "--port", "9369", "--no-dashboard"]):

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -509,13 +509,15 @@ async def test_cudf_spill_disabled():
     ) as cluster:
         async with Client(cluster, asynchronous=True) as client:
             cudf_spill = await client.run(
-                cudf.get_option, "spill",
+                cudf.get_option,
+                "spill",
             )
             for v in cudf_spill.values():
                 assert v is False
 
             cudf_spill_stats = await client.run(
-                cudf.get_option, "spill_stats",
+                cudf.get_option,
+                "spill_stats",
             )
             for v in cudf_spill_stats.values():
                 assert v == 0
@@ -532,13 +534,15 @@ async def test_cudf_spill():
     ) as cluster:
         async with Client(cluster, asynchronous=True) as client:
             cudf_spill = await client.run(
-                cudf.get_option, "spill",
+                cudf.get_option,
+                "spill",
             )
             for v in cudf_spill.values():
                 assert v is True
 
             cudf_spill_stats = await client.run(
-                cudf.get_option, "spill_stats",
+                cudf.get_option,
+                "spill_stats",
             )
             for v in cudf_spill_stats.values():
                 assert v == 2

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -500,6 +500,50 @@ async def test_worker_fraction_limits():
             )
 
 
+@gen_test(timeout=20)
+async def test_cudf_spill_disabled():
+    cudf = pytest.importorskip("cudf")
+
+    async with LocalCUDACluster(
+        asynchronous=True,
+    ) as cluster:
+        async with Client(cluster, asynchronous=True) as client:
+            cudf_spill = await client.run(
+                cudf.get_option, "spill",
+            )
+            for v in cudf_spill.values():
+                assert v is False
+
+            cudf_spill_stats = await client.run(
+                cudf.get_option, "spill_stats",
+            )
+            for v in cudf_spill_stats.values():
+                assert v == 0
+
+
+@gen_test(timeout=20)
+async def test_cudf_spill():
+    cudf = pytest.importorskip("cudf")
+
+    async with LocalCUDACluster(
+        enable_cudf_spill=True,
+        cudf_spill_stats=2,
+        asynchronous=True,
+    ) as cluster:
+        async with Client(cluster, asynchronous=True) as client:
+            cudf_spill = await client.run(
+                cudf.get_option, "spill",
+            )
+            for v in cudf_spill.values():
+                assert v is True
+
+            cudf_spill_stats = await client.run(
+                cudf.get_option, "spill_stats",
+            )
+            for v in cudf_spill_stats.values():
+                assert v == 2
+
+
 @pytest.mark.parametrize(
     "protocol",
     ["ucx", "ucxx"],


### PR DESCRIPTION
Add arguments to enable cuDF spilling and set statistics in `dask cuda worker`/`LocalCUDACluster`. This is implemented as a Dask plugin, and does not require users anymore to rely on `client.run` to do that.

Closes #1280 