### PR TITLE
Drop Python 3.10 support

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -24,7 +24,7 @@ dependencies:
 - pytest-cov
 - pytest-rerunfailures!=16.0.0
 - pytest-timeout
-- python>=3.10,<3.14
+- python>=3.11,<3.14
 - rapids-build-backend>=0.4.0,<0.5.0
 - rapids-dask-dependency==26.4.*,>=0.0.0a0
 - setuptools>=77.0.0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -24,7 +24,7 @@ dependencies:
 - pytest-cov
 - pytest-rerunfailures!=16.0.0
 - pytest-timeout
-- python>=3.10,<3.14
+- python>=3.11,<3.14
 - rapids-build-backend>=0.4.0,<0.5.0
 - rapids-dask-dependency==26.4.*,>=0.0.0a0
 - setuptools>=77.0.0

--- a/conda/environments/all_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-131_arch-aarch64.yaml
@@ -24,7 +24,7 @@ dependencies:
 - pytest-cov
 - pytest-rerunfailures!=16.0.0
 - pytest-timeout
-- python>=3.10,<3.14
+- python>=3.11,<3.14
 - rapids-build-backend>=0.4.0,<0.5.0
 - rapids-dask-dependency==26.4.*,>=0.0.0a0
 - setuptools>=77.0.0

--- a/conda/environments/all_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-131_arch-x86_64.yaml
@@ -24,7 +24,7 @@ dependencies:
 - pytest-cov
 - pytest-rerunfailures!=16.0.0
 - pytest-timeout
-- python>=3.10,<3.14
+- python>=3.11,<3.14
 - rapids-build-backend>=0.4.0,<0.5.0
 - rapids-dask-dependency==26.4.*,>=0.0.0a0
 - setuptools>=77.0.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -168,10 +168,6 @@ dependencies:
       - output_types: conda
         matrices:
           - matrix:
-              py: "3.10"
-            packages:
-              - python=3.10
-          - matrix:
               py: "3.11"
             packages:
               - python=3.11
@@ -185,7 +181,7 @@ dependencies:
               - python=3.13
           - matrix:
             packages:
-              - python>=3.10,<3.14
+              - python>=3.11,<3.14
   run_python:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
 ]
 license = "Apache-2.0"
 license-files = ["LICENSE"]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "click >=8.1",
     "cuda-core==0.3.*",
@@ -33,7 +33,6 @@ classifiers = [
     "Topic :: Database",
     "Topic :: Scientific/Engineering",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/246

Finishes the work of dropping Python 3.10 support.

This project stopped building / testing against Python 3.10 as of https://github.com/rapidsai/shared-workflows/pull/494
This PR updates configuration and docs to reflect that.

## Followups before merging

Check that there are no remaining uses like this:

```shell
git grep -E '3\.10'
git grep '310'
git grep 'py310'
```
