### PR TITLE
`get_device_memory_objects()`: use _columns instead of _value

### DIFF
--- a/dask_cuda/get_device_memory_objects.py
+++ b/dask_cuda/get_device_memory_objects.py
@@ -119,11 +119,8 @@ def get_device_memory_objects_register_cudf():
         return []
 
     @dispatch.register(cudf.core.index.Index)
-    def get_device_memory_objects_cudf_index(obj):
-        return dispatch(obj._values)
-
     @dispatch.register(cudf.core.multiindex.MultiIndex)
-    def get_device_memory_objects_cudf_multiindex(obj):
+    def get_device_memory_objects_cudf_index(obj):
         return dispatch(obj._columns)
 
     @dispatch.register(cudf.core.column.ColumnBase)


### PR DESCRIPTION
Use `_columns` now that `_value` has been removed by https://github.com/rapidsai/cudf/pull/19799
