### PR TITLE
Reference public cuDF Python objects during dispatch registration

### DIFF
--- a/dask_cuda/get_device_memory_objects.py
+++ b/dask_cuda/get_device_memory_objects.py
@@ -89,38 +89,28 @@ def get_device_memory_objects_register_cupy():
 
 @dispatch.register_lazy("cudf")
 def get_device_memory_objects_register_cudf():
-    import cudf.core.frame
-    import cudf.core.index
-    import cudf.core.multiindex
-    import cudf.core.series
+    import cudf
 
-    @dispatch.register(cudf.core.frame.Frame)
-    def get_device_memory_objects_cudf_frame(obj):
-        ret = []
-        for col in obj._data.columns:
-            ret += dispatch(col)
-        return ret
+    @dispatch.register(cudf.DataFrame)
+    def get_device_memory_objects_cudf_dataframe(obj):
+        return dispatch(obj.index) + dispatch(obj._columns)
 
-    @dispatch.register(cudf.core.indexed_frame.IndexedFrame)
-    def get_device_memory_objects_cudf_indexed_frame(obj):
-        return dispatch(obj._index) + get_device_memory_objects_cudf_frame(obj)
-
-    @dispatch.register(cudf.core.series.Series)
+    @dispatch.register(cudf.Series)
     def get_device_memory_objects_cudf_series(obj):
-        return dispatch(obj._index) + dispatch(obj._column)
+        return dispatch(obj.index) + dispatch(obj._column)
 
-    @dispatch.register(cudf.core.index.RangeIndex)
+    @dispatch.register(cudf.RangeIndex)
     def get_device_memory_objects_cudf_range_index(obj):
         # Avoid materializing RangeIndex. This introduce some inaccuracies
         # in total device memory usage, which we accept because the memory
         # use of RangeIndexes are limited.
         return []
 
-    @dispatch.register(cudf.core.index.Index)
+    @dispatch.register(cudf.Index)
     def get_device_memory_objects_cudf_index(obj):
-        return dispatch(obj._values)
+        return dispatch(obj._column)
 
-    @dispatch.register(cudf.core.multiindex.MultiIndex)
+    @dispatch.register(cudf.MultiIndex)
     def get_device_memory_objects_cudf_multiindex(obj):
         return dispatch(obj._columns)
 

--- a/dask_cuda/get_device_memory_objects.py
+++ b/dask_cuda/get_device_memory_objects.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2025 NVIDIA CORPORATION.
 from typing import Set
 
 from dask.sizeof import sizeof

--- a/dask_cuda/is_device_object.py
+++ b/dask_cuda/is_device_object.py
@@ -35,6 +35,8 @@ def register_cudf():
     def is_device_object_cudf_series(s):
         return True
 
-    @is_device_object.register(cudf.BaseIndex)
+    @is_device_object.register(cudf.RangeIndex)
+    @is_device_object.register(cudf.Index)
+    @is_device_object.register(cudf.MultiIndex)
     def is_device_object_cudf_index(s):
         return True

--- a/dask_cuda/is_device_object.py
+++ b/dask_cuda/is_device_object.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2025 NVIDIA CORPORATION.
 from __future__ import absolute_import, division, print_function
 
 from dask.utils import Dispatch

--- a/dask_cuda/is_spillable_object.py
+++ b/dask_cuda/is_spillable_object.py
@@ -30,11 +30,14 @@ def register_cudf():
     import cudf
     from cudf.core.frame import Frame
 
-    @is_spillable_object.register(Frame)
+    @is_spillable_object.register(cudf.DataFrame)
+    @is_spillable_object.register(cudf.Series)
     def is_device_object_cudf_dataframe(df):
         return cudf_spilling_status()
 
-    @is_spillable_object.register(cudf.BaseIndex)
+    @is_spillable_object.register(cudf.RangeIndex)
+    @is_spillable_object.register(cudf.Index)
+    @is_spillable_object.register(cudf.MultiIndex)
     def is_device_object_cudf_index(s):
         return cudf_spilling_status()
 

--- a/dask_cuda/is_spillable_object.py
+++ b/dask_cuda/is_spillable_object.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2025 NVIDIA CORPORATION.
 from __future__ import absolute_import, division, print_function
 
 from typing import Optional
@@ -28,7 +29,6 @@ def _(o):
 @is_spillable_object.register_lazy("cudf")
 def register_cudf():
     import cudf
-    from cudf.core.frame import Frame
 
     @is_spillable_object.register(cudf.DataFrame)
     @is_spillable_object.register(cudf.Series)

--- a/dask_cuda/proxify_device_objects.py
+++ b/dask_cuda/proxify_device_objects.py
@@ -242,7 +242,9 @@ def _register_cudf():
 
     @dispatch.register(cudf.DataFrame)
     @dispatch.register(cudf.Series)
-    @dispatch.register(cudf.BaseIndex)
+    @dispatch.register(cudf.RangeIndex)
+    @dispatch.register(cudf.Index)
+    @dispatch.register(cudf.MultiIndex)
     def proxify_device_object_cudf_dataframe(
         obj, proxied_id_to_proxy, found_proxies, excl_proxies
     ):

--- a/dask_cuda/proxify_device_objects.py
+++ b/dask_cuda/proxify_device_objects.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2025 NVIDIA CORPORATION.
 import functools
 import pydoc
 from collections import defaultdict


### PR DESCRIPTION
It appears some non-public subclasses were being referenced during registration such as `cudf.BaseIndex` or `cudf.core.frame.Frame`. It would be great to instead reference the public objects in cuDF python that should more commonly appear so cuDF has liberty to modify these non-public subclasses in the future.