### PR TITLE
Exclude 'examples' directory from distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ exclude = [
     "docs",
     "tests",
     "docs.*",
+    "examples.*",
     "tests.*",
 ]
 


### PR DESCRIPTION
Closes https://github.com/rapidsai/dask-cuda/issues/1566.

After this change `unzip -l dist/dask_cuda-25.12.0-py3-none-any.whl | grep -i examples` shows nothing. Previously, the `examples/ucx` files were present.