### PR TITLE
xfail `test_sizeof_cudf`

### DIFF
--- a/dask_cuda/tests/test_proxy.py
+++ b/dask_cuda/tests/test_proxy.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 import operator
@@ -644,6 +644,7 @@ def test_sizeof_cupy():
     assert pxy._pxy_get().is_serialized()
 
 
+@pytest.mark.xfail(strict=False, reason="cudf refactor in progress")
 def test_sizeof_cudf():
     cudf = pytest.importorskip("cudf")
     a = cudf.datasets.timeseries().reset_index()


### PR DESCRIPTION
After https://github.com/rapidsai/cudf/pull/20961, `test_sizeof_cudf` is failing. This adds an xfail marker while we come up with a longer-term plan for how to handle this properly.

There are a few issues at play here: cudf is in the midst of refactoring some things that are pretty sensitive to the implementation. We don't want to be this sensitive to the internal buffers used by some column.

This test is also testing some proxying / spilling mechanism. cudf is in the midst of implementing an improved version of that. dask-cuda should use that where possible.

Finally, we don't import dask-cudf, which registers the custom `sizeof` for cudf objects, so some of the sizeof computations were off to being with. Overall, xfailing for now seems reasonable.