### PR TITLE
Add upper bound to prevent usage of numba 0.61.0

### DIFF
--- a/conda/environments/all_cuda-114_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-114_arch-x86_64.yaml
@@ -15,7 +15,7 @@ dependencies:
 - distributed-ucxx==0.42.*,>=0.0.0a0
 - kvikio==25.2.*,>=0.0.0a0
 - numactl-devel-cos7-x86_64
-- numba>=0.57
+- numba>=0.59.1,<0.61.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc>=1.1.0
 - pandas>=1.3

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -15,7 +15,7 @@ dependencies:
 - distributed-ucxx==0.42.*,>=0.0.0a0
 - kvikio==25.2.*,>=0.0.0a0
 - numactl-devel-cos7-x86_64
-- numba>=0.57
+- numba>=0.59.1,<0.61.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc>=1.1.0
 - pandas>=1.3

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -16,7 +16,7 @@ dependencies:
 - distributed-ucxx==0.42.*,>=0.0.0a0
 - kvikio==25.2.*,>=0.0.0a0
 - numactl-devel-cos7-x86_64
-- numba>=0.57
+- numba>=0.59.1,<0.61.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc>=1.1.0
 - pandas>=1.3

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -146,7 +146,7 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         packages:
           - click >=8.1
-          - numba>=0.57
+          - numba>=0.59.1,<0.61.0a0
           - numpy>=1.23,<3.0a0
           - pandas>=1.3
           - pynvml>=12.0.0,<13.0.0a0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ license = { text = "Apache 2.0" }
 requires-python = ">=3.10"
 dependencies = [
     "click >=8.1",
-    "numba>=0.57",
+    "numba>=0.59.1,<0.61.0a0",
     "numpy>=1.23,<3.0a0",
     "pandas>=1.3",
     "pynvml>=12.0.0,<13.0.0a0",


### PR DESCRIPTION
Numba 0.61.0 just got released with couple of breaking changes, this pr is required to unblock the ci.

xref: https://github.com/rapidsai/cudf/pull/17777