### PR TITLE
Update to numba-cuda >=0.18.0,<0.19.0a0

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -14,8 +14,8 @@ dependencies:
 - distributed-ucxx==0.46.*,>=0.0.0a0
 - kvikio==25.10.*,>=0.0.0a0
 - numactl-devel-cos7-aarch64
-- numba-cuda>=0.14.0,<0.15.0a0
-- numba>=0.59.1,<0.62.0a0
+- numba-cuda>=0.18.0,<0.19.0a0
+- numba>=0.60.0,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc>=1.1.0
 - pandas>=1.3

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -14,8 +14,8 @@ dependencies:
 - distributed-ucxx==0.46.*,>=0.0.0a0
 - kvikio==25.10.*,>=0.0.0a0
 - numactl-devel-cos7-x86_64
-- numba-cuda>=0.14.0,<0.15.0a0
-- numba>=0.59.1,<0.62.0a0
+- numba-cuda>=0.18.0,<0.19.0a0
+- numba>=0.60.0,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc>=1.1.0
 - pandas>=1.3

--- a/conda/recipes/dask-cuda/recipe.yaml
+++ b/conda/recipes/dask-cuda/recipe.yaml
@@ -36,8 +36,8 @@ requirements:
   run:
     - python
     - click >=8.1
-    - numba >=0.59.1,<0.62.0a0
-    - numba-cuda >=0.14.0,<0.15.0a0
+    - numba >=0.60.0,<0.62.0a0
+    - numba-cuda >=0.18.0,<0.19.0a0
     - numpy >=1.23,<3.0a0
     - pandas >=1.3
     - pynvml >=12.0.0,<13.0.0a0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -142,7 +142,7 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         packages:
           - click >=8.1
-          - numba>=0.59.1,<0.62.0a0
+          - numba>=0.60.0,<0.62.0a0
           - numpy>=1.23,<3.0a0
           - pandas>=1.3
           - pynvml>=12.0.0,<13.0.0a0
@@ -150,13 +150,13 @@ dependencies:
           - zict>=2.0.0
       - output_types: [conda]
         packages:
-          - &numba_cuda numba-cuda>=0.14.0,<0.15.0a0
+          - &numba_cuda numba-cuda>=0.18.0,<0.19.0a0
     specific:
       - output_types: [requirements, pyproject]
         matrices:
           - matrix: {cuda: "12.*"}
             packages:
-              - &numba_cuda_cu12 numba-cuda[cu12]>=0.14.0,<0.15.0a0
+              - &numba_cuda_cu12 numba-cuda[cu12]>=0.18.0,<0.19.0a0
           - matrix: # Fallback for no matrix
             packages:
               - *numba_cuda_cu12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ license = { text = "Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
     "click >=8.1",
-    "numba-cuda[cu12]>=0.14.0,<0.15.0a0",
-    "numba>=0.59.1,<0.62.0a0",
+    "numba-cuda[cu12]>=0.18.0,<0.19.0a0",
+    "numba>=0.60.0,<0.62.0a0",
     "numpy>=1.23,<3.0a0",
     "pandas>=1.3",
     "pynvml>=12.0.0,<13.0.0a0",


### PR DESCRIPTION
This PR updates the numba-cuda version to `>=0.18.0,<0.19.0a0`.

xref: https://github.com/rapidsai/cudf/pull/19604
