### PR TITLE
Use CUDA 12.9 in Conda, Devcontainers, Spark, GHA, etc.

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -16,7 +16,7 @@ To install the latest version of Dask-CUDA along with the CUDA Toolkit:
 
 .. code-block:: bash
 
-    conda install -c rapidsai -c conda-forge -c nvidia dask-cuda cuda-version=12.8
+    conda install -c rapidsai -c conda-forge -c nvidia dask-cuda cuda-version=12.9
 
 Pip
 ---


### PR DESCRIPTION
Addressing issues:
* https://github.com/rapidsai/build-planning/issues/195
* https://github.com/rapidsai/build-planning/issues/173

## Description

Use CUDA 12.9 throughout different build and test environments.