### PR TITLE
Add notes on cudf spilling to docs

### DIFF
--- a/docs/source/examples/best-practices.rst
+++ b/docs/source/examples/best-practices.rst
@@ -44,6 +44,14 @@ We also recommend allocating most, though not all, of the GPU memory space. We d
 
 Additionally, when using `Accelerated Networking`_ , we only need to register a single IPC handle for the whole pool (which is expensive, but only done once) since from the IPC point of viewer there's only a single allocation. As opposed to just using RMM without a pool where each new allocation must be registered with IPC.
 
+Spilling from Device
+~~~~~~~~~~~~~~~~~~~~
+
+Dask CUDA offers several different ways to enable automatic spilling from device memory.
+The best method often depends on the specific workflow. For classic ETL workloads with
+`Dask cuDF <https://docs.rapids.ai/api/dask-cudf/stable/>`_, cuDF spilling is usually
+the best place to start. See `spilling`_ for more details.
+
 Accelerated Networking
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/examples/best-practices.rst
+++ b/docs/source/examples/best-practices.rst
@@ -48,8 +48,8 @@ Spilling from Device
 ~~~~~~~~~~~~~~~~~~~~
 
 Dask-CUDA offers several different ways to enable automatic spilling from device memory.
-The best method often depends on the specific workflow. For classic ETL workloads with
-`Dask-cuDF <https://docs.rapids.ai/api/dask-cudf/stable/>`_, cuDF spilling is usually the
+The best method often depends on the specific workflow. For classic ETL workloads using
+`Dask cuDF <https://docs.rapids.ai/api/dask-cudf/stable/>`_, cuDF spilling is usually the
 best place to start. See :ref:`Spilling from device <spilling-from-device>` for more details.
 
 Accelerated Networking

--- a/docs/source/examples/best-practices.rst
+++ b/docs/source/examples/best-practices.rst
@@ -49,8 +49,8 @@ Spilling from Device
 
 Dask-CUDA offers several different ways to enable automatic spilling from device memory.
 The best method often depends on the specific workflow. For classic ETL workloads with
-`Dask cuDF <https://docs.rapids.ai/api/dask-cudf/stable/>`_, cuDF spilling is usually
-the best place to start. See `spilling`_ for more details.
+`Dask-cuDF <https://docs.rapids.ai/api/dask-cudf/stable/>`_, cuDF spilling is usually the
+best place to start. See :ref:`Spilling from device <spilling-from-device>` for more details.
 
 Accelerated Networking
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/examples/best-practices.rst
+++ b/docs/source/examples/best-practices.rst
@@ -47,7 +47,7 @@ Additionally, when using `Accelerated Networking`_ , we only need to register a 
 Spilling from Device
 ~~~~~~~~~~~~~~~~~~~~
 
-Dask CUDA offers several different ways to enable automatic spilling from device memory.
+Dask-CUDA offers several different ways to enable automatic spilling from device memory.
 The best method often depends on the specific workflow. For classic ETL workloads with
 `Dask cuDF <https://docs.rapids.ai/api/dask-cudf/stable/>`_, cuDF spilling is usually
 the best place to start. See `spilling`_ for more details.

--- a/docs/source/spilling.rst
+++ b/docs/source/spilling.rst
@@ -112,9 +112,9 @@ to enable compatibility mode, which automatically calls ``unproxy()`` on all fun
 cuDF Spilling
 -------------
 
-When executing a `Dask-cuDF <https://docs.rapids.ai/api/dask-cudf/stable/>`_
-(i.e. Dask DataFrame) ETL workflow, it is usually best to leverage `native spilling support in
-cuDF <https://docs.rapids.ai/api/cudf/stable/developer_guide/library_design/#spilling-to-host-memory>`.
+When executing an ETL workflow with `Dask cuDF <https://docs.rapids.ai/api/dask-cudf/stable/>`_
+(i.e. Dask DataFrame), it is usually best to leverage `native spilling support in cuDF
+<https://docs.rapids.ai/api/cudf/stable/developer_guide/library_design/#spilling-to-host-memory>`.
 
 Native cuDF spilling has an important advantage over the other methodologies mentioned
 above. When JIT-unspill or default spilling are used, the worker is only able to spill
@@ -148,7 +148,7 @@ Statistics
 
 When cuDF spilling is enabled, it is also possible to have cuDF collect basic
 spill statistics. Collecting this information can be a useful way to understand
-the performance of Dask-cuDF workflows with high memory utilization.
+the performance of memory-intensive workflows using cuDF.
 
 When deploying a ``LocalCUDACluster``, cuDF spilling can be enabled with the
 ``cudf_spill_stats`` argument:
@@ -179,7 +179,7 @@ for more information on the available spill-statistics options.
 Limitations
 ~~~~~~~~~~~
 
-Although cuDF spilling is the best option for most Dask-cuDF ETL workflows,
+Although cuDF spilling is the best option for most ETL workflows using Dask cuDF,
 it will be much less effective if that workflow converts between ``cudf.DataFrame``
 and other data formats (e.g. ``cupy.ndarray``). Once the underlying device buffers
 are "exposed" to external memory references, they become "unspillable" by cuDF.

--- a/docs/source/spilling.rst
+++ b/docs/source/spilling.rst
@@ -1,3 +1,5 @@
+.. _spilling-from-device:
+
 Spilling from device
 ====================
 
@@ -110,7 +112,7 @@ to enable compatibility mode, which automatically calls ``unproxy()`` on all fun
 cuDF Spilling
 -------------
 
-When executing a `Dask cuDF <https://docs.rapids.ai/api/dask-cudf/stable/>`_
+When executing a `Dask-cuDF <https://docs.rapids.ai/api/dask-cudf/stable/>`_
 (i.e. Dask DataFrame) ETL workflow, it is usually best to leverage `native spilling support in
 cuDF <https://docs.rapids.ai/api/cudf/stable/developer_guide/library_design/#spilling-to-host-memory>`.
 
@@ -145,14 +147,23 @@ Statistics
 ~~~~~~~~~~
 
 When cuDF spilling is enabled, it is also possible to have cuDF collect basic
-spill statistics. This information can be a useful way to understand the
-performance of Dask cuDF workflows with high memory utilization:
+spill statistics. Collecting this information can be a useful way to understand
+the performance of Dask-cuDF workflows with high memory utilization.
+
+When deploying a ``LocalCUDACluster``, cuDF spilling can be enabled with the
+``cudf_spill_stats`` argument:
+
+.. code-block::
+
+    >>> cluster = LocalCUDACluster(n_workers=10, enable_cudf_spill=True, cudf_spill_stats=1)​
+
+The same applies for ``dask cuda worker``:
 
 .. code-block::
 
     $ dask cuda worker --enable-cudf-spill --cudf-spill-stats 1
 
-To have each dask-cuda worker print spill statistics, do something like:
+To have each dask-cuda worker print spill statistics within the workflow, do something like:
 
 .. code-block::
 
@@ -161,11 +172,14 @@ To have each dask-cuda worker print spill statistics, do something like:
         print(get_global_manager().statistics)
     client.submit(spill_info)
 
+See the `cuDF spilling documentation
+<https://docs.rapids.ai/api/cudf/stable/developer_guide/library_design/#statistics>`_
+for more information on the available spill-statistics options.
 
 Limitations
 ~~~~~~~~~~~
 
-Although cuDF spilling is the best option for most Dask cuDF ETL workflows,
+Although cuDF spilling is the best option for most Dask-cuDF ETL workflows,
 it will be much less effective if that workflow converts between ``cudf.DataFrame``
 and other data formats (e.g. ``cupy.ndarray``). Once the underlying device buffers
 are "exposed" to external memory references, they become "unspillable" by cuDF.

--- a/docs/source/spilling.rst
+++ b/docs/source/spilling.rst
@@ -169,4 +169,4 @@ Although cuDF spilling is the best option for most Dask cuDF ETL workflows,
 it will be much less effective if that workflow converts between ``cudf.DataFrame``
 and other data formats (e.g. ``cupy.ndarray``). Once the underlying device buffers
 are "exposed" to external memory references, they become "unspillable" by cuDF.
-In cases like this (e.g. Dask CUDA + XGBoost), JIT-Unspill is usually a better choice.
+In cases like this (e.g., Dask-CUDA + XGBoost), JIT-Unspill is usually a better choice.


### PR DESCRIPTION
Updates the dask-cuda documentation to include notes on native cuDF spilling, since it is often the best spilling approach for ETL with Dask cuDA (please feel free to correct me if I'm wrong).