### PR TITLE
chore: bump upper bound of numba for python 3.13 support

### DIFF
--- a/conda/environments/all_cuda-114_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-114_arch-aarch64.yaml
@@ -15,7 +15,7 @@ dependencies:
 - distributed-ucxx==0.44.*,>=0.0.0a0
 - kvikio==25.6.*,>=0.0.0a0
 - numactl-devel-cos7-aarch64
-- numba>=0.59.1,<0.61.0a0
+- numba>=0.59.1,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc>=1.1.0
 - pandas>=1.3

--- a/conda/environments/all_cuda-114_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-114_arch-x86_64.yaml
@@ -15,7 +15,7 @@ dependencies:
 - distributed-ucxx==0.44.*,>=0.0.0a0
 - kvikio==25.6.*,>=0.0.0a0
 - numactl-devel-cos7-x86_64
-- numba>=0.59.1,<0.61.0a0
+- numba>=0.59.1,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc>=1.1.0
 - pandas>=1.3

--- a/conda/environments/all_cuda-118_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-118_arch-aarch64.yaml
@@ -15,7 +15,7 @@ dependencies:
 - distributed-ucxx==0.44.*,>=0.0.0a0
 - kvikio==25.6.*,>=0.0.0a0
 - numactl-devel-cos7-aarch64
-- numba>=0.59.1,<0.61.0a0
+- numba>=0.59.1,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc>=1.1.0
 - pandas>=1.3

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -15,7 +15,7 @@ dependencies:
 - distributed-ucxx==0.44.*,>=0.0.0a0
 - kvikio==25.6.*,>=0.0.0a0
 - numactl-devel-cos7-x86_64
-- numba>=0.59.1,<0.61.0a0
+- numba>=0.59.1,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc>=1.1.0
 - pandas>=1.3

--- a/conda/environments/all_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-128_arch-aarch64.yaml
@@ -16,7 +16,7 @@ dependencies:
 - distributed-ucxx==0.44.*,>=0.0.0a0
 - kvikio==25.6.*,>=0.0.0a0
 - numactl-devel-cos7-aarch64
-- numba>=0.59.1,<0.61.0a0
+- numba>=0.59.1,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc>=1.1.0
 - pandas>=1.3

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -16,7 +16,7 @@ dependencies:
 - distributed-ucxx==0.44.*,>=0.0.0a0
 - kvikio==25.6.*,>=0.0.0a0
 - numactl-devel-cos7-x86_64
-- numba>=0.59.1,<0.61.0a0
+- numba>=0.59.1,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc>=1.1.0
 - pandas>=1.3

--- a/conda/recipes/dask-cuda/recipe.yaml
+++ b/conda/recipes/dask-cuda/recipe.yaml
@@ -36,7 +36,7 @@ requirements:
   run:
     - python
     - click >=8.1
-    - numba >=0.59.1,<0.61.0a0
+    - numba >=0.59.1,<0.62.0a0
     - numpy >=1.23,<3.0a0
     - pandas >=1.3
     - pynvml >=12.0.0,<13.0.0a0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -156,7 +156,7 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         packages:
           - click >=8.1
-          - numba>=0.59.1,<0.61.0a0
+          - numba>=0.59.1,<0.62.0a0
           - numpy>=1.23,<3.0a0
           - pandas>=1.3
           - pynvml>=12.0.0,<13.0.0a0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ license = { text = "Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
     "click >=8.1",
-    "numba>=0.59.1,<0.61.0a0",
+    "numba>=0.59.1,<0.62.0a0",
     "numpy>=1.23,<3.0a0",
     "pandas>=1.3",
     "pynvml>=12.0.0,<13.0.0a0",


### PR DESCRIPTION
xref #rapidsai/build-planning#120

This upper pin on `numba` is preventing a solve in `cudf` for the Python 3.13 environment
