### PR TITLE
xfail test_dataframes_share_dev_mem

### DIFF
--- a/dask_cuda/tests/test_proxify_host_file.py
+++ b/dask_cuda/tests/test_proxify_host_file.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Iterable
@@ -280,6 +280,7 @@ async def test_local_cuda_cluster(jit_unspill):
             assert_frame_equal(got.to_pandas(), df.to_pandas())
 
 
+@pytest.mark.xfail(strict=False, reason="cudf refactor in progress")
 def test_dataframes_share_dev_mem(root_dir):
     cudf = pytest.importorskip("cudf")
 


### PR DESCRIPTION
Very similar to https://github.com/rapidsai/dask-cuda/pull/1602: a refactor of cudf's internals is in progress, and so our tests that are extremely sensitive to its implementation details are going to be rocky for a bit.

For now I'll xfail these. I'll deliver a plan for how to handle this more generally soon (hopefully next week).