### PR TITLE
Remove NumPy <2 pin

### DIFF
--- a/conda/environments/all_cuda-114_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-114_arch-x86_64.yaml
@@ -16,7 +16,7 @@ dependencies:
 - kvikio==24.10.*,>=0.0.0a0
 - numactl-devel-cos7-x86_64
 - numba>=0.57
-- numpy>=1.23,<2.0a0
+- numpy>=1.23,<3
 - numpydoc>=1.1.0
 - pandas>=1.3
 - pre-commit

--- a/conda/environments/all_cuda-114_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-114_arch-x86_64.yaml
@@ -16,7 +16,7 @@ dependencies:
 - kvikio==24.10.*,>=0.0.0a0
 - numactl-devel-cos7-x86_64
 - numba>=0.57
-- numpy>=1.23,<3
+- numpy>=1.23,<3.0a0
 - numpydoc>=1.1.0
 - pandas>=1.3
 - pre-commit

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -16,7 +16,7 @@ dependencies:
 - kvikio==24.10.*,>=0.0.0a0
 - numactl-devel-cos7-x86_64
 - numba>=0.57
-- numpy>=1.23,<2.0a0
+- numpy>=1.23,<3
 - numpydoc>=1.1.0
 - pandas>=1.3
 - pre-commit

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -16,7 +16,7 @@ dependencies:
 - kvikio==24.10.*,>=0.0.0a0
 - numactl-devel-cos7-x86_64
 - numba>=0.57
-- numpy>=1.23,<3
+- numpy>=1.23,<3.0a0
 - numpydoc>=1.1.0
 - pandas>=1.3
 - pre-commit

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - kvikio==24.10.*,>=0.0.0a0
 - numactl-devel-cos7-x86_64
 - numba>=0.57
-- numpy>=1.23,<3
+- numpy>=1.23,<3.0a0
 - numpydoc>=1.1.0
 - pandas>=1.3
 - pre-commit

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - kvikio==24.10.*,>=0.0.0a0
 - numactl-devel-cos7-x86_64
 - numba>=0.57
-- numpy>=1.23,<2.0a0
+- numpy>=1.23,<3
 - numpydoc>=1.1.0
 - pandas>=1.3
 - pre-commit

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -155,7 +155,7 @@ dependencies:
         packages:
           - click >=8.1
           - numba>=0.57
-          - numpy>=1.23,<3
+          - numpy>=1.23,<3.0a0
           - pandas>=1.3
           - pynvml>=11.0.0,<11.5
           - rapids-dask-dependency==24.10.*,>=0.0.0a0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -155,7 +155,7 @@ dependencies:
         packages:
           - click >=8.1
           - numba>=0.57
-          - numpy>=1.23,<2.0a0
+          - numpy>=1.23,<3
           - pandas>=1.3
           - pynvml>=11.0.0,<11.5
           - rapids-dask-dependency==24.10.*,>=0.0.0a0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ requires-python = ">=3.9"
 dependencies = [
     "click >=8.1",
     "numba>=0.57",
-    "numpy>=1.23,<3",
+    "numpy>=1.23,<3.0a0",
     "pandas>=1.3",
     "pynvml>=11.0.0,<11.5",
     "rapids-dask-dependency==24.10.*,>=0.0.0a0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ requires-python = ">=3.9"
 dependencies = [
     "click >=8.1",
     "numba>=0.57",
-    "numpy>=1.23,<2.0a0",
+    "numpy>=1.23,<3",
     "pandas>=1.3",
     "pynvml>=11.0.0,<11.5",
     "rapids-dask-dependency==24.10.*,>=0.0.0a0",


### PR DESCRIPTION
This PR removes the NumPy<2 pin which is expected to work for
RAPIDS projects once CuPy 13.3.0 is released (CuPy 13.2.0 had
some issues preventing the use with NumPy 2).
