### PR TITLE
Deprecate rmm_pool_size and rmm_async

### DIFF
--- a/ci/run_benchmarks.sh
+++ b/ci/run_benchmarks.sh
@@ -54,7 +54,6 @@ python benchmarks/local_cudf_shuffle.py \
   "$@"
 
 python benchmarks/local_cudf_shuffle.py \
-  --rmm-pool-size 2GiB \
   --rmm-maximum-pool-size 4GiB \
   --enable-rmm-async \
   --partition-size="1 KiB" \

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -375,7 +375,7 @@ def parse_benchmark_args(
 
     args = parser.parse_args()
 
-    if args.rmm_async and args.rmm_pool_size is not None:
+    if args.enable_rmm_async and args.rmm_pool_size is not None:
         raise ValueError("--rmm-async and --rmm-pool-size cannot be used together")
 
     if args.multi_node and len(args.hosts.split(",")) < 2:

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -375,6 +375,9 @@ def parse_benchmark_args(
 
     args = parser.parse_args()
 
+    if args.rmm_async and args.rmm_pool_size is not None:
+        raise ValueError("--rmm-async and --rmm-pool-size cannot be used together")
+
     if args.multi_node and len(args.hosts.split(",")) < 2:
         raise ValueError("--multi-node requires at least 2 hosts")
 
@@ -497,7 +500,6 @@ def setup_memory_pool(
     if not disable_rmm:
         if rmm_async:
             mr = rmm.mr.CudaAsyncMemoryResource(
-                initial_pool_size=pool_size,
                 release_threshold=release_threshold,
             )
 

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -307,6 +307,15 @@ class LocalCUDACluster(LocalCluster):
         self.rmm_release_threshold = rmm_release_threshold
         self.rmm_allocator_external_lib_list = rmm_allocator_external_lib_list
 
+        if self.rmm_async and self.rmm_pool_size is not None:
+            # check for https://github.com/rapidsai/rmm/issues/2060
+            msg = (
+                "'rmm_pool_size' is not needed when 'rmm_async' is enabled and will "
+                "raise a 'TypeError' in the future. Remove the 'rmm_pool_size' "
+                "argument when creating this cluster to silence this warning."
+            )
+            warnings.warn(msg, FutureWarning)
+
         if rmm_pool_size is not None or rmm_managed_memory or rmm_async:
             try:
                 import rmm  # noqa F401

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -311,7 +311,7 @@ class LocalCUDACluster(LocalCluster):
             # check for https://github.com/rapidsai/rmm/issues/2060
             msg = (
                 "'rmm_pool_size' is not needed when 'rmm_async' is enabled and will "
-                "raise a 'TypeError' in the future. Remove the 'rmm_pool_size' "
+                "raise an exception in the future. Remove the 'rmm_pool_size' "
                 "argument when creating this cluster to silence this warning."
             )
             warnings.warn(msg, FutureWarning)

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -650,4 +650,7 @@ def test_rmm_pool_size_warns():
     with pytest.warns(
         FutureWarning, match="'rmm_pool_size' is not needed when 'rmm_async' is enabled"
     ):
-        LocalCUDACluster(n_workers=1, rmm_pool_size="1GB", rmm_async=True)
+        try:
+            cluster = LocalCUDACluster(n_workers=1, rmm_pool_size="1GB", rmm_async=True)
+        finally:
+            cluster.close()

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -644,3 +644,10 @@ def test_death_timeout_raises():
             dashboard_address=":0",
         ):
             pass
+
+
+def test_rmm_pool_size_warns():
+    with pytest.warns(
+        FutureWarning, match="'rmm_pool_size' is not needed when 'rmm_async' is enabled"
+    ):
+        LocalCUDACluster(n_workers=1, rmm_pool_size="1GB", rmm_async=True)

--- a/docs/source/ucx.rst
+++ b/docs/source/ucx.rst
@@ -182,7 +182,7 @@ However, some will affect related libraries, such as RMM:
   Replaces ``sockcm`` with ``rdmacm`` in ``UCX_SOCKADDR_TLS_PRIORITY``, enabling remote direct memory access (RDMA) for InfiniBand transfers.
   This is recommended by UCX for use with InfiniBand, and will not work if InfiniBand is disabled.
 
-- ``distributed-ucxx.rmm.pool-size: <str|int>`` -- **recommended for synchronous memory resources.**
+- ``distributed-ucxx.rmm.pool-size: <str|int>`` -- **recommended for pool memory resources.**
 
   Allocates an RMM pool of the specified size for the process; size can be provided with an integer number of bytes or in human readable format, e.g. ``"4GB"``.
   It is recommended to set the pool size to at least the minimum amount of memory used by the process; if possible, one can map all GPU memory to a single pool, to be utilized for the lifetime of the process.

--- a/docs/source/ucx.rst
+++ b/docs/source/ucx.rst
@@ -182,10 +182,12 @@ However, some will affect related libraries, such as RMM:
   Replaces ``sockcm`` with ``rdmacm`` in ``UCX_SOCKADDR_TLS_PRIORITY``, enabling remote direct memory access (RDMA) for InfiniBand transfers.
   This is recommended by UCX for use with InfiniBand, and will not work if InfiniBand is disabled.
 
-- ``distributed-ucxx.rmm.pool-size: <str|int>`` -- **recommended.**
+- ``distributed-ucxx.rmm.pool-size: <str|int>`` -- **recommended for synchronous memory resources.**
 
   Allocates an RMM pool of the specified size for the process; size can be provided with an integer number of bytes or in human readable format, e.g. ``"4GB"``.
   It is recommended to set the pool size to at least the minimum amount of memory used by the process; if possible, one can map all GPU memory to a single pool, to be utilized for the lifetime of the process.
+
+  This has no effect with ``rmm_async=True``.
 
 .. note::
     These options can be used with mainline Dask.distributed.


### PR DESCRIPTION
As noted in https://github.com/rapidsai/rmm/issues/2060, the "pool size" argument for for the async allocator is quite different from RMM's pool allocator. This PR deprecates passing `rmm_pool_size` and when `rmm_async=True`.