### PR TITLE
enable Python 3.12 tests on PRs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -34,9 +34,6 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@python-3.12
     with:
       build_type: pull-request
-      # TODO: remove this matrix_filter once there are Python 3.12 ucxx and cudf wheels
-      #       (this helps publish dask-cuda wheels to resolve a circular dependency between those projects)
-      matrix_filter: map(select(.PY_VER != "3.12"))
   docs-build:
     needs: conda-python-build
     secrets: inherit


### PR DESCRIPTION
Follow-up to #1380.

Now that both `cudf` (https://github.com/rapidsai/cudf/pull/16745) and `ucxx` (https://github.com/rapidsai/ucxx/pull/276) have Python 3.12 wheels available, it should be possible to test `dask-cuda` against Python 3.12 in CI.

This proposes that.