### PR TITLE
Add shellcheck to pre-commit and fix warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,12 @@ repos:
         hooks:
             - id: rapids-dependency-file-generator
               args: ["--clean"]
+      - repo: https://github.com/shellcheck-py/shellcheck-py
+        rev: v0.10.0.1
+        hooks:
+          - id: shellcheck
+            args: ["--severity=warning"]
+            files: ^ci/
 
 default_language_version:
       python: python3

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -25,7 +25,8 @@ rapids-mamba-retry install \
     --channel "${PYTHON_CHANNEL}" \
     "dask-cuda=${RAPIDS_VERSION}"
 
-export RAPIDS_DOCS_DIR="$(mktemp -d)"
+RAPIDS_DOCS_DIR="$(mktemp -d)"
+export RAPIDS_DOCS_DIR
 
 rapids-logger "Build Python docs"
 pushd docs

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -13,23 +13,19 @@ NEXT_FULL_TAG=$1
 
 # Get current version
 CURRENT_TAG=$(git tag --merged HEAD | grep -xE '^v.*' | sort --version-sort | tail -n 1 | tr -d 'v')
-CURRENT_MAJOR=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[1]}')
-CURRENT_MINOR=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[2]}')
-CURRENT_PATCH=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[3]}')
-CURRENT_SHORT_TAG=${CURRENT_MAJOR}.${CURRENT_MINOR}
 
 #Get <major>.<minor> for next version
-NEXT_MAJOR=$(echo $NEXT_FULL_TAG | awk '{split($0, a, "."); print a[1]}')
-NEXT_MINOR=$(echo $NEXT_FULL_TAG | awk '{split($0, a, "."); print a[2]}')
+NEXT_MAJOR=$(echo "$NEXT_FULL_TAG" | awk '{split($0, a, "."); print a[1]}')
+NEXT_MINOR=$(echo "$NEXT_FULL_TAG" | awk '{split($0, a, "."); print a[2]}')
 NEXT_SHORT_TAG=${NEXT_MAJOR}.${NEXT_MINOR}
 NEXT_SHORT_TAG_PEP440=$(python -c "from packaging.version import Version; print(Version('${NEXT_SHORT_TAG}'))")
-NEXT_UCXPY_VERSION="$(curl -s https://version.gpuci.io/rapids/${NEXT_SHORT_TAG})"
+NEXT_UCXPY_VERSION="$(curl -s https://version.gpuci.io/rapids/"${NEXT_SHORT_TAG}")"
 
 echo "Preparing release $CURRENT_TAG => $NEXT_FULL_TAG"
 
 # Inplace sed replace; workaround for Linux and Mac
 function sed_runner() {
-    sed -i.bak ''"$1"'' $2 && rm -f ${2}.bak
+    sed -i.bak ''"$1"'' "$2" && rm -f "${2}".bak
 }
 
 # Centralized version file update
@@ -70,6 +66,6 @@ for FILE in .github/workflows/*.yaml; do
 done
 
 # Docs referencing source code
-find docs/source/ -type f -name *.rst -print0 | while IFS= read -r -d '' filename; do
+find docs/source/ -type f -name '*.rst' -print0 | while IFS= read -r -d '' filename; do
     sed_runner "s|/branch-[^/]*/|/branch-${NEXT_SHORT_TAG}/|g" "${filename}"
 done

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -37,6 +37,7 @@ rapids-logger "Check GPU usage"
 nvidia-smi
 
 EXITCODE=0
+# shellcheck disable=SC2317
 set_exit_code() {
     EXITCODE=$?
     rapids-logger "Test failed with error ${EXITCODE}"

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -14,6 +14,6 @@ rapids-dependency-file-generator \
 
 rapids-logger "Installing test dependencies"
 # echo to expand wildcard
-python -m pip install -v --prefer-binary -r /tmp/requirements-test.txt $(echo ./dist/dask_cuda*.whl)
+python -m pip install -v --prefer-binary -r /tmp/requirements-test.txt "$(echo ./dist/dask_cuda*.whl)"
 
 python -m pytest ./dask_cuda/tests -k "not ucxx"

--- a/ci/validate_wheel.sh
+++ b/ci/validate_wheel.sh
@@ -9,10 +9,10 @@ rapids-logger "validate packages with 'pydistcheck'"
 
 pydistcheck \
     --inspect \
-    "$(echo ${wheel_dir_relative_path}/*.whl)"
+    "$(echo "${wheel_dir_relative_path}"/*.whl)"
 
 rapids-logger "validate packages with 'twine'"
 
 twine check \
     --strict \
-    "$(echo ${wheel_dir_relative_path}/*.whl)"
+    "$(echo "${wheel_dir_relative_path}"/*.whl)"


### PR DESCRIPTION
## Description                                                                                           
                                                                                                              
 shellcheck  is a fast, static analysis tool for shell scripts. It's good at                                  
flagging up unused variables, unintentional glob expansions, and other potential                              
execution and security headaches that arise from the wonders of  bash  (and other shlangs).                   
                                                                                                              
This PR adds a  pre-commit  hook to run  shellcheck  on all of the  sh-lang  files in the  ci/  directory, and
the changes requested by  shellcheck  to make the existing files pass the check.                              
                                                                                                              
xref: rapidsai/build-planning#135