### PR TITLE
fix(wheel): override wheel artifact name in input to publish job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -96,3 +96,4 @@ jobs:
       date: ${{ inputs.date }}
       package-name: dask-cuda
       package-type: python
+      publish-wheel-search-key: "dask-cuda_wheel"


### PR DESCRIPTION
Followup to #1577 -- should resolve the publishing issues seen in https://github.com/rapidsai/dask-cuda/actions/runs/19321124419/job/55274180710
