### PR TITLE
Reorganize CI tests and benchmarks

### DIFF
--- a/ci/run_benchmarks.sh
+++ b/ci/run_benchmarks.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Copyright (c) 2025, NVIDIA CORPORATION.
+
+set -euo pipefail
+
+# Support invoking run_benchmarks.sh outside the script directory
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../dask_cuda
+
+rapids-logger "Run local benchmark"
+python benchmarks/local_cudf_shuffle.py \
+  --partition-size="1 KiB" \
+  -d 0 \
+  --runs 1 \
+  --backend dask
+
+python benchmarks/local_cudf_shuffle.py \
+  --partition-size="1 KiB" \
+  -d 0 \
+  --runs 1 \
+  --backend explicit-comms
+
+python benchmarks/local_cudf_shuffle.py \
+  --disable-rmm \
+  --partition-size="1 KiB" \
+  -d 0 \
+  --runs 1 \
+  --backend explicit-comms
+
+python benchmarks/local_cudf_shuffle.py \
+  --disable-rmm-pool \
+  --partition-size="1 KiB" \
+  -d 0 \
+  --runs 1 \
+  --backend explicit-comms
+
+python benchmarks/local_cudf_shuffle.py \
+  --rmm-pool-size 2GiB \
+  --partition-size="1 KiB" \
+  -d 0 \
+  --runs 1 \
+  --backend explicit-comms
+
+python benchmarks/local_cudf_shuffle.py \
+  --rmm-pool-size 2GiB \
+  --rmm-maximum-pool-size 4GiB \
+  --partition-size="1 KiB" \
+  -d 0 \
+  --runs 1 \
+  --backend explicit-comms
+
+python benchmarks/local_cudf_shuffle.py \
+  --rmm-pool-size 2GiB \
+  --rmm-maximum-pool-size 4GiB \
+  --enable-rmm-async \
+  --partition-size="1 KiB" \
+  -d 0 \
+  --runs 1 \
+  --backend explicit-comms
+
+python benchmarks/local_cudf_shuffle.py \
+  --rmm-pool-size 2GiB \
+  --rmm-maximum-pool-size 4GiB \
+  --enable-rmm-managed \
+  --partition-size="1 KiB" \
+  -d 0 \
+  --runs 1 \
+  --backend explicit-comms

--- a/ci/run_benchmarks.sh
+++ b/ci/run_benchmarks.sh
@@ -6,7 +6,6 @@ set -euo pipefail
 # Support invoking run_benchmarks.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../dask_cuda
 
-rapids-logger "Run local benchmark"
 python benchmarks/local_cudf_shuffle.py \
   --partition-size="1 KiB" \
   -d 0 \

--- a/ci/run_pytest.sh
+++ b/ci/run_pytest.sh
@@ -6,13 +6,12 @@ set -euo pipefail
 # Support invoking run_pytest.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../dask_cuda
 
-rapids-logger "pytest dask-cuda"
 DASK_CUDA_TEST_SINGLE_GPU=1 \
   DASK_CUDA_WAIT_WORKERS_MIN_TIMEOUT=20 \
   UCXPY_IFNAME=eth0 \
   UCX_WARN_UNUSED_ENV_VARS=n \
   UCX_MEMTYPE_CACHE=n \
-  timeout 90m pytest \
+  timeout 90m python -m pytest \
   -vv \
   --capture=no \
   --cache-clear \

--- a/ci/run_pytest.sh
+++ b/ci/run_pytest.sh
@@ -7,7 +7,6 @@ set -euo pipefail
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../dask_cuda
 
 rapids-logger "pytest dask-cuda"
-pushd dask_cuda
 DASK_CUDA_TEST_SINGLE_GPU=1 \
   DASK_CUDA_WAIT_WORKERS_MIN_TIMEOUT=20 \
   UCXPY_IFNAME=eth0 \
@@ -20,4 +19,3 @@ DASK_CUDA_TEST_SINGLE_GPU=1 \
   "$@" \
   -k "not ucxx" \
   tests
-popd

--- a/ci/run_pytest.sh
+++ b/ci/run_pytest.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright (c) 2025, NVIDIA CORPORATION.
+
+set -euo pipefail
+
+# Support invoking run_pytest.sh outside the script directory
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../dask_cuda
+
+rapids-logger "pytest dask-cuda"
+pushd dask_cuda
+DASK_CUDA_TEST_SINGLE_GPU=1 \
+  DASK_CUDA_WAIT_WORKERS_MIN_TIMEOUT=20 \
+  UCXPY_IFNAME=eth0 \
+  UCX_WARN_UNUSED_ENV_VARS=n \
+  UCX_MEMTYPE_CACHE=n \
+  timeout 90m pytest \
+  -vv \
+  --capture=no \
+  --cache-clear \
+  "$@" \
+  -k "not ucxx" \
+  tests
+popd

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -45,6 +45,7 @@ set_exit_code() {
 trap set_exit_code ERR
 set +e
 
+rapids-logger "pytest dask-cuda"
 ./ci/run_pytest.sh \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-dask-cuda.xml" \
   --cov-config=../pyproject.toml \
@@ -52,6 +53,7 @@ set +e
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/dask-cuda-coverage.xml" \
   --cov-report=term
 
+rapids-logger "Run local benchmark"
 ./ci/run_benchmarks.sh
 
 rapids-logger "Test script exiting with latest error code: $EXITCODE"

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -39,8 +39,8 @@ nvidia-smi
 EXITCODE=0
 # shellcheck disable=SC2317
 set_exit_code() {
-  EXITCODE=$?
-  rapids-logger "Test failed with error ${EXITCODE}"
+    EXITCODE=$?
+    rapids-logger "Test failed with error ${EXITCODE}"
 }
 trap set_exit_code ERR
 set +e

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -7,13 +7,16 @@ RAPIDS_PY_WHEEL_NAME="dask-cuda" RAPIDS_PY_WHEEL_PURE="1" rapids-download-wheels
 
 # Install cuda-suffixed dependencies b/c while `dask-cuda` has no cuda suffix, the test dependencies do
 rapids-dependency-file-generator \
-    --output requirements \
-    --file-key "test_python" \
-    --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION};cuda_suffixed=true" \
-| tee /tmp/requirements-test.txt
+  --output requirements \
+  --file-key "test_python" \
+  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION};cuda_suffixed=true" |
+  tee /tmp/requirements-test.txt
 
 rapids-logger "Installing test dependencies"
 # echo to expand wildcard
 python -m pip install -v --prefer-binary -r /tmp/requirements-test.txt "$(echo ./dist/dask_cuda*.whl)"
 
-python -m pytest ./dask_cuda/tests -k "not ucxx"
+./ci/run_pytest.sh \
+  --junitxml="${RAPIDS_TESTS_DIR}/junit-dask-cuda.xml"
+
+./ci/run_benchmarks.sh

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -7,10 +7,10 @@ RAPIDS_PY_WHEEL_NAME="dask-cuda" RAPIDS_PY_WHEEL_PURE="1" rapids-download-wheels
 
 # Install cuda-suffixed dependencies b/c while `dask-cuda` has no cuda suffix, the test dependencies do
 rapids-dependency-file-generator \
-  --output requirements \
-  --file-key "test_python" \
-  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION};cuda_suffixed=true" |
-  tee /tmp/requirements-test.txt
+    --output requirements \
+    --file-key "test_python" \
+    --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION};cuda_suffixed=true" \
+| tee /tmp/requirements-test.txt
 
 rapids-logger "Installing test dependencies"
 # echo to expand wildcard

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -16,7 +16,9 @@ rapids-logger "Installing test dependencies"
 # echo to expand wildcard
 python -m pip install -v --prefer-binary -r /tmp/requirements-test.txt "$(echo ./dist/dask_cuda*.whl)"
 
+rapids-logger "pytest dask-cuda"
 ./ci/run_pytest.sh \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-dask-cuda.xml"
 
+rapids-logger "Run local benchmark"
 ./ci/run_benchmarks.sh

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -320,7 +320,7 @@ def test_unknown_argument():
     assert b"Scheduler address: --my-argument" in ret.stderr
 
 
-@pytest.xfail(reason="https://github.com/rapidsai/dask-cuda/issues/1441")
+@pytest.mark.xfail(reason="https://github.com/rapidsai/dask-cuda/issues/1441")
 @patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0"})
 def test_pre_import(loop):  # noqa: F811
     module = None

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -320,6 +320,7 @@ def test_unknown_argument():
     assert b"Scheduler address: --my-argument" in ret.stderr
 
 
+@pytest.xfail(reason="https://github.com/rapidsai/dask-cuda/issues/1441")
 @patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0"})
 def test_pre_import(loop):  # noqa: F811
     module = None


### PR DESCRIPTION
Recently wheel tests have been failing, this is probably due to the `DASK_CUDA_WAIT_WORKERS_MIN_TIMEOUT=20` configuration that is set for conda tests but not for wheels. With this change, the tests and benchmarks are now moved to new scripts that can be called by both conda and wheels tests to provide unified configurations with sane values for CI, and therefore should also resolve the CI failures.

Additionally removed `--durations` which was previously added to help understand timeouts but has not been of much use since.