### PR TITLE
Use cuda-core for context initialization.

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -16,7 +16,6 @@ dependencies:
 - kvikio==25.10.*,>=0.0.0a0
 - numactl-devel-cos7-aarch64
 - numba-cuda>=0.19.0,<0.20.0a0
-- numba>=0.60.0,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc>=1.1.0
 - pandas>=1.3

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -6,9 +6,9 @@ channels:
 - conda-forge
 dependencies:
 - click >=8.1
+- cuda-core==0.3.*
 - cuda-nvcc-impl
 - cuda-nvrtc
-- cuda-python>=12.9.1,<13.0a0
 - cuda-version=12.9
 - cudf==25.10.*,>=0.0.0a0
 - dask-cudf==25.10.*,>=0.0.0a0

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -8,6 +8,7 @@ dependencies:
 - click >=8.1
 - cuda-nvcc-impl
 - cuda-nvrtc
+- cuda-python>=12.9.1,<13.0a0
 - cuda-version=12.9
 - cudf==25.10.*,>=0.0.0a0
 - dask-cudf==25.10.*,>=0.0.0a0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -6,9 +6,9 @@ channels:
 - conda-forge
 dependencies:
 - click >=8.1
+- cuda-core==0.3.*
 - cuda-nvcc-impl
 - cuda-nvrtc
-- cuda-python>=12.9.1,<13.0a0
 - cuda-version=12.9
 - cudf==25.10.*,>=0.0.0a0
 - dask-cudf==25.10.*,>=0.0.0a0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -8,6 +8,7 @@ dependencies:
 - click >=8.1
 - cuda-nvcc-impl
 - cuda-nvrtc
+- cuda-python>=12.9.1,<13.0a0
 - cuda-version=12.9
 - cudf==25.10.*,>=0.0.0a0
 - dask-cudf==25.10.*,>=0.0.0a0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -16,7 +16,6 @@ dependencies:
 - kvikio==25.10.*,>=0.0.0a0
 - numactl-devel-cos7-x86_64
 - numba-cuda>=0.19.0,<0.20.0a0
-- numba>=0.60.0,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc>=1.1.0
 - pandas>=1.3

--- a/dask_cuda/initialize.py
+++ b/dask_cuda/initialize.py
@@ -100,18 +100,10 @@ def _initialize_ucxx():
 
 
 def _create_cuda_context(protocol="ucx"):
-    if protocol not in ["ucx", "ucxx", "ucx-old"]:
-        return
-
-    # protocol is in {"ucx", "ucxx", "ucx-old"} here
-
     try:
         ucx_implementation = _get_active_ucx_implementation_name(protocol)
     except ValueError:
         # Not a UCX protocol, just raise CUDA context warnings if needed.
-        # Claim: this is unreachable.
-        # We raise a ValueError iff protocol is not in {"ucx", "ucxx", "ucx-old"}
-        # but we know it is in that set because of the early return above.
         _warn_generic()
     else:
         if ucx_implementation == "ucxx":

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -142,7 +142,7 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         packages:
           - click >=8.1
-          - cuda-python>=12.9.1,<13.0a0
+          - cuda-core==0.3.*
           - numba>=0.60.0,<0.62.0a0
           - numpy>=1.23,<3.0a0
           - pandas>=1.3

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -142,6 +142,7 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         packages:
           - click >=8.1
+          - cuda-python>=12.9.1,<13.0a0
           - numba>=0.60.0,<0.62.0a0
           - numpy>=1.23,<3.0a0
           - pandas>=1.3

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -143,24 +143,11 @@ dependencies:
         packages:
           - click >=8.1
           - cuda-core==0.3.*
-          - numba>=0.60.0,<0.62.0a0
           - numpy>=1.23,<3.0a0
           - pandas>=1.3
           - pynvml>=12.0.0,<13.0.0a0
           - rapids-dask-dependency==25.10.*,>=0.0.0a0
           - zict>=2.0.0
-      - output_types: [conda]
-        packages:
-          - &numba_cuda numba-cuda>=0.19.0,<0.20.0a0
-    specific:
-      - output_types: [requirements, pyproject]
-        matrices:
-          - matrix: {cuda: "12.*"}
-            packages:
-              - &numba_cuda_cu12 numba-cuda[cu12]>=0.19.0,<0.20.0a0
-          - matrix: # Fallback for no matrix
-            packages:
-              - *numba_cuda_cu12
   test_python:
     common:
       - output_types: [conda, requirements, pyproject]
@@ -176,6 +163,8 @@ dependencies:
           - &kvikio_unsuffixed kvikio==25.10.*,>=0.0.0a0
           - &ucx_py_unsuffixed ucx-py==0.46.*,>=0.0.0a0
           - ucxx==0.46.*,>=0.0.0a0
+          - &numba_cuda numba-cuda>=0.19.0,<0.20.0a0
+
     specific:
       - output_types: conda
         matrices:
@@ -198,6 +187,7 @@ dependencies:
               - distributed-ucxx-cu12==0.46.*,>=0.0.0a0
               - kvikio-cu12==25.10.*,>=0.0.0a0
               - ucx-py-cu12==0.46.*,>=0.0.0a0
+              - &numba_cuda_cu12 numba-cuda[cu12]>=0.19.0,<0.20.0a0
           - matrix:
             packages:
               - *cudf_unsuffixed
@@ -205,6 +195,7 @@ dependencies:
               - *distributed_ucxx_unsuffixed
               - *kvikio_unsuffixed
               - *ucx_py_unsuffixed
+              - *numba_cuda_cu12
   depends_on_dask_cuda:
     common:
       - output_types: conda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ license = { text = "Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
     "click >=8.1",
-    "cuda-python>=12.9.1,<13.0a0",
+    "cuda-core==0.3.*",
     "numba-cuda[cu12]>=0.19.0,<0.20.0a0",
     "numba>=0.60.0,<0.62.0a0",
     "numpy>=1.23,<3.0a0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,6 @@ requires-python = ">=3.10"
 dependencies = [
     "click >=8.1",
     "cuda-core==0.3.*",
-    "numba-cuda[cu12]>=0.19.0,<0.20.0a0",
-    "numba>=0.60.0,<0.62.0a0",
     "numpy>=1.23,<3.0a0",
     "pandas>=1.3",
     "pynvml>=12.0.0,<13.0.0a0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ license = { text = "Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
     "click >=8.1",
+    "cuda-python>=12.9.1,<13.0a0",
     "numba-cuda[cu12]>=0.19.0,<0.20.0a0",
     "numba>=0.60.0,<0.62.0a0",
     "numpy>=1.23,<3.0a0",


### PR DESCRIPTION
This uses `cuda.core` in place of the non-optional `numba.cuda` usage, enabling `numba.cuda` to become an optional dependency.