### PR TITLE
Move env out of with context workflow context

### DIFF
--- a/.github/workflows/test_ucxx.yaml
+++ b/.github/workflows/test_ucxx.yaml
@@ -16,12 +16,12 @@ jobs:
   ucxx-python-tests:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-25.06
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GHA_DASK_UCXX_ONLY: true
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       script: ci/test_python.sh
-      env:
-        GH_TOKEN: ${{ github.token }}
-        GHA_DASK_UCXX_ONLY: true


### PR DESCRIPTION
The `env` context in GHA workflows cannot be within `with` context, causing errors as below:

```
The workflow is not valid. .github/workflows/test_ucxx.yaml (Line: 26, Col: 9): A mapping was not expected
```