### PR TITLE
Mark `test_all_to_all` flaky and rerun

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -22,6 +22,7 @@ dependencies:
 - pre-commit
 - pytest
 - pytest-cov
+- pytest-rerunfailures!=16.0.0
 - pytest-timeout
 - python>=3.10,<3.14
 - rapids-build-backend>=0.4.0,<0.5.0dev0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -22,6 +22,7 @@ dependencies:
 - pre-commit
 - pytest
 - pytest-cov
+- pytest-rerunfailures!=16.0.0
 - pytest-timeout
 - python>=3.10,<3.14
 - rapids-build-backend>=0.4.0,<0.5.0dev0

--- a/conda/environments/all_cuda-130_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-130_arch-aarch64.yaml
@@ -22,6 +22,7 @@ dependencies:
 - pre-commit
 - pytest
 - pytest-cov
+- pytest-rerunfailures!=16.0.0
 - pytest-timeout
 - python>=3.10,<3.14
 - rapids-build-backend>=0.4.0,<0.5.0dev0

--- a/conda/environments/all_cuda-130_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-130_arch-x86_64.yaml
@@ -22,6 +22,7 @@ dependencies:
 - pre-commit
 - pytest
 - pytest-cov
+- pytest-rerunfailures!=16.0.0
 - pytest-timeout
 - python>=3.10,<3.14
 - rapids-build-backend>=0.4.0,<0.5.0dev0

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -190,6 +190,9 @@ async def test_no_memory_limits_cudaworker():
 
 
 @gen_test(timeout=20)
+@pytest.mark.flaky(
+    reruns=3,
+)
 async def test_all_to_all():
     async with LocalCUDACluster(
         CUDA_VISIBLE_DEVICES="0,1",

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -188,6 +188,7 @@ dependencies:
         packages:
           - pytest
           - pytest-cov
+          - pytest-rerunfailures!=16.0.0  # See https://github.com/pytest-dev/pytest-rerunfailures/issues/302
           - pytest-timeout
       - output_types: [conda]
         packages:


### PR DESCRIPTION
The `test_all_to_all` has been flaky for a while, however, so far it has not been possible to reproduce it outside CI, therefore mark it flaky and rerun for now.