### PR TITLE
provide input 'script' for build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,7 @@ jobs:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      script: ci/build_python.sh
       sha: ${{ inputs.sha }}
   docs-build:
     if: github.ref_type == 'branch'


### PR DESCRIPTION
Nightly builds on `branch-25.06` are failing like this:

> [Invalid workflow file: .github/workflows/build.yaml#L31](https://github.com/rapidsai/dask-cuda/actions/runs/15267027408/workflow)
> The workflow is not valid. .github/workflows/build.yaml (Line: 31, Col: 11): Input script is required, but not provided while calling.

([build link](https://github.com/rapidsai/dask-cuda/actions/runs/15267027408))

Looks like one place was missed in #1496, and that's now showing up as a failure because https://github.com/rapidsai/shared-workflows/pull/362 was merged.

This fixes that.