### PR TITLE
Workaround hang with dask main and explicit comms

### DIFF
--- a/dask_cuda/_compat.py
+++ b/dask_cuda/_compat.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2025 NVIDIA CORPORATION.
+# Copyright (c) 2025 NVIDIA CORPORATION.
 
 import functools
 import importlib.metadata

--- a/dask_cuda/_compat.py
+++ b/dask_cuda/_compat.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2021-2025 NVIDIA CORPORATION.
+
+import functools
+import importlib.metadata
+
+import packaging.version
+
+
+@functools.lru_cache(maxsize=None)
+def get_dask_version() -> packaging.version.Version:
+    return packaging.version.parse(importlib.metadata.version("dask"))
+
+
+@functools.lru_cache(maxsize=None)
+def DASK_2025_4_0():
+    # dask 2025.4.0 isn't currently released, so we're relying
+    # on strictly greater than here.
+    return get_dask_version() > packaging.version.parse("2025.3.0")

--- a/dask_cuda/explicit_comms/dataframe/shuffle.py
+++ b/dask_cuda/explicit_comms/dataframe/shuffle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 from collections import defaultdict
 from math import ceil
 from operator import getitem
@@ -25,6 +26,7 @@ from distributed import wait
 from distributed.protocol import nested_deserialize, to_serialize
 from distributed.worker import Worker
 
+from ..._compat import DASK_2025_4_0
 from .. import comms
 
 T = TypeVar("T")
@@ -584,6 +586,124 @@ def _use_explicit_comms() -> bool:
     return False
 
 
+_base_lower = dask_expr._shuffle.Shuffle._lower
+_base_compute = dask.base.compute
+
+
+def _contains_shuffle_expr(*args) -> bool:
+    """
+    Check whether any of the arguments is a Shuffle expression.
+
+    This is called by `compute`, which is given a sequence of Dask Collections
+    to process. For each of those, we'll check whether the expresion contains a
+    Shuffle operation.
+    """
+    for collection in args:
+        if isinstance(collection, dask.dataframe.DataFrame):
+            shuffle_ops = list(
+                collection.expr.find_operations(
+                    (dask_expr._shuffle.RearrangeByColumn, dask_expr.SetIndex)
+                )
+            )
+            if len(shuffle_ops) > 0:
+                return True
+    return False
+
+
+@functools.wraps(_base_compute)
+def _patched_compute(
+    *args,
+    traverse=True,
+    optimize_graph=True,
+    scheduler=None,
+    get=None,
+    **kwargs,
+):
+    # A patched version of dask.compute that explicitly materializes the task
+    # graph when we're using explicit-comms and the expression contains a
+    # Shuffle operation.
+    # https://github.com/rapidsai/dask-upstream-testing/issues/37#issuecomment-2779798670
+    # contains more details on the issue.
+    if DASK_2025_4_0() and _use_explicit_comms() and _contains_shuffle_expr(*args):
+        from dask.base import (
+            collections_to_expr,
+            flatten,
+            get_scheduler,
+            shorten_traceback,
+            unpack_collections,
+        )
+
+        collections, repack = unpack_collections(*args, traverse=traverse)
+        if not collections:
+            return args
+
+        schedule = get_scheduler(
+            scheduler=scheduler,
+            collections=collections,
+            get=get,
+        )
+        from dask._expr import FinalizeCompute
+
+        expr = collections_to_expr(collections, optimize_graph)
+        expr = FinalizeCompute(expr)
+
+        with shorten_traceback():
+            expr = expr.optimize()
+            keys = list(flatten(expr.__dask_keys__()))
+
+            # materialize the HLG here
+            expr = dict(expr.__dask_graph__())
+
+            results = schedule(expr, keys, **kwargs)
+            return repack(results)
+
+    else:
+        return _base_compute(
+            *args,
+            traverse=traverse,
+            optimize_graph=optimize_graph,
+            scheduler=scheduler,
+            get=get,
+            **kwargs,
+        )
+
+
+class ECShuffle(dask_expr._shuffle.TaskShuffle):
+    """Explicit-Comms Shuffle Expression."""
+
+    def _layer(self):
+        # Execute an explicit-comms shuffle
+        if not hasattr(self, "_ec_shuffled"):
+            on = self.partitioning_index
+            df = dask_expr.new_collection(self.frame)
+            ec_shuffled = shuffle(
+                df,
+                [on] if isinstance(on, str) else on,
+                self.npartitions_out,
+                self.ignore_index,
+            )
+            object.__setattr__(self, "_ec_shuffled", ec_shuffled)
+        graph = self._ec_shuffled.dask.copy()
+        shuffled_name = self._ec_shuffled._name
+        for i in range(self.npartitions_out):
+            graph[(self._name, i)] = graph[(shuffled_name, i)]
+        return graph
+
+
+def _patched_lower(self):
+    if self.method in (None, "tasks") and _use_explicit_comms():
+        return ECShuffle(
+            self.frame,
+            self.partitioning_index,
+            self.npartitions_out,
+            self.ignore_index,
+            self.options,
+            self.original_partitioning_index,
+        )
+    else:
+        return _base_lower(self)
+
+
 def patch_shuffle_expression() -> None:
     """Patch Dasks Shuffle expression.
 
@@ -592,41 +712,6 @@ def patch_shuffle_expression() -> None:
     an `ECShuffle` expression when the 'explicit-comms'
     config is set to `True`.
     """
-
-    class ECShuffle(dask_expr._shuffle.TaskShuffle):
-        """Explicit-Comms Shuffle Expression."""
-
-        def _layer(self):
-            # Execute an explicit-comms shuffle
-            if not hasattr(self, "_ec_shuffled"):
-                on = self.partitioning_index
-                df = dask_expr.new_collection(self.frame)
-                ec_shuffled = shuffle(
-                    df,
-                    [on] if isinstance(on, str) else on,
-                    self.npartitions_out,
-                    self.ignore_index,
-                )
-                object.__setattr__(self, "_ec_shuffled", ec_shuffled)
-            graph = self._ec_shuffled.dask.copy()
-            shuffled_name = self._ec_shuffled._name
-            for i in range(self.npartitions_out):
-                graph[(self._name, i)] = graph[(shuffled_name, i)]
-            return graph
-
-    _base_lower = dask_expr._shuffle.Shuffle._lower
-
-    def _patched_lower(self):
-        if self.method in (None, "tasks") and _use_explicit_comms():
-            return ECShuffle(
-                self.frame,
-                self.partitioning_index,
-                self.npartitions_out,
-                self.ignore_index,
-                self.options,
-                self.original_partitioning_index,
-            )
-        else:
-            return _base_lower(self)
+    dask.base.compute = _patched_compute
 
     dask_expr._shuffle.Shuffle._lower = _patched_lower

--- a/dask_cuda/explicit_comms/dataframe/shuffle.py
+++ b/dask_cuda/explicit_comms/dataframe/shuffle.py
@@ -602,7 +602,11 @@ def _contains_shuffle_expr(*args) -> bool:
         if isinstance(collection, dask.dataframe.DataFrame):
             shuffle_ops = list(
                 collection.expr.find_operations(
-                    (dask_expr._shuffle.RearrangeByColumn, dask_expr.SetIndex)
+                    (
+                        dask_expr._shuffle.RearrangeByColumn,
+                        dask_expr.SetIndex,
+                        dask_expr._shuffle.Shuffle,
+                    )
                 )
             )
             if len(shuffle_ops) > 0:

--- a/dask_cuda/tests/test_explicit_comms.py
+++ b/dask_cuda/tests/test_explicit_comms.py
@@ -531,7 +531,6 @@ def test_scaled_cluster_gets_new_comms_context():
 
 
 def test_contains_shuffle_expr():
-    # a regular
     df = dd.from_pandas(pd.DataFrame({"key": np.arange(10)}), npartitions=2)
     assert not _contains_shuffle_expr(
         df,

--- a/dask_cuda/tests/test_explicit_comms.py
+++ b/dask_cuda/tests/test_explicit_comms.py
@@ -31,11 +31,6 @@ mp = mp.get_context("spawn")  # type: ignore
 ucp = pytest.importorskip("ucp")
 
 
-# Set default shuffle method to "tasks"
-if dask.config.get("dataframe.shuffle.method", None) is None:
-    dask.config.set({"dataframe.shuffle.method": "tasks"})
-
-
 # Notice, all of the following tests is executed in a new process such
 # that UCX options of the different tests doesn't conflict.
 

--- a/dask_cuda/tests/test_explicit_comms.py
+++ b/dask_cuda/tests/test_explicit_comms.py
@@ -21,7 +21,10 @@ from distributed.deploy.local import LocalCluster
 
 import dask_cuda
 from dask_cuda.explicit_comms import comms
-from dask_cuda.explicit_comms.dataframe.shuffle import shuffle as explicit_comms_shuffle
+from dask_cuda.explicit_comms.dataframe.shuffle import (
+    _contains_shuffle_expr,
+    shuffle as explicit_comms_shuffle,
+)
 from dask_cuda.utils_test import IncreasedCloseTimeoutNanny
 
 mp = mp.get_context("spawn")  # type: ignore
@@ -530,3 +533,29 @@ def test_scaled_cluster_gets_new_comms_context():
                 expected = shuffled.compute()
 
             assert_eq(result, expected)
+
+
+def test_contains_shuffle_expr():
+    # a regular
+    df = dd.from_pandas(pd.DataFrame({"key": np.arange(10)}), npartitions=2)
+    assert not _contains_shuffle_expr(
+        df,
+    )
+
+    with dask.config.set(explicit_comms=True):
+        shuffled = df.shuffle(on="key")
+
+        assert _contains_shuffle_expr(
+            shuffled,
+        )
+        assert not _contains_shuffle_expr(
+            df,
+        )
+
+        # this requires an active client.
+        with LocalCluster(n_workers=1) as cluster:
+            with Client(cluster):
+                explict_shuffled = explicit_comms_shuffle(df, ["key"])
+                assert not _contains_shuffle_expr(
+                    explict_shuffled,
+                )

--- a/dask_cuda/tests/test_explicit_comms.py
+++ b/dask_cuda/tests/test_explicit_comms.py
@@ -532,24 +532,16 @@ def test_scaled_cluster_gets_new_comms_context():
 
 def test_contains_shuffle_expr():
     df = dd.from_pandas(pd.DataFrame({"key": np.arange(10)}), npartitions=2)
-    assert not _contains_shuffle_expr(
-        df,
-    )
+    assert not _contains_shuffle_expr(df)
 
     with dask.config.set(explicit_comms=True):
         shuffled = df.shuffle(on="key")
 
-        assert _contains_shuffle_expr(
-            shuffled,
-        )
-        assert not _contains_shuffle_expr(
-            df,
-        )
+        assert _contains_shuffle_expr(shuffled)
+        assert not _contains_shuffle_expr(df)
 
         # this requires an active client.
         with LocalCluster(n_workers=1) as cluster:
             with Client(cluster):
                 explict_shuffled = explicit_comms_shuffle(df, ["key"])
-                assert not _contains_shuffle_expr(
-                    explict_shuffled,
-                )
+                assert not _contains_shuffle_expr(explict_shuffled)


### PR DESCRIPTION
Dask>2025.3.0 will delay materialization of the task graph for more operations, including expressions and HighLevelGraphs. The final task graph will now be built on the scheduler.

The explicit-comms shuffle relied on the low-level graph being materialized on the client. Parts of the task generation in `ECShuffle._lower` use code that, apparently, doesn't run well on the scheduler in the context of graph materialization.

This works around that issue by continuing to materialize the task graph on the client before sending it to the scheduler. We only do this when we're using explicit comms and the result to compute contains a shuffle task.

https://github.com/rapidsai/dask-upstream-testing/issues/37#issuecomment-2779798670 contains more information on the issue.

Given the fragility of this, a followup PR will deprecate using explicit comms shuffle through `df.shuffle()`. It'll still be available through `explicit_comms.dataframe.shuffle(df)`.