### PR TITLE
Disable codecov step in custom `test-ucxx` workflow

### DIFF
--- a/.github/workflows/test-ucxx.yaml
+++ b/.github/workflows/test-ucxx.yaml
@@ -39,4 +39,5 @@ jobs:
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
+      run_codecov: false
       script: ci/test_python_ucxx.sh


### PR DESCRIPTION
After #1472 the tests now run to completion but fail due to the missing token for codecov, thus it should be disabled.