### PR TITLE
remove ucx-proc dependency

### DIFF
--- a/conda/environments/all_cuda-114_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-114_arch-x86_64.yaml
@@ -30,7 +30,6 @@ dependencies:
 - sphinx
 - sphinx-click>=2.7.1
 - sphinx-rtd-theme>=0.5.1
-- ucx-proc=*=gpu
 - ucx-py==0.42.*,>=0.0.0a0
 - ucxx==0.42.*,>=0.0.0a0
 - zict>=2.0.0

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -30,7 +30,6 @@ dependencies:
 - sphinx
 - sphinx-click>=2.7.1
 - sphinx-rtd-theme>=0.5.1
-- ucx-proc=*=gpu
 - ucx-py==0.42.*,>=0.0.0a0
 - ucxx==0.42.*,>=0.0.0a0
 - zict>=2.0.0

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -31,7 +31,6 @@ dependencies:
 - sphinx
 - sphinx-click>=2.7.1
 - sphinx-rtd-theme>=0.5.1
-- ucx-proc=*=gpu
 - ucx-py==0.42.*,>=0.0.0a0
 - ucxx==0.42.*,>=0.0.0a0
 - zict>=2.0.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -165,7 +165,6 @@ dependencies:
           - distributed-ucxx==0.42.*,>=0.0.0a0
           - &kvikio_unsuffixed kvikio==25.2.*,>=0.0.0a0
           - &ucx_py_unsuffixed ucx-py==0.42.*,>=0.0.0a0
-          - ucx-proc=*=gpu
           - ucxx==0.42.*,>=0.0.0a0
     specific:
       - output_types: conda


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/142

`ucx-proc` is no longer necessary, for the reasons described in that issue. This proposes dropping the dependency on it here.