### PR TITLE
Conda: Use `c_stdlib_version` to constrain `__glibc`

### DIFF
--- a/conda/recipes/dask-cuda/recipe.yaml
+++ b/conda/recipes/dask-cuda/recipe.yaml
@@ -47,7 +47,7 @@ requirements:
     - rapids-dask-dependency =${{ minor_version }}
     - zict >=2.0.0
     - __linux
-    - __glibc >=2.28
+    - __glibc >=${{ c_stdlib_version }}
 
 tests:
   - python:

--- a/conda/recipes/dask-cuda/variants.yaml
+++ b/conda/recipes/dask-cuda/variants.yaml
@@ -1,0 +1,5 @@
+c_stdlib:
+  - sysroot
+
+c_stdlib_version:
+  - "2.28"


### PR DESCRIPTION
In other Conda packages, `${{ stdlib("c") }}` is used to configure GLIBC with a specific version is built against. Pure Python packages don't need to use `${{ stdlib("c") }}`. However we decided in PR ( https://github.com/rapidsai/dask-cuda/pull/1581 ) to constrain pure Python packages to GLIBC versions we test against and claim support for. That said, we did this by adding the GLIBC version in the Conda recipe. However normally this info would go in `conda_build_config.yaml`/`variants.yaml` when using `${{ stdlib("c") }}`. To close this gap between the handling of pure Python  packages and other compiled packages, move the GLIBC version into `variants.yaml` and use that in the recipe