### PR TITLE
Fix test wheels for local CI runs

### DIFF
--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -18,6 +18,9 @@ rapids-logger "Installing test dependencies"
 # echo to expand wildcard
 rapids-pip-retry install -v --prefer-binary -r /tmp/requirements-test.txt "$(echo "${DASK_CUDA_WHEELHOUSE}"/dask_cuda*.whl)"
 
+RAPIDS_TESTS_DIR=${RAPIDS_TESTS_DIR:-"${PWD}/test-results"}
+mkdir -p "${RAPIDS_TESTS_DIR}"
+
 EXITCODE=0
 # shellcheck disable=SC2317
 set_exit_code() {


### PR DESCRIPTION
Running `ci/test_wheel.sh` when attempting to reproduce CI locally fails because it attempts to use `RAPIDS_TESTS_DIR` that is defined somewhere in GHA but is missing in the script itself. This change fixes that by defining the variable like done in `ci/test_python.sh`.