### PR TITLE
WIP: use 'nvidia-ml-py' package for 'pynvml' module

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -17,6 +17,7 @@ dependencies:
 - numba-cuda>=0.19.1,<0.20.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc>=1.1.0
+- nvidia-ml-py>=12.560.30
 - pandas>=1.3
 - pre-commit
 - pynvml>=12.0.0,<13.0.0a0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -17,6 +17,7 @@ dependencies:
 - numba-cuda>=0.19.1,<0.20.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc>=1.1.0
+- nvidia-ml-py>=12.560.30
 - pandas>=1.3
 - pre-commit
 - pynvml>=12.0.0,<13.0.0a0

--- a/conda/environments/all_cuda-130_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-130_arch-aarch64.yaml
@@ -17,6 +17,7 @@ dependencies:
 - numba-cuda>=0.19.1,<0.20.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc>=1.1.0
+- nvidia-ml-py>=12.560.30
 - pandas>=1.3
 - pre-commit
 - pynvml>=12.0.0,<13.0.0a0

--- a/conda/environments/all_cuda-130_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-130_arch-x86_64.yaml
@@ -17,6 +17,7 @@ dependencies:
 - numba-cuda>=0.19.1,<0.20.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc>=1.1.0
+- nvidia-ml-py>=12.560.30
 - pandas>=1.3
 - pre-commit
 - pynvml>=12.0.0,<13.0.0a0

--- a/conda/recipes/dask-cuda/recipe.yaml
+++ b/conda/recipes/dask-cuda/recipe.yaml
@@ -39,8 +39,10 @@ requirements:
     - numba >=0.60.0,<0.62.0a0
     - numba-cuda >=0.19.1,<0.20.0a0
     - numpy >=1.23,<3.0a0
+    # 'nvidia-ml-py' provides the 'pynvml' module, since v12.560.30
+    # ref: https://github.com/conda-forge/nvidia-ml-py-feedstock/pull/24
+    - nvidia-ml-py>=12.560.30
     - pandas >=1.3
-    - pynvml >=12.0.0,<13.0.0a0
     - rapids-dask-dependency =${{ minor_version }}
     - zict >=2.0.0
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -161,6 +161,9 @@ dependencies:
           - click >=8.1
           - cuda-core==0.3.*
           - numpy>=1.23,<3.0a0
+          # 'nvidia-ml-py' provides the 'pynvml' module, since v12.560.30
+          # ref: https://github.com/conda-forge/nvidia-ml-py-feedstock/pull/24
+          - nvidia-ml-py>=12.560.30
           - pandas>=1.3
           - pynvml>=12.0.0,<13.0.0a0
           - rapids-dask-dependency==25.10.*,>=0.0.0a0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "click >=8.1",
     "cuda-core==0.3.*",
     "numpy>=1.23,<3.0a0",
+    "nvidia-ml-py>=12.560.30",
     "pandas>=1.3",
     "pynvml>=12.0.0,<13.0.0a0",
     "rapids-dask-dependency==25.10.*,>=0.0.0a0",


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-infra/issues/293

The `pynvml` *package* (https://github.com/gpuopenanalytics/pynvml) provides 2 things:

* the `pynvml` **Python module**, transitively via a dependency on the `nvidia-ml-py` package
* the `pynvml_utils` Python module

This project's doesn't need the `pynvml_utils` Python module, so this PR proposes dropping the dependency on the `pynvml` package in favor of `nvidia-ml-py`.