### PR TITLE
Update `test_initialize` for to match `protocol="ucx"` changes

### DIFF
--- a/dask_cuda/tests/test_initialize.py
+++ b/dask_cuda/tests/test_initialize.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
 import multiprocessing as mp
 import sys
 
@@ -23,9 +26,9 @@ mp = mp.get_context("spawn")  # type: ignore
 
 def _test_initialize_ucx_tcp(protocol):
     if protocol == "ucx":
-        ucp = pytest.importorskip("ucp")
-    elif protocol == "ucxx":
         ucp = pytest.importorskip("ucxx")
+    elif protocol == "ucx-old":
+        ucp = pytest.importorskip("ucp")
 
     kwargs = {"enable_tcp_over_ucx": True}
     initialize(protocol=protocol, **kwargs)
@@ -55,12 +58,12 @@ def _test_initialize_ucx_tcp(protocol):
             assert all(client.run(check_ucx_options).values())
 
 
-@pytest.mark.parametrize("protocol", ["ucx", "ucxx"])
+@pytest.mark.parametrize("protocol", ["ucx", "ucx-old"])
 def test_initialize_ucx_tcp(protocol):
     if protocol == "ucx":
-        pytest.importorskip("ucp")
-    elif protocol == "ucxx":
         pytest.importorskip("ucxx")
+    elif protocol == "ucx-old":
+        pytest.importorskip("ucp")
 
     p = mp.Process(target=_test_initialize_ucx_tcp, args=(protocol,))
     p.start()
@@ -70,9 +73,9 @@ def test_initialize_ucx_tcp(protocol):
 
 def _test_initialize_ucx_nvlink(protocol):
     if protocol == "ucx":
-        ucp = pytest.importorskip("ucp")
-    elif protocol == "ucxx":
         ucp = pytest.importorskip("ucxx")
+    elif protocol == "ucx-old":
+        ucp = pytest.importorskip("ucp")
 
     kwargs = {"enable_nvlink": True}
     initialize(protocol=protocol, **kwargs)
@@ -103,12 +106,12 @@ def _test_initialize_ucx_nvlink(protocol):
             assert all(client.run(check_ucx_options).values())
 
 
-@pytest.mark.parametrize("protocol", ["ucx", "ucxx"])
+@pytest.mark.parametrize("protocol", ["ucx", "ucx-old"])
 def test_initialize_ucx_nvlink(protocol):
     if protocol == "ucx":
-        pytest.importorskip("ucp")
-    elif protocol == "ucxx":
         pytest.importorskip("ucxx")
+    elif protocol == "ucx-old":
+        pytest.importorskip("ucp")
 
     p = mp.Process(target=_test_initialize_ucx_nvlink, args=(protocol,))
     p.start()
@@ -118,9 +121,9 @@ def test_initialize_ucx_nvlink(protocol):
 
 def _test_initialize_ucx_infiniband(protocol):
     if protocol == "ucx":
-        ucp = pytest.importorskip("ucp")
-    elif protocol == "ucxx":
         ucp = pytest.importorskip("ucxx")
+    elif protocol == "ucx-old":
+        ucp = pytest.importorskip("ucp")
 
     kwargs = {"enable_infiniband": True}
     initialize(protocol=protocol, **kwargs)
@@ -154,12 +157,12 @@ def _test_initialize_ucx_infiniband(protocol):
 @pytest.mark.skipif(
     "ib0" not in psutil.net_if_addrs(), reason="Infiniband interface ib0 not found"
 )
-@pytest.mark.parametrize("protocol", ["ucx", "ucxx"])
+@pytest.mark.parametrize("protocol", ["ucx", "ucx-old"])
 def test_initialize_ucx_infiniband(protocol):
     if protocol == "ucx":
-        pytest.importorskip("ucp")
-    elif protocol == "ucxx":
         pytest.importorskip("ucxx")
+    elif protocol == "ucx-old":
+        pytest.importorskip("ucp")
 
     p = mp.Process(target=_test_initialize_ucx_infiniband, args=(protocol,))
     p.start()
@@ -169,9 +172,9 @@ def test_initialize_ucx_infiniband(protocol):
 
 def _test_initialize_ucx_all(protocol):
     if protocol == "ucx":
-        ucp = pytest.importorskip("ucp")
-    elif protocol == "ucxx":
         ucp = pytest.importorskip("ucxx")
+    elif protocol == "ucx-old":
+        ucp = pytest.importorskip("ucp")
 
     initialize(protocol=protocol)
     with LocalCluster(
@@ -204,12 +207,12 @@ def _test_initialize_ucx_all(protocol):
             assert all(client.run(check_ucx_options).values())
 
 
-@pytest.mark.parametrize("protocol", ["ucx", "ucxx"])
+@pytest.mark.parametrize("protocol", ["ucx", "ucx-old"])
 def test_initialize_ucx_all(protocol):
     if protocol == "ucx":
-        pytest.importorskip("ucp")
-    elif protocol == "ucxx":
         pytest.importorskip("ucxx")
+    elif protocol == "ucx-old":
+        pytest.importorskip("ucp")
 
     p = mp.Process(target=_test_initialize_ucx_all, args=(protocol,))
     p.start()


### PR DESCRIPTION
With changes from https://github.com/rapidsai/rapids-dask-dependency/pull/116, `protocol="ucx"` now uses UCXX when `distributed-ucxx` is installed as is the case in CI. Some tests broke because of the conditionals to validate UCX-Py vs UCXX, this change fixes those that are currently failing in CI, the remaining tests will be addressed in a follow-up PR.