### PR TITLE
ensure dask_cuda.__git_commit__ is populated

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,12 +33,12 @@ repos:
                 args: ["--module=dask_cuda", "--ignore-missing-imports"]
                 pass_filenames: false
       - repo: https://github.com/rapidsai/pre-commit-hooks
-        rev: v0.4.0
+        rev: v0.6.0
         hooks:
             - id: verify-alpha-spec
             - id: verify-copyright
       - repo: https://github.com/rapidsai/dependency-file-generator
-        rev: v1.16.0
+        rev: v1.17.1
         hooks:
             - id: rapids-dependency-file-generator
               args: ["--clean"]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
+include dask_cuda/GIT_COMMIT
 include dask_cuda/_version.py
 include dask_cuda/VERSION


### PR DESCRIPTION
Installing `dask-cuda` like this:

```shell
pip install \
  --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/ \
  'dask-cuda==25.4.*,>=0.0.0a0'
```

The `__git_commit__` attribute on the main module isn't populated:

```shell
python -c "import dask_cuda; print(dask_cuda.__git_commit__)"
```

The way this *should* work is that `rapids-build-backend` writes a file `dask_cuda/GIT_COMMIT` which is then read by this code: 

https://github.com/rapidsai/dask-cuda/blob/412ef5891f1cca78af48c076e0922874c227b34b/dask_cuda/_version.py#L20-L28

I think that what's happening here is this:

* `rapids-build-backend` *is* writing that file
* the file is not being packaged, because this project uses `setuptools` + a `MANIFEST.in`, and that `MANIFEST.in` does not include that file

This proposes the following:

* add `GIT_COMMIT` to `MANIFEST.in`
* update RAPIDS-specific pre-commit hooks to their latest versions (not related, but might as well, while we're using a CI run anyway)

## Notes for Reviewers

Helpful reference for this... "Controlling files in the distribution" from the `setuptools` docs: https://setuptools.pypa.io/en/latest/userguide/miscellaneous.html