### PR TITLE
ci(labeler): update labeler action to @v5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,10 +3,14 @@
 # Labels culled from https://github.com/rapidsai/dask-cuda/labels
 
 python:
- - 'dask_cuda/**'
-
+  - changed-files:
+      any-glob-to-any-file:
+        - 'dask_cuda/**'
 ci:
-  - 'ci/**'
-
+  - changed-files:
+      any-glob-to-any-file:
+        - 'ci/**'
 conda:
-  - 'conda/**'
+  - changed-files:
+      any-glob-to-any-file:
+        - 'conda/**'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,6 @@ jobs:
  triage:
    runs-on: ubuntu-latest
    steps:
-   - uses: actions/labeler@v4
+   - uses: actions/labeler@v5
      with:
        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Bumps the version of `actions/labeler` to `@v5` and updates the syntax in
the `labeler.yml` file to account for breaking changes in that version bump.

xref: rapidsai/ops#2968
