### PR TITLE
Clean up imports for `dask>2024.12.1` support

### DIFF
--- a/dask_cuda/__init__.py
+++ b/dask_cuda/__init__.py
@@ -5,7 +5,6 @@ if sys.platform != "linux":
 
 import dask
 import dask.utils
-import dask.dataframe as dd
 import dask.dataframe.shuffle
 from .explicit_comms.dataframe.shuffle import patch_shuffle_expression
 from distributed.protocol.cuda import cuda_deserialize, cuda_serialize
@@ -16,17 +15,6 @@ from .cuda_worker import CUDAWorker
 
 from .local_cuda_cluster import LocalCUDACluster
 from .proxify_device_objects import proxify_decorator, unproxify_decorator
-
-
-try:
-    if not dd._dask_expr_enabled():
-        raise ValueError(
-            "Dask-CUDA no longer supports the legacy Dask DataFrame API. "
-            "Please set the 'dataframe.query-planning' config to `True` "
-            "or None, or downgrade RAPIDS to <=24.12."
-        )
-except AttributeError:
-    pass
 
 
 # Monkey patching Dask to make use of explicit-comms when `DASK_EXPLICIT_COMMS=True`

--- a/dask_cuda/__init__.py
+++ b/dask_cuda/__init__.py
@@ -5,10 +5,9 @@ if sys.platform != "linux":
 
 import dask
 import dask.utils
-import dask.dataframe.core
+import dask.dataframe as dd
 import dask.dataframe.shuffle
 from .explicit_comms.dataframe.shuffle import patch_shuffle_expression
-from dask.dataframe import DASK_EXPR_ENABLED
 from distributed.protocol.cuda import cuda_deserialize, cuda_serialize
 from distributed.protocol.serialize import dask_deserialize, dask_serialize
 
@@ -19,12 +18,15 @@ from .local_cuda_cluster import LocalCUDACluster
 from .proxify_device_objects import proxify_decorator, unproxify_decorator
 
 
-if not DASK_EXPR_ENABLED:
-    raise ValueError(
-        "Dask-CUDA no longer supports the legacy Dask DataFrame API. "
-        "Please set the 'dataframe.query-planning' config to `True` "
-        "or None, or downgrade RAPIDS to <=24.12."
-    )
+try:
+    if not dd._dask_expr_enabled():
+        raise ValueError(
+            "Dask-CUDA no longer supports the legacy Dask DataFrame API. "
+            "Please set the 'dataframe.query-planning' config to `True` "
+            "or None, or downgrade RAPIDS to <=24.12."
+        )
+except AttributeError:
+    pass
 
 
 # Monkey patching Dask to make use of explicit-comms when `DASK_EXPLICIT_COMMS=True`

--- a/dask_cuda/explicit_comms/dataframe/shuffle.py
+++ b/dask_cuda/explicit_comms/dataframe/shuffle.py
@@ -18,7 +18,7 @@ import distributed.worker
 from dask.base import tokenize
 from dask.dataframe import DataFrame, Series
 from dask.dataframe.core import _concat as dd_concat
-from dask.dataframe.shuffle import group_split_dispatch, hash_object_dispatch
+from dask.dataframe.dispatch import group_split_dispatch, hash_object_dispatch
 from distributed import wait
 from distributed.protocol import nested_deserialize, to_serialize
 from distributed.worker import Worker
@@ -585,7 +585,7 @@ def patch_shuffle_expression() -> None:
             # Execute an explicit-comms shuffle
             if not hasattr(self, "_ec_shuffled"):
                 on = self.partitioning_index
-                df = dask_expr._collection.new_collection(self.frame)
+                df = dask_expr.new_collection(self.frame)
                 self._ec_shuffled = shuffle(
                     df,
                     [on] if isinstance(on, str) else on,

--- a/dask_cuda/explicit_comms/dataframe/shuffle.py
+++ b/dask_cuda/explicit_comms/dataframe/shuffle.py
@@ -31,6 +31,20 @@ T = TypeVar("T")
 Proxify = Callable[[T], T]
 
 
+try:
+    from dask.dataframe import dask_expr
+
+except ImportError:
+    # TODO: Remove when pinned to dask>2024.12.1
+    import dask_expr
+
+    if not dd._dask_expr_enabled():
+        raise ValueError(
+            "The legacy DataFrame API is not supported in dask_cudf>24.12. "
+            "Please enable query-planning, or downgrade to dask_cudf<=24.12"
+        )
+
+
 def get_proxify(worker: Worker) -> Proxify:
     """Get function to proxify objects"""
     from dask_cuda.proxify_host_file import ProxifyHostFile
@@ -576,7 +590,6 @@ def patch_shuffle_expression() -> None:
     an `ECShuffle` expression when the 'explicit-comms'
     config is set to `True`.
     """
-    import dask_expr
 
     class ECShuffle(dask_expr._shuffle.TaskShuffle):
         """Explicit-Comms Shuffle Expression."""

--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -504,27 +504,27 @@ def test_pandas():
     df1 = pandas.DataFrame({"a": range(10)})
     df2 = pandas.DataFrame({"a": range(10)})
 
-    res = dask.dataframe.methods.concat([df1, df2])
-    got = dask.dataframe.methods.concat([df1, df2])
+    res = dask.dataframe.dispatch.concat([df1, df2])
+    got = dask.dataframe.dispatch.concat([df1, df2])
     assert_frame_equal(res, got)
 
-    got = dask.dataframe.methods.concat([proxy_object.asproxy(df1), df2])
+    got = dask.dataframe.dispatch.concat([proxy_object.asproxy(df1), df2])
     assert_frame_equal(res, got)
 
-    got = dask.dataframe.methods.concat([df1, proxy_object.asproxy(df2)])
+    got = dask.dataframe.dispatch.concat([df1, proxy_object.asproxy(df2)])
     assert_frame_equal(res, got)
 
     df1 = pandas.Series(range(10))
     df2 = pandas.Series(range(10))
 
-    res = dask.dataframe.methods.concat([df1, df2])
-    got = dask.dataframe.methods.concat([df1, df2])
+    res = dask.dataframe.dispatch.concat([df1, df2])
+    got = dask.dataframe.dispatch.concat([df1, df2])
     assert all(res == got)
 
-    got = dask.dataframe.methods.concat([proxy_object.asproxy(df1), df2])
+    got = dask.dataframe.dispatch.concat([proxy_object.asproxy(df1), df2])
     assert all(res == got)
 
-    got = dask.dataframe.methods.concat([df1, proxy_object.asproxy(df2)])
+    got = dask.dataframe.dispatch.concat([df1, proxy_object.asproxy(df2)])
     assert all(res == got)
 
 


### PR DESCRIPTION
Follow up to https://github.com/rapidsai/dask-cuda/pull/1417

Cleans up some imports (some of which don't work for `dask>2024.12.1`).