### PR TITLE
Fix RMM setup in benchmarks

### DIFF
--- a/dask_cuda/benchmarks/common.py
+++ b/dask_cuda/benchmarks/common.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse


### PR DESCRIPTION
https://github.com/rapidsai/dask-cuda/pull/1538 introduced a guard to prevent setting up RMM resources on an already setup external cluster. However, this also ignores all RMM CLI arguments when `LocalCUDACluster` is used because benchmarks setup the cluster and later setup RMM to its own configurations. Now this change introduces a check to only prevent rerunning RMM setup on external clusters, thus honoring CLI arguments for runs with `LocalCUDACluster`.