### PR TITLE
Register OwnerWithCAI with dask.utils.sizeof

### DIFF
--- a/dask_cuda/get_device_memory_objects.py
+++ b/dask_cuda/get_device_memory_objects.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+
 from typing import Set
 
 from dask.sizeof import sizeof
@@ -140,3 +142,15 @@ def register_cupy():  # NB: this overwrites dask.sizeof.register_cupy()
     @sizeof.register(cupy.ndarray)
     def sizeof_cupy_ndarray(x):
         return int(x.nbytes)
+
+
+@sizeof.register_lazy("pylibcudf")
+def register_pylibcudf():
+    import cupy
+    import pylibcudf
+
+    @sizeof.register(pylibcudf.column.OwnerWithCAI)
+    def sizeof_owner_with_cai(x):
+        # OwnerWithCAI implements __cuda_array_interface__
+        # so this should always be zero-copy
+        return cupy.array(x, copy=False).nbytes

--- a/dask_cuda/get_device_memory_objects.py
+++ b/dask_cuda/get_device_memory_objects.py
@@ -153,5 +153,5 @@ def register_pylibcudf():
         # OwnerWithCAI implements __cuda_array_interface__ so this should always
         # be zero-copy
         col = pylibcudf.column.Column.from_cuda_array_interface(x)
-        # col.data() returns a gpumemoryview, which knows the size in bytes 
+        # col.data() returns a gpumemoryview, which knows the size in bytes
         return col.data().nbytes

--- a/dask_cuda/get_device_memory_objects.py
+++ b/dask_cuda/get_device_memory_objects.py
@@ -153,4 +153,5 @@ def register_pylibcudf():
         # OwnerWithCAI implements __cuda_array_interface__ so this should always
         # be zero-copy
         col = pylibcudf.column.Column.from_cuda_array_interface(x)
+        # col.data() returns a gpumemoryview, which knows the size in bytes 
         return col.data().nbytes

--- a/dask_cuda/get_device_memory_objects.py
+++ b/dask_cuda/get_device_memory_objects.py
@@ -146,11 +146,11 @@ def register_cupy():  # NB: this overwrites dask.sizeof.register_cupy()
 
 @sizeof.register_lazy("pylibcudf")
 def register_pylibcudf():
-    import cupy
     import pylibcudf
 
     @sizeof.register(pylibcudf.column.OwnerWithCAI)
     def sizeof_owner_with_cai(x):
-        # OwnerWithCAI implements __cuda_array_interface__
-        # so this should always be zero-copy
-        return cupy.array(x, copy=False).nbytes
+        # OwnerWithCAI implements __cuda_array_interface__ so this should always
+        # be zero-copy
+        col = pylibcudf.column.Column.from_cuda_array_interface(x)
+        return col.data().nbytes

--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+
 from typing import Iterable
 from unittest.mock import patch
 
@@ -498,3 +500,14 @@ def test_on_demand_debug_info():
             assert f"WARNING - RMM allocation of {size} failed" in log
             assert f"RMM allocs: {size}" in log
             assert "traceback:" in log
+
+
+def test_sizeof_owner_with_cai():
+    cudf = pytest.importorskip("cudf")
+    s = cudf.Series([1, 2, 3])
+
+    items = dask_cuda.get_device_memory_objects.dispatch(s)
+    assert len(items) == 1
+    item = items[0]
+    result = dask.sizeof.sizeof(item)
+    assert result == 24


### PR DESCRIPTION
Fixes the failing proxy test seen in https://github.com/rapidsai/dask-cuda/pull/1467.

---

The first change we see is in `get_device_memory_objcects.dispatch`


```python
import cudf
import dask_cuda.get_device_memory_objects
import dask.sizeof


def main():
    s = cudf.Series([1, 2, 3])
    
    items = dask_cuda.get_device_memory_objects.dispatch(s)
    print(items, dask.sizeof.sizeof(s), dask.sizeof.sizeof(items[0]))


if __name__ == "__main__":
    main()
```

Previously, that found the RMM DeviceBuffer. The sizeof the Series was 48 and the sizeof the DeviceBuffer was 24:

```
./old/bin/python ./debug.py 
[<rmm.pylibrmm.device_buffer.DeviceBuffer object at 0x7fb53dfd0940>] 48 24
```

Now, we get a `pylibcudf.column.OwnerWithCAI`. The sizeof the Series is still 48, but now the sizeof this OwnerWithCAI thing is 56, I think because Dask is using some default sizeof for unknown objects?

```
./new/bin/python ./debug.py 
[<pylibcudf.column.OwnerWithCAI object at 0x7fec2b6d5a00>] 48 56
```

This causes the test to fail because the program sees we've crossed some memory limit (thanks to 56 > 24) and spills the cupy array, which breaks the identity assert.
