### PR TITLE
Updated shuffle for new setattr

### DIFF
--- a/dask_cuda/explicit_comms/dataframe/shuffle.py
+++ b/dask_cuda/explicit_comms/dataframe/shuffle.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2021-2025 NVIDIA CORPORATION.
+
 from __future__ import annotations
 
 import asyncio
@@ -599,12 +601,13 @@ def patch_shuffle_expression() -> None:
             if not hasattr(self, "_ec_shuffled"):
                 on = self.partitioning_index
                 df = dask_expr.new_collection(self.frame)
-                self._ec_shuffled = shuffle(
+                ec_shuffled = shuffle(
                     df,
                     [on] if isinstance(on, str) else on,
                     self.npartitions_out,
                     self.ignore_index,
                 )
+                object.__setattr__(self, "_ec_shuffled", ec_shuffled)
             graph = self._ec_shuffled.dask.copy()
             shuffled_name = self._ec_shuffled._name
             for i in range(self.npartitions_out):


### PR DESCRIPTION
The base class for Shuffle has changed such that doing self._name = value doesn't work for attributes not defined on the class when it's instantiated. Trying to monkey-patch that on later gives

```
  File "/__w/dask-upstream-testing/dask-upstream-testing/.venv/lib/python3.12/site-packages/dask/_expr.py", line 183, in __setattr__
    raise AttributeError(
AttributeError: ECShuffle object has no attribute _ec_shuffled
```

xref https://github.com/rapidsai/dask-upstream-testing/issues/37