### PR TITLE
Enable Pytorch to share same memory pool as RMM via cli

### DIFF
--- a/dask_cuda/cli.py
+++ b/dask_cuda/cli.py
@@ -165,6 +165,14 @@ def cuda():
         result in failure.""",
 )
 @click.option(
+    "--set-rmm-allocator-for-libs",
+    default=None,
+    show_default=True,
+    help="""
+    Set RMM as the allocator for external libraries. Provide a comma-separated
+    list of libraries to set, e.g., "torch,cupy". Supported options are: torch, cupy.""",
+)
+@click.option(
     "--rmm-release-threshold",
     default=None,
     help="""When ``rmm.async`` is ``True`` and the pool size grows beyond this
@@ -351,6 +359,7 @@ def worker(
     rmm_maximum_pool_size,
     rmm_managed_memory,
     rmm_async,
+    rmm_allocator_external_lib_list,
     rmm_release_threshold,
     rmm_log_directory,
     rmm_track_allocations,
@@ -425,6 +434,7 @@ def worker(
             rmm_maximum_pool_size,
             rmm_managed_memory,
             rmm_async,
+            rmm_allocator_external_lib_list,
             rmm_release_threshold,
             rmm_log_directory,
             rmm_track_allocations,

--- a/dask_cuda/cli.py
+++ b/dask_cuda/cli.py
@@ -166,11 +166,13 @@ def cuda():
 )
 @click.option(
     "--set-rmm-allocator-for-libs",
+    "rmm_allocator_external_lib_list",
     default=None,
     show_default=True,
     help="""
     Set RMM as the allocator for external libraries. Provide a comma-separated
-    list of libraries to set, e.g., "torch,cupy". Supported options are: torch, cupy.""",
+    list of libraries to set, e.g., "torch,cupy".
+    Supported options are: torch, cupy.""",
 )
 @click.option(
     "--rmm-release-threshold",

--- a/dask_cuda/cli.py
+++ b/dask_cuda/cli.py
@@ -13,7 +13,7 @@ from distributed.security import Security
 from distributed.utils import import_term
 
 from .cuda_worker import CUDAWorker
-from .utils import print_cluster_config
+from .utils import CommaSeparatedChoice, print_cluster_config
 
 logger = logging.getLogger(__name__)
 
@@ -167,6 +167,7 @@ def cuda():
 @click.option(
     "--set-rmm-allocator-for-libs",
     "rmm_allocator_external_lib_list",
+    type=CommaSeparatedChoice(["cupy", "torch"]),
     default=None,
     show_default=True,
     help="""

--- a/dask_cuda/cli.py
+++ b/dask_cuda/cli.py
@@ -172,8 +172,7 @@ def cuda():
     show_default=True,
     help="""
     Set RMM as the allocator for external libraries. Provide a comma-separated
-    list of libraries to set, e.g., "torch,cupy".
-    Supported options are: torch, cupy.""",
+    list of libraries to set, e.g., "torch,cupy".""",
 )
 @click.option(
     "--rmm-release-threshold",

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -47,6 +47,7 @@ class CUDAWorker(Server):
         rmm_maximum_pool_size=None,
         rmm_managed_memory=False,
         rmm_async=False,
+        rmm_allocator_external_lib_list=None,
         rmm_release_threshold=None,
         rmm_log_directory=None,
         rmm_track_allocations=False,
@@ -202,6 +203,9 @@ class CUDAWorker(Server):
                 "processes set `CUDF_SPILL=on` as well. To disable this warning "
                 "set `DASK_CUDF_SPILL_WARNING=False`."
             )
+        
+        if rmm_allocator_external_lib_list is not None:
+            rmm_allocator_external_lib_list = [s.strip() for s in rmm_allocator_external_lib_list.split(',')]
 
         self.nannies = [
             Nanny(
@@ -231,6 +235,7 @@ class CUDAWorker(Server):
                         release_threshold=rmm_release_threshold,
                         log_directory=rmm_log_directory,
                         track_allocations=rmm_track_allocations,
+                        external_lib_list=rmm_allocator_external_lib_list,
                     ),
                     PreImport(pre_import),
                     CUDFSetup(spill=enable_cudf_spill, spill_stats=cudf_spill_stats),

--- a/dask_cuda/cuda_worker.py
+++ b/dask_cuda/cuda_worker.py
@@ -203,9 +203,6 @@ class CUDAWorker(Server):
                 "processes set `CUDF_SPILL=on` as well. To disable this warning "
                 "set `DASK_CUDF_SPILL_WARNING=False`."
             )
-        
-        if rmm_allocator_external_lib_list is not None:
-            rmm_allocator_external_lib_list = [s.strip() for s in rmm_allocator_external_lib_list.split(',')]
 
         self.nannies = [
             Nanny(

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -289,9 +289,12 @@ class LocalCUDACluster(LocalCluster):
         self.rmm_managed_memory = rmm_managed_memory
         self.rmm_async = rmm_async
         self.rmm_release_threshold = rmm_release_threshold
-        if rmm_allocator_external_lib_list is not None:
-            rmm_allocator_external_lib_list = [s.strip() for s in  
-                                                    rmm_allocator_external_lib_list.split(',')]
+        if rmm_allocator_external_lib_list is not None and isinstance(
+            rmm_allocator_external_lib_list, str
+        ):
+            rmm_allocator_external_lib_list = [
+                s.strip() for s in rmm_allocator_external_lib_list.split(",")
+            ]
         self.rmm_allocator_external_lib_list = rmm_allocator_external_lib_list
 
         if rmm_pool_size is not None or rmm_managed_memory or rmm_async:
@@ -447,7 +450,7 @@ class LocalCUDACluster(LocalCluster):
                         release_threshold=self.rmm_release_threshold,
                         log_directory=self.rmm_log_directory,
                         track_allocations=self.rmm_track_allocations,
-                        external_lib_list=self.rmm_allocator_external_lib_list
+                        external_lib_list=self.rmm_allocator_external_lib_list,
                     ),
                     PreImport(self.pre_import),
                     CUDFSetup(self.enable_cudf_spill, self.cudf_spill_stats),

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -145,7 +145,7 @@ class LocalCUDACluster(LocalCluster):
             result in an exception.
     rmm_allocator_external_lib_list: list or None, default None
         List of external libraries for which to set RMM as the allocator.
-        Supported options are: ``["torch", "cupy"]``. If None, no external
+        Supported options are: ``["torch", "cupy"]``. If ``None``, no external
         libraries will use RMM as their allocator.
     rmm_release_threshold: int, str or None, default None
         When ``rmm.async is True`` and the pool size grows beyond this value, unused
@@ -271,8 +271,16 @@ class LocalCUDACluster(LocalCluster):
         if n_workers < 1:
             raise ValueError("Number of workers cannot be less than 1.")
 
-        if isinstance(rmm_allocator_external_lib_list, str):
-            rmm_allocator_external_lib_list = []
+        if rmm_allocator_external_lib_list is not None and not isinstance(
+            rmm_allocator_external_lib_list, list
+        ):
+            raise ValueError(
+                "rmm_allocator_external_lib_list must be a list of strings. "
+                "Valid examples: ['torch'], ['cupy'], or ['torch', 'cupy']. "
+                f"Received: {type(rmm_allocator_external_lib_list)} "
+                f"with value: {rmm_allocator_external_lib_list}"
+            )
+
         # Set nthreads=1 when parsing mem_limit since it only depends on n_workers
         logger = logging.getLogger(__name__)
         self.memory_limit = parse_memory_limit(

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -143,10 +143,10 @@ class LocalCUDACluster(LocalCluster):
             The asynchronous allocator requires CUDA Toolkit 11.2 or newer. It is also
             incompatible with RMM pools and managed memory. Trying to enable both will
             result in an exception.
-    rmm_allocator_external_lib_list: str or list or None, default None
-        Set RMM as the allocator for external libraries. Can be a comma-separated
-        string (like "torch,cupy").
-
+    rmm_allocator_external_lib_list: list or None, default None
+        List of external libraries for which to set RMM as the allocator.
+        Supported options are: ``["torch", "cupy"]``. If None, no external
+        libraries will use RMM as their allocator.
     rmm_release_threshold: int, str or None, default None
         When ``rmm.async is True`` and the pool size grows beyond this value, unused
         memory held by the pool will be released at the next synchronization point.
@@ -289,12 +289,6 @@ class LocalCUDACluster(LocalCluster):
         self.rmm_managed_memory = rmm_managed_memory
         self.rmm_async = rmm_async
         self.rmm_release_threshold = rmm_release_threshold
-        if rmm_allocator_external_lib_list is not None and isinstance(
-            rmm_allocator_external_lib_list, str
-        ):
-            rmm_allocator_external_lib_list = [
-                s.strip() for s in rmm_allocator_external_lib_list.split(",")
-            ]
         self.rmm_allocator_external_lib_list = rmm_allocator_external_lib_list
 
         if rmm_pool_size is not None or rmm_managed_memory or rmm_async:

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -270,6 +270,9 @@ class LocalCUDACluster(LocalCluster):
             n_workers = len(CUDA_VISIBLE_DEVICES)
         if n_workers < 1:
             raise ValueError("Number of workers cannot be less than 1.")
+
+        if isinstance(rmm_allocator_external_lib_list, str):
+            rmm_allocator_external_lib_list = []
         # Set nthreads=1 when parsing mem_limit since it only depends on n_workers
         logger = logging.getLogger(__name__)
         self.memory_limit = parse_memory_limit(

--- a/dask_cuda/plugins.py
+++ b/dask_cuda/plugins.py
@@ -3,7 +3,11 @@ import os
 
 from distributed import WorkerPlugin
 
-from .utils import get_rmm_log_file_name, parse_device_memory_limit, enable_rmm_memory_for_library
+from .utils import (
+    enable_rmm_memory_for_library,
+    get_rmm_log_file_name,
+    parse_device_memory_limit,
+)
 
 
 class CPUAffinity(WorkerPlugin):
@@ -63,7 +67,6 @@ class RMMSetup(WorkerPlugin):
         self.log_directory = log_directory
         self.rmm_track_allocations = track_allocations
         self.external_lib_list = external_lib_list
-
 
     def setup(self, worker=None):
         if self.initial_pool_size is not None:
@@ -125,7 +128,7 @@ class RMMSetup(WorkerPlugin):
 
             mr = rmm.mr.get_current_device_resource()
             rmm.mr.set_current_device_resource(rmm.mr.TrackingResourceAdaptor(mr))
-        
+
         if self.external_lib_list is not None:
             for lib in self.external_lib_list:
                 enable_rmm_memory_for_library(lib)

--- a/dask_cuda/plugins.py
+++ b/dask_cuda/plugins.py
@@ -3,7 +3,7 @@ import os
 
 from distributed import WorkerPlugin
 
-from .utils import get_rmm_log_file_name, parse_device_memory_limit
+from .utils import get_rmm_log_file_name, parse_device_memory_limit, enable_rmm_memory_for_library
 
 
 class CPUAffinity(WorkerPlugin):
@@ -39,6 +39,7 @@ class RMMSetup(WorkerPlugin):
         release_threshold,
         log_directory,
         track_allocations,
+        external_lib_list,
     ):
         if initial_pool_size is None and maximum_pool_size is not None:
             raise ValueError(
@@ -61,6 +62,8 @@ class RMMSetup(WorkerPlugin):
         self.logging = log_directory is not None
         self.log_directory = log_directory
         self.rmm_track_allocations = track_allocations
+        self.external_lib_list = external_lib_list
+
 
     def setup(self, worker=None):
         if self.initial_pool_size is not None:
@@ -122,6 +125,10 @@ class RMMSetup(WorkerPlugin):
 
             mr = rmm.mr.get_current_device_resource()
             rmm.mr.set_current_device_resource(rmm.mr.TrackingResourceAdaptor(mr))
+        
+        if self.external_lib_list is not None:
+            for lib in self.external_lib_list:
+                enable_rmm_memory_for_library(lib)
 
 
 class PreImport(WorkerPlugin):

--- a/dask_cuda/plugins.py
+++ b/dask_cuda/plugins.py
@@ -1,13 +1,10 @@
 import importlib
 import os
+from typing import Callable, Dict
 
 from distributed import WorkerPlugin
 
-from .utils import (
-    enable_rmm_memory_for_library,
-    get_rmm_log_file_name,
-    parse_device_memory_limit,
-)
+from .utils import get_rmm_log_file_name, parse_device_memory_limit
 
 
 class CPUAffinity(WorkerPlugin):
@@ -132,6 +129,66 @@ class RMMSetup(WorkerPlugin):
         if self.external_lib_list is not None:
             for lib in self.external_lib_list:
                 enable_rmm_memory_for_library(lib)
+
+
+def enable_rmm_memory_for_library(lib_name: str) -> None:
+    """Enable RMM memory pool support for a specified third-party library.
+
+    This function allows the given library to utilize RMM's memory pool if it supports
+    integration with RMM. The library name is passed as a string argument, and if the
+    library is compatible, its memory allocator will be configured to use RMM.
+
+    Parameters
+    ----------
+    lib_name : str
+        The name of the third-party library to enable RMM memory pool support for.
+        Supported libraries are "cupy" and "torch".
+
+    Raises
+    ------
+    ValueError
+        If the library name is not supported or does not have RMM integration.
+    ImportError
+        If the required library is not installed.
+    """
+
+    # Mapping of supported libraries to their respective setup functions
+    setup_functions: Dict[str, Callable[[], None]] = {
+        "torch": _setup_rmm_for_torch,
+        "cupy": _setup_rmm_for_cupy,
+    }
+
+    if lib_name not in setup_functions:
+        supported_libs = ", ".join(setup_functions.keys())
+        raise ValueError(
+            f"The library '{lib_name}' is not supported for RMM integration. "
+            f"Supported libraries are: {supported_libs}."
+        )
+
+    # Call the setup function for the specified library
+    setup_functions[lib_name]()
+
+
+def _setup_rmm_for_torch() -> None:
+    try:
+        import torch
+    except ImportError as e:
+        raise ImportError("PyTorch is not installed.") from e
+
+    from rmm.allocators.torch import rmm_torch_allocator
+
+    torch.cuda.memory.change_current_allocator(rmm_torch_allocator)
+
+
+def _setup_rmm_for_cupy() -> None:
+    try:
+        import cupy
+    except ImportError as e:
+        raise ImportError("CuPy is not installed.") from e
+
+    from rmm.allocators.cupy import rmm_cupy_allocator
+
+    cupy.cuda.set_allocator(rmm_cupy_allocator)
 
 
 class PreImport(WorkerPlugin):

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -7,7 +7,7 @@ import warnings
 from contextlib import suppress
 from functools import singledispatch
 from multiprocessing import cpu_count
-from typing import Optional
+from typing import Optional, Callable, Dict
 
 import numpy as np
 import pynvml
@@ -764,3 +764,60 @@ def get_rmm_device_memory_usage() -> Optional[int]:
         if isinstance(mr, rmm.mr.StatisticsResourceAdaptor):
             return mr.allocation_counts["current_bytes"]
     return None
+
+
+def enable_rmm_memory_for_library(lib_name: str) -> None:
+    """
+    Enable RMM memory pool support for a specified third-party library.
+
+    This function allows the given library to utilize RMM's memory pool if it supports
+    integration with RMM. The library name is passed as a string argument, and if the 
+    library is compatible, its memory allocator will be configured to use RMM.
+
+    Parameters
+    ----------
+    lib_name : str
+        The name of the third-party library to enable RMM memory pool support for.
+
+    Raises
+    ------
+    ValueError
+        If the library name is not supported or does not have RMM integration.
+    ImportError
+        If the required library is not installed.
+    """
+
+    # Mapping of supported libraries to their respective setup functions
+    setup_functions: Dict[str, Callable[[], None]] = {
+        "torch": _setup_rmm_for_torch,
+        "cupy": _setup_rmm_for_cupy,
+    }
+
+    if lib_name not in setup_functions:
+        supported_libs = ', '.join(setup_functions.keys())
+        raise ValueError(
+            f"The library '{lib_name}' is not supported for RMM integration. "
+            f"Supported libraries are: {supported_libs}."
+        )
+
+    # Call the setup function for the specified library
+    setup_functions[lib_name]()
+
+def _setup_rmm_for_torch() -> None:
+    try:
+        import torch
+    except ImportError as e:
+        raise ImportError("PyTorch is not installed.") from e
+
+    from rmm.allocators.torch import rmm_torch_allocator
+
+    torch.cuda.memory.change_current_allocator(rmm_torch_allocator)
+
+def _setup_rmm_for_cupy() -> None:
+    try:
+        import cupy
+    except ImportError as e:
+        raise ImportError("CuPy is not installed.") from e
+
+    from rmm.allocators.cupy import rmm_cupy_allocator
+    cupy.cuda.set_allocator(rmm_cupy_allocator)


### PR DESCRIPTION
This PR closes: https://github.com/rapidsai/dask-cuda/issues/1281

Usage example:
```
from dask_cuda import LocalCUDACluster
from dask.distributed import Client

cluster = LocalCUDACluster(rmm_allocator_external_lib_list=["torch", "cupy"])
client = Client(cluster)
```

Verify working
```
def get_torch_allocator():
    import torch
    return torch.cuda.get_allocator_backend()
    
client.run(get_torch_allocator)
```

```
client.run(get_torch_allocator)
```

```
{'tcp://127.0.0.1:37167': 'pluggable',
 'tcp://127.0.0.1:38749': 'pluggable',
 'tcp://127.0.0.1:43109': 'pluggable',
 'tcp://127.0.0.1:44259': 'pluggable',
 'tcp://127.0.0.1:44953': 'pluggable',
 'tcp://127.0.0.1:45087': 'pluggable',
 'tcp://127.0.0.1:45623': 'pluggable',
 'tcp://127.0.0.1:45847': 'pluggable'}
```

Without it its `native`.


Context: This helps NeMo-Curator to have a  more stable use of Pytorch+dask-cuda 

CC: @pentschev . 

