### PR TITLE
Drop CUDA 11 checks and warnings

### DIFF
--- a/dask_cuda/cli.py
+++ b/dask_cuda/cli.py
@@ -163,9 +163,8 @@ def cuda():
     allocator. See ``rmm.mr.CudaAsyncMemoryResource`` for more info.
 
     .. warning::
-        The asynchronous allocator requires CUDA Toolkit 11.2 or newer. It is also
-        incompatible with RMM pools and managed memory, trying to enable both will
-        result in failure.""",
+        The asynchronous allocator is incompatible with RMM pools and managed memory,
+        trying to enable both will result in failure.""",
 )
 @click.option(
     "--set-rmm-allocator-for-libs",

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -143,9 +143,8 @@ class LocalCUDACluster(LocalCluster):
         See ``rmm.mr.CudaAsyncMemoryResource`` for more info.
 
         .. warning::
-            The asynchronous allocator requires CUDA Toolkit 11.2 or newer. It is also
-            incompatible with RMM pools and managed memory. Trying to enable both will
-            result in an exception.
+            The asynchronous allocator is incompatible with RMM pools and managed
+            memory. Trying to enable both will result in an exception.
     rmm_allocator_external_lib_list: str, list or None, default None
         List of external libraries for which to set RMM as the allocator.
         Supported options are: ``["torch", "cupy"]``. Can be a comma-separated string

--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -119,11 +119,6 @@ def test_rmm_managed(loop):  # noqa: F811
 def test_rmm_async(loop):  # noqa: F811
     rmm = pytest.importorskip("rmm")
 
-    driver_version = rmm._cuda.gpu.driverGetVersion()
-    runtime_version = rmm._cuda.gpu.runtimeGetVersion()
-    if driver_version < 11020 or runtime_version < 11020:
-        pytest.skip("cudaMallocAsync not supported")
-
     with popen(["dask", "scheduler", "--port", "9369", "--no-dashboard"]):
         with popen(
             [
@@ -158,11 +153,6 @@ def test_rmm_async(loop):  # noqa: F811
 
 def test_rmm_async_with_maximum_pool_size(loop):  # noqa: F811
     rmm = pytest.importorskip("rmm")
-
-    driver_version = rmm._cuda.gpu.driverGetVersion()
-    runtime_version = rmm._cuda.gpu.runtimeGetVersion()
-    if driver_version < 11020 or runtime_version < 11020:
-        pytest.skip("cudaMallocAsync not supported")
 
     with popen(["dask", "scheduler", "--port", "9369", "--no-dashboard"]):
         with popen(

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -263,11 +263,6 @@ async def test_rmm_managed():
 async def test_rmm_async():
     rmm = pytest.importorskip("rmm")
 
-    driver_version = rmm._cuda.gpu.driverGetVersion()
-    runtime_version = rmm._cuda.gpu.runtimeGetVersion()
-    if driver_version < 11020 or runtime_version < 11020:
-        pytest.skip("cudaMallocAsync not supported")
-
     async with LocalCUDACluster(
         rmm_async=True,
         rmm_pool_size="2GB",
@@ -289,11 +284,6 @@ async def test_rmm_async():
 @gen_test(timeout=20)
 async def test_rmm_async_with_maximum_pool_size():
     rmm = pytest.importorskip("rmm")
-
-    driver_version = rmm._cuda.gpu.driverGetVersion()
-    runtime_version = rmm._cuda.gpu.runtimeGetVersion()
-    if driver_version < 11020 or runtime_version < 11020:
-        pytest.skip("cudaMallocAsync not supported")
 
     async with LocalCUDACluster(
         rmm_async=True,


### PR DESCRIPTION
Since CUDA 11 is not supported anymore
(see https://github.com/rapidsai/dask-cuda/pull/1503), there's no need anymore for checks and documentation mentioning async memory version requirements.