### PR TITLE
update dependencies: nvidia-ml-py (>=12)

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - numba-cuda>=0.19.1,<0.20.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc>=1.1.0
-- nvidia-ml-py>=12.560.30
+- nvidia-ml-py>=12
 - pandas>=1.3
 - pre-commit
 - pytest

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - numba-cuda>=0.19.1,<0.20.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc>=1.1.0
-- nvidia-ml-py>=12.560.30
+- nvidia-ml-py>=12
 - pandas>=1.3
 - pre-commit
 - pytest

--- a/conda/environments/all_cuda-130_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-130_arch-aarch64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - numba-cuda>=0.19.1,<0.20.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc>=1.1.0
-- nvidia-ml-py>=12.560.30
+- nvidia-ml-py>=12
 - pandas>=1.3
 - pre-commit
 - pytest

--- a/conda/environments/all_cuda-130_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-130_arch-x86_64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - numba-cuda>=0.19.1,<0.20.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc>=1.1.0
-- nvidia-ml-py>=12.560.30
+- nvidia-ml-py>=12
 - pandas>=1.3
 - pre-commit
 - pytest

--- a/conda/recipes/dask-cuda/recipe.yaml
+++ b/conda/recipes/dask-cuda/recipe.yaml
@@ -40,9 +40,8 @@ requirements:
     - numba >=0.60.0,<0.62.0a0
     - numba-cuda >=0.19.1,<0.20.0a0
     - numpy >=1.23,<3.0a0
-    # 'nvidia-ml-py' provides the 'pynvml' module, since v12.560.30
-    # ref: https://github.com/conda-forge/nvidia-ml-py-feedstock/pull/24
-    - nvidia-ml-py>=12.560.30
+    # 'nvidia-ml-py' provides the 'pynvml' module
+    - nvidia-ml-py>=12
     - pandas >=1.3
     - rapids-dask-dependency =${{ minor_version }}
     - zict >=2.0.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -162,9 +162,8 @@ dependencies:
           - cuda-core==0.3.*
           - numba-cuda>=0.19.1,<0.20.0a0
           - numpy>=1.23,<3.0a0
-          # 'nvidia-ml-py' provides the 'pynvml' module, since v12.560.30
-          # ref: https://github.com/conda-forge/nvidia-ml-py-feedstock/pull/24
-          - nvidia-ml-py>=12.560.30
+          # 'nvidia-ml-py' provides the 'pynvml' module
+          - nvidia-ml-py>=12
           - pandas>=1.3
           - rapids-dask-dependency==25.10.*,>=0.0.0a0
           - zict>=2.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "cuda-core==0.3.*",
     "numba-cuda>=0.19.1,<0.20.0a0",
     "numpy>=1.23,<3.0a0",
-    "nvidia-ml-py>=12.560.30",
+    "nvidia-ml-py>=12",
     "pandas>=1.3",
     "rapids-dask-dependency==25.10.*,>=0.0.0a0",
     "zict>=2.0.0",


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/214, updating pins to match the rest of RAPIDS:

* nvidia-ml-py: `>=12`

## Notes for Reviewers

### Benefits of these changes

The stricter `nvidia-ml-py` floor I'd introduced in an earlier PR was a mistake... `>=12` has what we need. A looser floor means a bit lower risk of environment-solve conflicts.