### PR TITLE
Ignore legacy Dask dataframe warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,9 @@ filterwarnings = [
     # is enabled in both dask-cudf and dask-cuda.
     # See: https://github.com/rapidsai/dask-cuda/issues/1311
     "ignore:Dask DataFrame implementation is deprecated:DeprecationWarning",
+    # Dask now loudly throws warnings: https://github.com/dask/dask/pull/11437
+    # When the legacy implementation is removed we can remove this warning and stop running pytests with `DASK_DATAFRAME__QUERY_PLANNING=False`
+    "ignore:The legacy Dask DataFrame implementation is deprecated and will be removed in a future version.*:FutureWarning",
 ]
 
 [tool.rapids-build-backend]


### PR DESCRIPTION
Ignore legacy Dask dataframe warnings that the implementation is going to be soon removed, introduced in
https://github.com/dask/dask/pull/11437 .

The warning is only raised for `DASK_DATAFRAME__QUERY_PLANNING=False` cases.