### PR TITLE
Add missing `runs-on` to `ucxx-python-tests`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,6 +27,7 @@ jobs:
       sha: ${{ inputs.sha }}
   ucxx-python-tests:
     if: inputs.build_type == 'nightly'
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code repo
         uses: actions/checkout@v4


### PR DESCRIPTION
The `runs-on` option is required and may use `ubuntu-latest`, as it is just used to launch another workflow.