### PR TITLE
Add function to get device handle and fix MIG handle

### DIFF
--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import absolute_import, division, print_function
 
 import os
@@ -16,7 +19,7 @@ from dask_cuda.utils import (
     get_cluster_configuration,
     get_device_total_memory,
     get_gpu_count_mig,
-    get_gpu_uuid_from_index,
+    get_gpu_uuid,
     get_n_gpus,
     wait_workers,
 )
@@ -409,7 +412,7 @@ def test_cuda_mig_visible_devices_and_memory_limit_and_nthreads(loop):  # noqa: 
 
 
 def test_cuda_visible_devices_uuid(loop):  # noqa: F811
-    gpu_uuid = get_gpu_uuid_from_index(0)
+    gpu_uuid = get_gpu_uuid(0)
 
     with patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": gpu_uuid}):
         with popen(["dask", "scheduler", "--port", "9359", "--no-dashboard"]):

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
 import asyncio
 import os
 import pkgutil
@@ -16,7 +19,7 @@ from dask_cuda.utils import (
     get_cluster_configuration,
     get_device_total_memory,
     get_gpu_count_mig,
-    get_gpu_uuid_from_index,
+    get_gpu_uuid,
     print_cluster_config,
 )
 from dask_cuda.utils_test import MockWorker
@@ -419,7 +422,7 @@ async def test_available_mig_workers():
 
 @gen_test(timeout=20)
 async def test_gpu_uuid():
-    gpu_uuid = get_gpu_uuid_from_index(0)
+    gpu_uuid = get_gpu_uuid(0)
 
     async with LocalCUDACluster(
         CUDA_VISIBLE_DEVICES=gpu_uuid,

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -191,7 +191,7 @@ def get_cpu_affinity(device_index=None):
             math.ceil(get_cpu_count() / 64),
         )
         return unpack_bitmask(affinity)
-    except pynvml.NVMLError:
+    except (pynvml.NVMLError, ValueError):
         warnings.warn(
             "Cannot get CPU affinity for device with index %d, setting default affinity"
             % device_index

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -89,36 +89,43 @@ def get_gpu_count():
     return pynvml.nvmlDeviceGetCount()
 
 
-def get_gpu_handle(device_index=0):
+def get_gpu_handle(device_id=0):
     """Get GPU handle from device index or UUID.
 
     Parameters
     ----------
-    device_index: int or str
+    device_id: int or str
         The index or UUID of the device from which to obtain the handle.
+
+    Raises
+    ------
+    ValueError
+        If acquiring the device handle for the device specified failed.
+    pynvml.NVMLError
+        If any NVML error occurred while initializing.
 
     Examples
     --------
-    >>> get_gpu_handle(device_index=0)
+    >>> get_gpu_handle(device_id=0)
 
-    >>> get_gpu_handle(device_index="GPU-9fb42d6f-7d6b-368f-f79c-3c3e784c93f6")
+    >>> get_gpu_handle(device_id="GPU-9fb42d6f-7d6b-368f-f79c-3c3e784c93f6")
     """
     pynvml.nvmlInit()
 
     try:
-        if device_index and not str(device_index).isnumeric():
-            # This means device_index is UUID.
+        if device_id and not str(device_id).isnumeric():
+            # This means device_id is UUID.
             # This works for both MIG and non-MIG device UUIDs.
-            handle = pynvml.nvmlDeviceGetHandleByUUID(str.encode(device_index))
+            handle = pynvml.nvmlDeviceGetHandleByUUID(str.encode(device_id))
             if pynvml.nvmlDeviceIsMigDeviceHandle(handle):
                 # Additionally get parent device handle
                 # if the device itself is a MIG instance
                 handle = pynvml.nvmlDeviceGetDeviceHandleFromMigDeviceHandle(handle)
         else:
-            handle = pynvml.nvmlDeviceGetHandleByIndex(device_index)
+            handle = pynvml.nvmlDeviceGetHandleByIndex(device_id)
         return handle
     except pynvml.NVMLError:
-        raise ValueError(f"Invalid device index: {device_index}")
+        raise ValueError(f"Invalid device index or UUID: {device_id}")
 
 
 @toolz.memoize


### PR DESCRIPTION
This change reduces duplication on code getting NVML device handles and fixes one instance where getting the MIG handle was not previously done correctly. It has a small breaking change on the `get_gpu_uuid_from_index` function being renamed to `get_gpu_uuid`, but there are apparently no uses outside of Dask-CUDA.