### PR TITLE
Use SPDX license identifier in pyproject.toml

### DIFF
--- a/conda/recipes/dask-cuda/meta.yaml
+++ b/conda/recipes/dask-cuda/meta.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 
 # Usage:
 #   conda build -c conda-forge .
@@ -50,7 +50,7 @@ test:
 
 about:
   home: {{ data["project"]["urls"]["Homepage"] }}
-  license: {{ data["project"]["license"]["text"] }}
+  license: {{ data["project"]["license"] }}
   license_file:
     {% for e in data["tool"]["setuptools"]["license-files"] %}
     - ../../../{{ e }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]
-license = { text = "Apache 2.0" }
+license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
     "click >=8.1",


### PR DESCRIPTION
This uses an SPDX identifier for the project `license` field in `pyproject.toml`.

xref: https://github.com/rapidsai/build-planning/issues/152
