### PR TITLE
Replace rmm.mr.get_current_device_resource_type with type(rmm.mr.get_current_device_resource())

### DIFF
--- a/dask_cuda/tests/test_dask_cuda_worker.py
+++ b/dask_cuda/tests/test_dask_cuda_worker.py
@@ -116,7 +116,7 @@ def test_rmm_pool(loop):  # noqa: F811
                 assert wait_workers(client, n_gpus=get_n_gpus())
 
                 memory_resource_type = client.run(
-                    rmm.mr.get_current_device_resource_type
+                    lambda: type(rmm.mr.get_current_device_resource())
                 )
                 for v in memory_resource_type.values():
                     assert v is rmm.mr.PoolMemoryResource
@@ -141,7 +141,7 @@ def test_rmm_managed(loop):  # noqa: F811
                 assert wait_workers(client, n_gpus=get_n_gpus())
 
                 memory_resource_type = client.run(
-                    rmm.mr.get_current_device_resource_type
+                    lambda: type(rmm.mr.get_current_device_resource())
                 )
                 for v in memory_resource_type.values():
                     assert v is rmm.mr.ManagedMemoryResource
@@ -169,7 +169,7 @@ def test_rmm_async(loop):  # noqa: F811
                 assert wait_workers(client, n_gpus=get_n_gpus())
 
                 memory_resource_type = client.run(
-                    rmm.mr.get_current_device_resource_type
+                    lambda: type(rmm.mr.get_current_device_resource())
                 )
                 for v in memory_resource_type.values():
                     assert v is rmm.mr.CudaAsyncMemoryResource
@@ -205,7 +205,7 @@ def test_rmm_async_with_maximum_pool_size(loop):  # noqa: F811
 
                 memory_resource_types = client.run(
                     lambda: (
-                        rmm.mr.get_current_device_resource_type(),
+                        type(rmm.mr.get_current_device_resource()),
                         type(rmm.mr.get_current_device_resource().get_upstream()),
                     )
                 )
@@ -245,7 +245,7 @@ def test_rmm_logging(loop):  # noqa: F811
                 assert wait_workers(client, n_gpus=get_n_gpus())
 
                 memory_resource_type = client.run(
-                    rmm.mr.get_current_device_resource_type
+                    lambda: type(rmm.mr.get_current_device_resource())
                 )
                 for v in memory_resource_type.values():
                     assert v is rmm.mr.LoggingResourceAdaptor
@@ -496,7 +496,7 @@ def test_rmm_track_allocations(loop):  # noqa: F811
                 assert wait_workers(client, n_gpus=get_n_gpus())
 
                 memory_resource_type = client.run(
-                    rmm.mr.get_current_device_resource_type
+                    lambda: type(rmm.mr.get_current_device_resource())
                 )
                 for v in memory_resource_type.values():
                     assert v is rmm.mr.TrackingResourceAdaptor

--- a/dask_cuda/tests/test_local_cuda_cluster.py
+++ b/dask_cuda/tests/test_local_cuda_cluster.py
@@ -235,7 +235,7 @@ async def test_rmm_pool():
     ) as cluster:
         async with Client(cluster, asynchronous=True) as client:
             memory_resource_type = await client.run(
-                rmm.mr.get_current_device_resource_type
+                lambda: type(rmm.mr.get_current_device_resource())
             )
             for v in memory_resource_type.values():
                 assert v is rmm.mr.PoolMemoryResource
@@ -251,7 +251,7 @@ async def test_rmm_managed():
     ) as cluster:
         async with Client(cluster, asynchronous=True) as client:
             memory_resource_type = await client.run(
-                rmm.mr.get_current_device_resource_type
+                lambda: type(rmm.mr.get_current_device_resource())
             )
             for v in memory_resource_type.values():
                 assert v is rmm.mr.ManagedMemoryResource
@@ -268,7 +268,7 @@ async def test_rmm_async():
     ) as cluster:
         async with Client(cluster, asynchronous=True) as client:
             memory_resource_type = await client.run(
-                rmm.mr.get_current_device_resource_type
+                lambda: type(rmm.mr.get_current_device_resource())
             )
             for v in memory_resource_type.values():
                 assert v is rmm.mr.CudaAsyncMemoryResource
@@ -290,7 +290,7 @@ async def test_rmm_async_with_maximum_pool_size():
         async with Client(cluster, asynchronous=True) as client:
             memory_resource_types = await client.run(
                 lambda: (
-                    rmm.mr.get_current_device_resource_type(),
+                    type(rmm.mr.get_current_device_resource()),
                     type(rmm.mr.get_current_device_resource().get_upstream()),
                 )
             )
@@ -315,7 +315,7 @@ async def test_rmm_logging():
     ) as cluster:
         async with Client(cluster, asynchronous=True) as client:
             memory_resource_type = await client.run(
-                rmm.mr.get_current_device_resource_type
+                lambda: type(rmm.mr.get_current_device_resource())
             )
             for v in memory_resource_type.values():
                 assert v is rmm.mr.LoggingResourceAdaptor
@@ -433,7 +433,7 @@ async def test_rmm_track_allocations():
     ) as cluster:
         async with Client(cluster, asynchronous=True) as client:
             memory_resource_type = await client.run(
-                rmm.mr.get_current_device_resource_type
+                lambda: type(rmm.mr.get_current_device_resource())
             )
             for v in memory_resource_type.values():
                 assert v is rmm.mr.TrackingResourceAdaptor


### PR DESCRIPTION
## Summary

- Replace all uses of `rmm.mr.get_current_device_resource_type` with `type(rmm.mr.get_current_device_resource())` in tests, enabling removal of the `get_current_device_resource_type` function from RMM.

## Details

`rmm.mr.get_current_device_resource_type` is being removed from RMM. The only usage in dask-cuda is in tests. This PR replaces all 12 call sites across `test_dask_cuda_worker.py` and `test_local_cuda_cluster.py` with the equivalent `type(rmm.mr.get_current_device_resource())`.