### PR TITLE
Make `dask.dataframe` optional

### DIFF
--- a/dask_cuda/__init__.py
+++ b/dask_cuda/__init__.py
@@ -15,7 +15,6 @@ from .local_cuda_cluster import LocalCUDACluster
 
 
 try:
-    import lasdfbg
     import dask.dataframe as dask_dataframe
 except ImportError:
     # Dask DataFrame (optional) isn't installed

--- a/dask_cuda/__init__.py
+++ b/dask_cuda/__init__.py
@@ -5,8 +5,6 @@ if sys.platform != "linux":
 
 import dask
 import dask.utils
-import dask.dataframe.shuffle
-from .explicit_comms.dataframe.shuffle import patch_shuffle_expression
 from distributed.protocol.cuda import cuda_deserialize, cuda_serialize
 from distributed.protocol.serialize import dask_deserialize, dask_serialize
 
@@ -17,13 +15,23 @@ from .local_cuda_cluster import LocalCUDACluster
 from .proxify_device_objects import proxify_decorator, unproxify_decorator
 
 
-# Monkey patching Dask to make use of explicit-comms when `DASK_EXPLICIT_COMMS=True`
-patch_shuffle_expression()
-# Monkey patching Dask to make use of proxify and unproxify in compatibility mode
-dask.dataframe.shuffle.shuffle_group = proxify_decorator(
-    dask.dataframe.shuffle.shuffle_group
-)
-dask.dataframe.core._concat = unproxify_decorator(dask.dataframe.core._concat)
+try:
+    import dask.dataframe as dask_dataframe
+except ImportError:
+    # Dask DataFrame (optional) isn't installed
+    dask_dataframe = None
+
+
+if dask_dataframe is not None:
+    from .explicit_comms.dataframe.shuffle import patch_shuffle_expression
+
+    # Monkey patching Dask to make use of explicit-comms when `DASK_EXPLICIT_COMMS=True`
+    patch_shuffle_expression()
+    # Monkey patching Dask to make use of proxify and unproxify in compatibility mode
+    dask_dataframe.shuffle.shuffle_group = proxify_decorator(
+        dask.dataframe.shuffle.shuffle_group
+    )
+    dask_dataframe.core._concat = unproxify_decorator(dask.dataframe.core._concat)
 
 
 def _register_cudf_spill_aware():


### PR DESCRIPTION
Dask-CUDA currently requires that `dask.dataframe` be imported in a few places. We only do this to patch in explicit-comms shuffling and to register various dispatch functions. There is no fundamental reason that we need `dask.dataframe` to be installed if the user is not actually using `dask.dataframe`/`dask_cudf` in their workflow.

This PR essentially adds exception handling for "automatic" `dask.dataframe` imports (when `dask_cuda` is imported).