### PR TITLE
wheel builds: react to changes in pip's handling of build constraints 

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -16,15 +16,6 @@ RAPIDS_PIP_WHEEL_ARGS=(
   --disable-pip-version-check
 )
 
-# Only use --build-constraint when build isolation is enabled.
-#
-# Passing '--build-constraint' and '--no-build-isolation` together results in an error from 'pip',
-# but we want to keep environment variable PIP_CONSTRAINT set unconditionally.
-# PIP_NO_BUILD_ISOLATION=0 means "add --no-build-isolation" (ref: https://github.com/pypa/pip/issues/573
-if [[ "${PIP_NO_BUILD_ISOLATION:-}" != "0" ]]; then
-    RAPIDS_PIP_WHEEL_ARGS+=(--build-constraint="${PIP_CONSTRAINT}")
-fi
-
 # unset PIP_CONSTRAINT (set by rapids-init-pip)... it doesn't affect builds as of pip 25.3, and
 # results in an error from 'pip wheel' when set and --build-constraint is also passed
 unset PIP_CONSTRAINT


### PR DESCRIPTION
## Description
Contributes to https://github.com/rapidsai/build-planning/issues/242

Modifying `ci/build_wheel.sh` to

- pass`--build-constraint="${PIP_CONSTRAINT}"` unless build isolation is enabled.
- unset `PIP_CONSTRAINT` (set by rapids-init-pip)... it doesn't affect builds as of pip 25.3, and results in an error from `pip wheel` when set and `--build-constraint` is also passed