### PR TITLE
Fixes for `test_worker_force_spill_to_disk`

### DIFF
--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -457,7 +457,6 @@ async def test_worker_force_spill_to_disk():
         ) as cluster:
             async with Client(cluster, asynchronous=True) as client:
                 # Create a df that are spilled to host memory immediately
-                # df = cudf.DataFrame({"key": np.arange(10**8)})
                 ddf = dask.dataframe.from_delayed(
                     dask.delayed(create_dataframe)(),
                     meta=cudf.DataFrame({"key": cupy.arange(0)}),


### PR DESCRIPTION
Two fixes for this test, which hopefully preserve the cases it intends to cover:

1. Generate data on the worker, rather than on the client and serializing
2. Ensure that the coroutine making the assertions is awaited

This brings the test runtime down from 33s to 10s locally.

Spotted while looking at #1561. It shouldn't have an effect on that one way or the other.