### PR TITLE
fix(docker): use versioned `-latest` tag for all `rapidsai` images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,7 +50,7 @@ jobs:
       arch: "amd64"
       branch: ${{ inputs.branch }}
       build_type: ${{ inputs.build_type || 'branch' }}
-      container_image: "rapidsai/ci-conda:latest"
+      container_image: "rapidsai/ci-conda:25.08-latest"
       date: ${{ inputs.date }}
       node_type: "gpu-l4-latest-1"
       script: "ci/build_docs.sh"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -59,7 +59,7 @@ jobs:
       build_type: pull-request
       node_type: "gpu-l4-latest-1"
       arch: "amd64"
-      container_image: "rapidsai/ci-conda:latest"
+      container_image: "rapidsai/ci-conda:25.08-latest"
       script: "ci/build_docs.sh"
   wheel-build:
     secrets: inherit

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -71,6 +71,3 @@ done
 find docs/source/ -type f -name '*.rst' -print0 | while IFS= read -r -d '' filename; do
     sed_runner "s|/branch-[^/]*/|/branch-${NEXT_SHORT_TAG}/|g" "${filename}"
 done
-
-# Update CI image tags of the form {rapids_version}-{something}
-sed_runner "s/:[0-9]*\\.[0-9]*-/:${NEXT_SHORT_TAG}-/g" ./CONTRIBUTING.md

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -64,9 +64,13 @@ done
 # CI files
 for FILE in .github/workflows/*.yaml; do
   sed_runner "/shared-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
+  sed_runner "s/:[0-9]*\\.[0-9]*-/:${NEXT_SHORT_TAG}-/g" "${FILE}"
 done
 
 # Docs referencing source code
 find docs/source/ -type f -name '*.rst' -print0 | while IFS= read -r -d '' filename; do
     sed_runner "s|/branch-[^/]*/|/branch-${NEXT_SHORT_TAG}/|g" "${filename}"
 done
+
+# Update CI image tags of the form {rapids_version}-{something}
+sed_runner "s/:[0-9]*\\.[0-9]*-/:${NEXT_SHORT_TAG}-/g" ./CONTRIBUTING.md


### PR DESCRIPTION
In rapidsai/build-planning#187 we switched the docker image tagging scheme
over to include the CalVer information.  This was done to allow us to make
changes to the images during burndown without breaking release pipelines.

This PR moves all of the existing `latest` tags to the newer versioned tag
`25.08-latest` and also modifies the `update_version.sh` script to bump
that version at branch creation time.

xref: https://github.com/rapidsai/build-planning/issues/187
