### PR TITLE
consolidate cuda_suffixed=false blocks in dependencies.yaml, fix update-version.sh

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -58,7 +58,7 @@ UCX_DEPENDENCIES=(
   ucxx
 )
 for DEP in "${UCX_DEPENDENCIES[@]}"; do
-  for FILE in dependencies.yaml conda/environments/*.yaml; do 
+  for FILE in dependencies.yaml conda/environments/*.yaml; do
     sed_runner "/-.* ${DEP}\(-cu[[:digit:]]\{2\}\)\{0,1\}==/ s/==.*/==${NEXT_UCXPY_VERSION}.*,>=0.0.0a0/g" "${FILE}"
   done
   sed_runner "/\"${DEP}==/ s/==.*\"/==${NEXT_UCXPY_VERSION}.*,>=0.0.0a0\"/g" pyproject.toml

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -45,10 +45,23 @@ DEPENDENCIES=(
   kvikio
   rapids-dask-dependency
 )
-for FILE in dependencies.yaml conda/environments/*.yaml; do
-  for DEP in "${DEPENDENCIES[@]}"; do
+for DEP in "${DEPENDENCIES[@]}"; do
+  for FILE in dependencies.yaml conda/environments/*.yaml; do
     sed_runner "/-.* ${DEP}\(-cu[[:digit:]]\{2\}\)\{0,1\}==/ s/==.*/==${NEXT_SHORT_TAG_PEP440}.*,>=0.0.0a0/g" "${FILE}"
   done
+  sed_runner "/\"${DEP}==/ s/==.*\"/==${NEXT_SHORT_TAG_PEP440}.*,>=0.0.0a0\"/g" pyproject.toml
+done
+
+UCX_DEPENDENCIES=(
+  distributed-ucxx
+  ucx-py
+  ucxx
+)
+for DEP in "${UCX_DEPENDENCIES[@]}"; do
+  for FILE in dependencies.yaml conda/environments/*.yaml; do 
+    sed_runner "/-.* ${DEP}\(-cu[[:digit:]]\{2\}\)\{0,1\}==/ s/==.*/==${NEXT_UCXPY_VERSION}.*,>=0.0.0a0/g" "${FILE}"
+  done
+  sed_runner "/\"${DEP}==/ s/==.*\"/==${NEXT_UCXPY_VERSION}.*,>=0.0.0a0\"/g" pyproject.toml
 done
 
 # CI files

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -168,11 +168,11 @@ dependencies:
           - pytest-cov
       - output_types: [conda]
         packages:
-          - &cudf_conda cudf==24.8.*,>=0.0.0a0
-          - &dask_cudf_conda dask-cudf==24.8.*,>=0.0.0a0
+          - &cudf_unsuffixed cudf==24.8.*,>=0.0.0a0
+          - &dask_cudf_unsuffixed dask-cudf==24.8.*,>=0.0.0a0
           - distributed-ucxx==0.39.*,>=0.0.0a0
-          - &kvikio_conda kvikio==24.8.*,>=0.0.0a0
-          - &ucx_py_conda ucx-py==0.39.*,>=0.0.0a0
+          - &kvikio_unsuffixed kvikio==24.8.*,>=0.0.0a0
+          - &ucx_py_unsuffixed ucx-py==0.39.*,>=0.0.0a0
           - ucx-proc=*=gpu
           - ucxx==0.39.*,>=0.0.0a0
     specific:
@@ -198,13 +198,6 @@ dependencies:
               - dask-cudf-cu12==24.8.*,>=0.0.0a0
               - ucx-py-cu12==0.39.*,>=0.0.0a0
           - matrix:
-              cuda: "12.*"
-              cuda_suffixed: "false"
-            packages:
-              - *cudf_conda
-              - *dask_cudf_conda
-              - *ucx_py_conda
-          - matrix:
               cuda: "11.*"
               cuda_suffixed: "true"
             packages:
@@ -212,15 +205,8 @@ dependencies:
               - dask-cudf-cu11==24.8.*,>=0.0.0a0
               - ucx-py-cu11==0.39.*,>=0.0.0a0
           - matrix:
-              cuda: "11.*"
-              cuda_suffixed: "false"
             packages:
-              - *cudf_conda
-              - *dask_cudf_conda
-              - *ucx_py_conda
-          - matrix:
-            packages:
-              - *cudf_conda
-              - *dask_cudf_conda
-              - *kvikio_conda
-              - *ucx_py_conda
+              - *cudf_unsuffixed
+              - *dask_cudf_unsuffixed
+              - *kvikio_unsuffixed
+              - *ucx_py_unsuffixed


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/31.

Follow-up to #1364.

Implements some of the suggestions made in https://github.com/rapidsai/cudf/pull/16183 (after #1364 was already merged):

* removing `cuda_suffixed: "false"` blocks in `dependencies.yaml` wherever they're identical to each other and the fallback matrix
* changing `dependencies.yaml` anchors with names like `*_conda` to `*_unsuffixed`, to reflect the fact that they're not conda-specific
* checking that `update-version.sh` catches all changes to versions

## Notes for Reviewers

### How I tested this

Looked for `update-versions.sh` issues manually like this:

```shell
git fetch upstream --tags
ci/release/update-version.sh '24.10.0'
git grep -E '24\.8|24\.08|0\.39'
```

The did find a few problems (like UCX dependency versions not being updated). This fixes those issues.