### PR TITLE
Make workflows reusable

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,20 @@ on:
       build_type:
         type: string
         default: nightly
+  workflow_call:
+    inputs:
+      branch:
+        required: true
+        type: string
+      date:
+        required: true
+        type: string
+      sha:
+        required: true
+        type: string
+      build_type:
+        type: string
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -1,4 +1,4 @@
-name: Trigger Nightly Build and Test Pipelines
+name: Trigger UCXX Nightly Build and Test Pipelines
 
 on:
   schedule:
@@ -29,7 +29,7 @@ jobs:
 
   test:
     needs: build
-    uses: ./.github/workflows/test.yaml
+    uses: ./.github/workflows/test-ucxx.yaml
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/test-ucxx.yaml
+++ b/.github/workflows/test-ucxx.yaml
@@ -15,6 +15,20 @@ on:
       build_type:
         type: string
         default: nightly
+  workflow_call:
+    inputs:
+      branch:
+        required: true
+        type: string
+      date:
+        required: true
+        type: string
+      sha:
+        required: true
+        type: string
+      build_type:
+        type: string
+        required: true
 
 jobs:
   conda-python-ucxx-tests:


### PR DESCRIPTION
Some necessary changes were missed in #1470: make `build` and `test-ucxx` reusable workflows so that they can be called from `nighly-pipeline`.