### PR TITLE
Add missing `setuptools` to conda recipe

### DIFF
--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - python
     - pip
     - rapids-build-backend>=0.3.0,<0.4.0.dev0
-    - setuptools
+    - setuptools>=64.0.0
   run:
     - python
     {% for r in data["project"]["dependencies"] %}

--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - python
     - pip
     - rapids-build-backend>=0.3.0,<0.4.0.dev0
+    - setuptools
   run:
     - python
     {% for r in data["project"]["dependencies"] %}


### PR DESCRIPTION
Conda builds are failing due to missing `setuptools`, this change add the missing dependency to fix the failure.