### PR TITLE
Add verify-copyright pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,7 @@ repos:
         rev: v0.4.0
         hooks:
             - id: verify-alpha-spec
+            - id: verify-copyright
       - repo: https://github.com/rapidsai/dependency-file-generator
         rev: v1.16.0
         hooks:


### PR DESCRIPTION
Adds a pre-commit hook to ensure files have an up-to-date copyright notice.