### PR TITLE
Fix anchor naming conventions in dependencies.yaml

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -150,16 +150,16 @@ dependencies:
           - zict>=2.0.0
       - output_types: [conda]
         packages:
-          - &numba-cuda-dep numba-cuda>=0.14.0,<0.15.0a0
+          - &numba_cuda numba-cuda>=0.14.0,<0.15.0a0
     specific:
       - output_types: [requirements, pyproject]
         matrices:
           - matrix: {cuda: "12.*"}
             packages:
-              - &numba-cuda-cu12-dep numba-cuda[cu12]>=0.14.0,<0.15.0a0
+              - &numba_cuda_cu12 numba-cuda[cu12]>=0.14.0,<0.15.0a0
           - matrix: # Fallback for no matrix
             packages:
-              - *numba-cuda-cu12-dep
+              - *numba_cuda_cu12
   test_python:
     common:
       - output_types: [conda, requirements, pyproject]


### PR DESCRIPTION
Replace hypens with underscores, and remove any `-dep` suffix.
