### PR TITLE
Add UCXX blocking tests in nightly CI runs

### DIFF
--- a/.github/workflows/build-ucxx.yaml
+++ b/.github/workflows/build-ucxx.yaml
@@ -1,4 +1,4 @@
-name: build
+name: Build Dask-CUDA for UCXX
 
 on:
   push:

--- a/ci/run_benchmarks.sh
+++ b/ci/run_benchmarks.sh
@@ -10,34 +10,39 @@ python benchmarks/local_cudf_shuffle.py \
   --partition-size="1 KiB" \
   -d 0 \
   --runs 1 \
-  --backend dask
+  --backend dask \
+  "$@"
 
 python benchmarks/local_cudf_shuffle.py \
   --partition-size="1 KiB" \
   -d 0 \
   --runs 1 \
-  --backend explicit-comms
+  --backend explicit-comms \
+  "$@"
 
 python benchmarks/local_cudf_shuffle.py \
   --disable-rmm \
   --partition-size="1 KiB" \
   -d 0 \
   --runs 1 \
-  --backend explicit-comms
+  --backend explicit-comms \
+  "$@"
 
 python benchmarks/local_cudf_shuffle.py \
   --disable-rmm-pool \
   --partition-size="1 KiB" \
   -d 0 \
   --runs 1 \
-  --backend explicit-comms
+  --backend explicit-comms \
+  "$@"
 
 python benchmarks/local_cudf_shuffle.py \
   --rmm-pool-size 2GiB \
   --partition-size="1 KiB" \
   -d 0 \
   --runs 1 \
-  --backend explicit-comms
+  --backend explicit-comms \
+  "$@"
 
 python benchmarks/local_cudf_shuffle.py \
   --rmm-pool-size 2GiB \
@@ -45,7 +50,8 @@ python benchmarks/local_cudf_shuffle.py \
   --partition-size="1 KiB" \
   -d 0 \
   --runs 1 \
-  --backend explicit-comms
+  --backend explicit-comms \
+  "$@"
 
 python benchmarks/local_cudf_shuffle.py \
   --rmm-pool-size 2GiB \
@@ -54,7 +60,8 @@ python benchmarks/local_cudf_shuffle.py \
   --partition-size="1 KiB" \
   -d 0 \
   --runs 1 \
-  --backend explicit-comms
+  --backend explicit-comms \
+  "$@"
 
 python benchmarks/local_cudf_shuffle.py \
   --rmm-pool-size 2GiB \
@@ -63,4 +70,5 @@ python benchmarks/local_cudf_shuffle.py \
   --partition-size="1 KiB" \
   -d 0 \
   --runs 1 \
-  --backend explicit-comms
+  --backend explicit-comms \
+  "$@"

--- a/ci/test_python_ucxx.sh
+++ b/ci/test_python_ucxx.sh
@@ -41,7 +41,7 @@ set_exit_code() {
 trap set_exit_code ERR
 set +e
 
-rapids-logger "pytest dask-cuda"
+rapids-logger "pytest dask-cuda with ucxx"
 ./ci/run_pytest.sh \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-dask-cuda.xml" \
   --cov-config=../pyproject.toml \
@@ -50,8 +50,21 @@ rapids-logger "pytest dask-cuda"
   --cov-report=term \
   -k "ucxx"
 
-rapids-logger "Run local benchmark"
-./ci/run_benchmarks.sh
+rapids-logger "Run local benchmark with ucxx"
+./ci/run_benchmarks.sh -p ucxx
+
+export UCXPY_PROGRESS_MODE=blocking
+rapids-logger "pytest dask-cuda with ucxx in blocking progress mode"
+./ci/run_pytest.sh \
+  --junitxml="${RAPIDS_TESTS_DIR}/junit-dask-cuda.xml" \
+  --cov-config=../pyproject.toml \
+  --cov=dask_cuda \
+  --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/dask-cuda-coverage.xml" \
+  --cov-report=term \
+  -k "ucxx"
+
+rapids-logger "Run local benchmark with ucxx in blocking progress mode"
+./ci/run_benchmarks.sh -p ucxx
 
 rapids-logger "Test script exiting with latest error code: $EXITCODE"
 exit ${EXITCODE}


### PR DESCRIPTION
Enable blocking progress mode tests for the UCXX test matrix. The default mode in UCXX is `thread`, but we want to test `blocking` too, as this is the equivalent to UCX-Py's default and will likely be used as initial default when switching from UCX-Py to UCXX.