### PR TITLE
Improve UCX documentation

### DIFF
--- a/dask_cuda/benchmarks/local_cudf_groupby.py
+++ b/dask_cuda/benchmarks/local_cudf_groupby.py
@@ -18,6 +18,8 @@ from dask_cuda.benchmarks.utils import (
     print_key_value,
     print_separator,
     print_throughput_bandwidth,
+    print_ucx_config,
+    ucx_config_to_dict,
 )
 
 
@@ -129,10 +131,7 @@ def pretty_print_results(args, address_to_index, p2p_bw, results, client=None):
             key="Device memory limit", value=f"{format_bytes(args.device_memory_limit)}"
         )
     print_key_value(key="RMM Pool", value=f"{not args.disable_rmm_pool}")
-    if args.protocol in ["ucx", "ucxx"]:
-        print_key_value(key="TCP", value=f"{args.enable_tcp_over_ucx}")
-        print_key_value(key="InfiniBand", value=f"{args.enable_infiniband}")
-        print_key_value(key="NVLink", value=f"{args.enable_nvlink}")
+    print_ucx_config(args)
     print_key_value(key="Worker thread(s)", value=f"{args.threads_per_worker}")
     print_key_value(key="Data processed", value=f"{format_bytes(results[0][0])}")
     print_key_value(key="Output size", value=f"{format_bytes(results[0][1])}")
@@ -159,9 +158,7 @@ def create_tidy_results(args, p2p_bw, results):
         "devs": args.devs,
         "device_memory_limit": args.device_memory_limit,
         "rmm_pool": not args.disable_rmm_pool,
-        "tcp": args.enable_tcp_over_ucx,
-        "ib": args.enable_infiniband,
-        "nvlink": args.enable_nvlink,
+        **ucx_config_to_dict(args),
     }
     timing_data = pd.DataFrame(
         [

--- a/dask_cuda/benchmarks/local_cudf_merge.py
+++ b/dask_cuda/benchmarks/local_cudf_merge.py
@@ -21,6 +21,8 @@ from dask_cuda.benchmarks.utils import (
     print_key_value,
     print_separator,
     print_throughput_bandwidth,
+    print_ucx_config,
+    ucx_config_to_dict,
 )
 
 # Benchmarking cuDF merge operation based on
@@ -222,10 +224,7 @@ def pretty_print_results(args, address_to_index, p2p_bw, results, client=None):
         )
     print_key_value(key="RMM Pool", value=f"{not args.disable_rmm_pool}")
     print_key_value(key="Frac-match", value=f"{args.frac_match}")
-    if args.protocol in ["ucx", "ucxx"]:
-        print_key_value(key="TCP", value=f"{args.enable_tcp_over_ucx}")
-        print_key_value(key="InfiniBand", value=f"{args.enable_infiniband}")
-        print_key_value(key="NVLink", value=f"{args.enable_nvlink}")
+    print_ucx_config(args)
     print_key_value(key="Worker thread(s)", value=f"{args.threads_per_worker}")
     print_key_value(key="Data processed", value=f"{format_bytes(results[0][0])}")
     if args.markdown:
@@ -260,9 +259,7 @@ def create_tidy_results(
         "worker_threads": args.threads_per_worker,
         "rmm_pool": not args.disable_rmm_pool,
         "protocol": args.protocol,
-        "tcp": args.enable_tcp_over_ucx,
-        "ib": args.enable_infiniband,
-        "nvlink": args.enable_nvlink,
+        **ucx_config_to_dict(args),
         "nreps": args.runs,
     }
     timing_data = pd.DataFrame(

--- a/dask_cuda/benchmarks/local_cudf_shuffle.py
+++ b/dask_cuda/benchmarks/local_cudf_shuffle.py
@@ -21,6 +21,8 @@ from dask_cuda.benchmarks.utils import (
     print_key_value,
     print_separator,
     print_throughput_bandwidth,
+    print_ucx_config,
+    ucx_config_to_dict,
 )
 
 try:
@@ -176,10 +178,7 @@ def pretty_print_results(args, address_to_index, p2p_bw, results, client=None):
             key="Device memory limit", value=f"{format_bytes(args.device_memory_limit)}"
         )
     print_key_value(key="RMM Pool", value=f"{not args.disable_rmm_pool}")
-    if args.protocol in ["ucx", "ucxx"]:
-        print_key_value(key="TCP", value=f"{args.enable_tcp_over_ucx}")
-        print_key_value(key="InfiniBand", value=f"{args.enable_infiniband}")
-        print_key_value(key="NVLink", value=f"{args.enable_nvlink}")
+    print_ucx_config(args)
     print_key_value(key="Worker thread(s)", value=f"{args.threads_per_worker}")
     print_key_value(key="Data processed", value=f"{format_bytes(results[0][0])}")
     if args.markdown:
@@ -206,9 +205,7 @@ def create_tidy_results(args, p2p_bw, results):
         "devs": args.devs,
         "device_memory_limit": args.device_memory_limit,
         "rmm_pool": not args.disable_rmm_pool,
-        "tcp": args.enable_tcp_over_ucx,
-        "ib": args.enable_infiniband,
-        "nvlink": args.enable_nvlink,
+        **ucx_config_to_dict(args),
     }
     timing_data = pd.DataFrame(
         [

--- a/dask_cuda/benchmarks/local_cupy.py
+++ b/dask_cuda/benchmarks/local_cupy.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib
@@ -20,6 +20,8 @@ from dask_cuda.benchmarks.utils import (
     print_key_value,
     print_separator,
     print_throughput_bandwidth,
+    print_ucx_config,
+    ucx_config_to_dict,
 )
 
 
@@ -195,10 +197,7 @@ def pretty_print_results(args, address_to_index, p2p_bw, results, client=None):
         )
     print_key_value(key="RMM Pool", value=f"{not args.disable_rmm_pool}")
     print_key_value(key="Protocol", value=f"{args.protocol}")
-    if args.protocol in ["ucx", "ucxx"]:
-        print_key_value(key="TCP", value=f"{args.enable_tcp_over_ucx}")
-        print_key_value(key="InfiniBand", value=f"{args.enable_infiniband}")
-        print_key_value(key="NVLink", value=f"{args.enable_nvlink}")
+    print_ucx_config(args)
     print_key_value(key="Worker thread(s)", value=f"{args.threads_per_worker}")
     data_processed, durations = zip(
         *((result["data_processed"], result["took"]) for result in results)
@@ -224,9 +223,7 @@ def create_tidy_results(args, p2p_bw, results):
         "worker_threads": args.threads_per_worker,
         "rmm_pool": not args.disable_rmm_pool,
         "protocol": args.protocol,
-        "tcp": args.enable_tcp_over_ucx,
-        "ib": args.enable_infiniband,
-        "nvlink": args.enable_nvlink,
+        **ucx_config_to_dict(args),
         "nreps": args.runs,
     }
     timing_data = pd.DataFrame(

--- a/dask_cuda/benchmarks/local_cupy_map_overlap.py
+++ b/dask_cuda/benchmarks/local_cupy_map_overlap.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib
@@ -22,6 +22,8 @@ from dask_cuda.benchmarks.utils import (
     print_key_value,
     print_separator,
     print_throughput_bandwidth,
+    print_ucx_config,
+    ucx_config_to_dict,
 )
 
 
@@ -80,10 +82,7 @@ def pretty_print_results(args, address_to_index, p2p_bw, results, client=None):
         )
     print_key_value(key="RMM Pool", value=f"{not args.disable_rmm_pool}")
     print_key_value(key="Protocol", value=f"{args.protocol}")
-    if args.protocol in ["ucx", "ucxx"]:
-        print_key_value(key="TCP", value=f"{args.enable_tcp_over_ucx}")
-        print_key_value(key="InfiniBand", value=f"{args.enable_infiniband}")
-        print_key_value(key="NVLink", value=f"{args.enable_nvlink}")
+    print_ucx_config(args)
     print_key_value(key="Worker thread(s)", value=f"{args.threads_per_worker}")
     data_processed, durations = zip(*results)
     if args.markdown:
@@ -105,9 +104,7 @@ def create_tidy_results(args, p2p_bw, results):
         "worker_threads": args.threads_per_worker,
         "rmm_pool": not args.disable_rmm_pool,
         "protocol": args.protocol,
-        "tcp": args.enable_tcp_over_ucx,
-        "ib": args.enable_infiniband,
-        "nvlink": args.enable_nvlink,
+        **ucx_config_to_dict(args),
         "nreps": args.runs,
         "kernel_size": args.kernel_size,
     }

--- a/dask_cuda/benchmarks/utils.py
+++ b/dask_cuda/benchmarks/utils.py
@@ -83,7 +83,8 @@ def parse_benchmark_args(
         choices=["tcp", "ucx", "ucxx"],
         default="tcp",
         type=str,
-        help="The communication protocol to use.",
+        help="The communication protocol to use. Use tcp as a baseline and ucx "
+        "for automatic UCX transport selection.",
     )
     cluster_args.add_argument(
         "--multiprocessing-method",
@@ -177,21 +178,24 @@ def parse_benchmark_args(
         default=None,
         action="store_true",
         dest="enable_tcp_over_ucx",
-        help="Enable TCP over UCX.",
+        help="Override automatic UCX transport selection to enable TCP over UCX for "
+        "transport-specific benchmarking.",
     )
     cluster_args.add_argument(
         "--enable-infiniband",
         default=None,
         action="store_true",
         dest="enable_infiniband",
-        help="Enable InfiniBand over UCX.",
+        help="Override automatic UCX transport selection to enable InfiniBand over "
+        "UCX for transport-specific benchmarking.",
     )
     cluster_args.add_argument(
         "--enable-nvlink",
         default=None,
         action="store_true",
         dest="enable_nvlink",
-        help="Enable NVLink over UCX.",
+        help="Override automatic UCX transport selection to enable NVLink over UCX "
+        "for transport-specific benchmarking.",
     )
     cluster_args.add_argument(
         "--enable-rdmacm",
@@ -204,19 +208,22 @@ def parse_benchmark_args(
         "--disable-tcp-over-ucx",
         action="store_false",
         dest="enable_tcp_over_ucx",
-        help="Disable TCP over UCX.",
+        help="Override automatic UCX transport selection to disable TCP over UCX for "
+        "transport-specific benchmarking.",
     )
     cluster_args.add_argument(
         "--disable-infiniband",
         action="store_false",
         dest="enable_infiniband",
-        help="Disable InfiniBand over UCX.",
+        help="Override automatic UCX transport selection to disable InfiniBand over "
+        "UCX for transport-specific benchmarking.",
     )
     cluster_args.add_argument(
         "--disable-nvlink",
         action="store_false",
         dest="enable_nvlink",
-        help="Disable NVLink over UCX.",
+        help="Override automatic UCX transport selection to disable NVLink over UCX "
+        "for transport-specific benchmarking.",
     )
     cluster_args.add_argument(
         "--disable-rdmacm",
@@ -433,6 +440,44 @@ def get_cluster_options(args):
         "args": cluster_args,
         "kwargs": cluster_kwargs,
         "scheduler_addr": scheduler_addr,
+    }
+
+
+def ucx_transport_selection(args):
+    """Return how UCX transports are selected for benchmark reporting."""
+    if args.protocol not in ("ucx", "ucxx"):
+        return "not-applicable"
+
+    transports = (
+        args.enable_tcp_over_ucx,
+        args.enable_infiniband,
+        args.enable_nvlink,
+    )
+    if all(transport is None for transport in transports):
+        return "automatic"
+    return "manual"
+
+
+def print_ucx_config(args):
+    """Print UCX transport selection details for benchmark output."""
+    selection = ucx_transport_selection(args)
+    if selection == "not-applicable":
+        return
+
+    print_key_value(key="UCX transport selection", value=selection)
+    if selection == "manual":
+        print_key_value(key="TCP", value=f"{args.enable_tcp_over_ucx}")
+        print_key_value(key="InfiniBand", value=f"{args.enable_infiniband}")
+        print_key_value(key="NVLink", value=f"{args.enable_nvlink}")
+
+
+def ucx_config_to_dict(args):
+    """Return UCX transport details for tidy benchmark output."""
+    return {
+        "ucx_transport_selection": ucx_transport_selection(args),
+        "tcp": args.enable_tcp_over_ucx,
+        "ib": args.enable_infiniband,
+        "nvlink": args.enable_nvlink,
     }
 
 

--- a/dask_cuda/cli.py
+++ b/dask_cuda/cli.py
@@ -313,29 +313,30 @@ def cuda():
     "--enable-tcp-over-ucx/--disable-tcp-over-ucx",
     default=None,
     show_default=True,
-    help="""Set environment variables to enable TCP over UCX, even if InfiniBand and
-    NVLink are not supported or disabled.""",
+    help="""Override automatic UCX transport selection to enable or disable TCP over
+    UCX. Prefer leaving this unset except when benchmarking a specific transport.""",
 )
 @click.option(
     "--enable-infiniband/--disable-infiniband",
     default=None,
     show_default=True,
-    help="""Set environment variables to enable UCX over InfiniBand, implies
-    ``--enable-tcp-over-ucx`` when enabled.""",
+    help="""Override automatic UCX transport selection to enable or disable
+    InfiniBand. Prefer leaving this unset except when benchmarking a specific
+    transport.""",
 )
 @click.option(
     "--enable-nvlink/--disable-nvlink",
     default=None,
     show_default=True,
-    help="""Set environment variables to enable UCX over NVLink, implies
-    ``--enable-tcp-over-ucx`` when enabled.""",
+    help="""Override automatic UCX transport selection to enable or disable NVLink.
+    Prefer leaving this unset except when benchmarking a specific transport.""",
 )
 @click.option(
     "--enable-rdmacm/--disable-rdmacm",
     default=None,
     show_default=True,
-    help="""Set environment variables to enable UCX RDMA connection manager support,
-    requires ``--enable-infiniband``.""",
+    help="""Override automatic UCX transport selection to enable or disable UCX RDMA
+    connection manager support, requires ``--enable-infiniband`` when enabled.""",
 )
 @click.option(
     "--worker-class",

--- a/dask_cuda/initialize.py
+++ b/dask_cuda/initialize.py
@@ -215,13 +215,16 @@ def initialize(
         Create CUDA context on initialization.
     enable_tcp_over_ucx : bool, default None
         Set environment variables to enable TCP over UCX, even if InfiniBand and NVLink
-        are not supported or disabled.
+        are not supported or disabled. Leave as ``None`` to use automatic UCX
+        transport selection.
     enable_infiniband : bool, default None
         Set environment variables to enable UCX over InfiniBand, implies
-        ``enable_tcp_over_ucx=True`` when ``True``.
+        ``enable_tcp_over_ucx=True`` when ``True``. Leave as ``None`` to use
+        automatic UCX transport selection.
     enable_nvlink : bool, default None
         Set environment variables to enable UCX over NVLink, implies
-        ``enable_tcp_over_ucx=True`` when ``True``.
+        ``enable_tcp_over_ucx=True`` when ``True``. Leave as ``None`` to use
+        automatic UCX transport selection.
     enable_rdmacm : bool, default None
         Set environment variables to enable UCX RDMA connection manager support,
         requires ``enable_infiniband=True``.

--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -92,14 +92,17 @@ class LocalCUDACluster(LocalCluster):
         Protocol to use for communication. Can be a string (like ``"tcp"`` or
         ``"ucx"``), or ``None`` to automatically choose the correct protocol.
     enable_tcp_over_ucx : bool, default None
-        Set environment variables to enable TCP over UCX, even if InfiniBand and NVLink
-        are not supported or disabled.
+        Set environment variables to enable TCP over UCX, even if InfiniBand and
+        NVLink are not supported or disabled. Leave as ``None`` to use automatic
+        UCX transport selection when ``protocol="ucx"``.
     enable_infiniband : bool, default None
         Set environment variables to enable UCX over InfiniBand, requires
         ``protocol="ucx"``, and implies ``enable_tcp_over_ucx=True`` when ``True``.
+        Leave as ``None`` to use automatic UCX transport selection.
     enable_nvlink : bool, default None
         Set environment variables to enable UCX over NVLink, requires
         ``protocol="ucx"``, and implies ``enable_tcp_over_ucx=True`` when ``True``.
+        Leave as ``None`` to use automatic UCX transport selection.
     enable_rdmacm : bool, default None
         Set environment variables to enable UCX RDMA connection manager support,
         requires ``protocol="ucx"``, and ``enable_infiniband=True``.

--- a/dask_cuda/tests/test_benchmarks.py
+++ b/dask_cuda/tests/test_benchmarks.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+from dask_cuda.benchmarks.utils import (
+    get_cluster_options,
+    parse_benchmark_args,
+    ucx_config_to_dict,
+    ucx_transport_selection,
+)
+
+
+def parse_args(monkeypatch, *argv):
+    monkeypatch.setattr(sys, "argv", ["benchmark", *argv])
+    return parse_benchmark_args()
+
+
+def test_benchmark_ucx_defaults_to_automatic_transport_selection(monkeypatch):
+    args = parse_args(monkeypatch, "--protocol", "ucx")
+
+    assert args.enable_tcp_over_ucx is None
+    assert args.enable_infiniband is None
+    assert args.enable_nvlink is None
+    assert ucx_transport_selection(args) == "automatic"
+    assert ucx_config_to_dict(args) == {
+        "ucx_transport_selection": "automatic",
+        "tcp": None,
+        "ib": None,
+        "nvlink": None,
+    }
+
+    cluster_kwargs = get_cluster_options(args)["kwargs"]
+    assert cluster_kwargs["enable_tcp_over_ucx"] is None
+    assert cluster_kwargs["enable_infiniband"] is None
+    assert cluster_kwargs["enable_nvlink"] is None
+
+
+def test_benchmark_ucx_transport_overrides_are_manual(monkeypatch):
+    args = parse_args(monkeypatch, "--protocol", "ucx", "--disable-nvlink")
+
+    assert args.enable_tcp_over_ucx is None
+    assert args.enable_infiniband is None
+    assert args.enable_nvlink is False
+    assert ucx_transport_selection(args) == "manual"

--- a/dask_cuda/tests/test_utils.py
+++ b/dask_cuda/tests/test_utils.py
@@ -219,6 +219,18 @@ def test_get_ucx_config(enable_tcp_over_ucx, enable_infiniband, enable_nvlink):
         assert ucx_config[canonical_name("cuda-copy", ucx_config)] is None
 
 
+def test_get_ucx_config_automatic_transport_selection():
+    pytest.importorskip("distributed_ucxx")
+
+    ucx_config = get_ucx_config()
+
+    assert ucx_config[canonical_name("tcp", ucx_config)] is None
+    assert ucx_config[canonical_name("infiniband", ucx_config)] is None
+    assert ucx_config[canonical_name("nvlink", ucx_config)] is None
+    assert ucx_config[canonical_name("cuda-copy", ucx_config)] is None
+    assert ucx_config[canonical_name("create_cuda_context", ucx_config)] is True
+
+
 def test_parse_visible_devices():
     pynvml.nvmlInit()
     indices = []

--- a/dask_cuda/utils.py
+++ b/dask_cuda/utils.py
@@ -327,16 +327,17 @@ def get_preload_options(
         needed by Dask workers.
     enable_tcp: bool, default None
         Set environment variables to enable TCP over UCX, even when InfiniBand or
-        NVLink support are disabled.
+        NVLink support are disabled. Leave as ``None`` to use automatic UCX
+        transport selection.
     enable_infiniband: bool, default None
         Set environment variables to enable UCX InfiniBand support. Implies
-        enable_tcp=True.
+        enable_tcp=True. Leave as ``None`` to use automatic UCX transport selection.
     enable_rdmacm: bool, default None
         Set environment variables to enable UCX RDMA connection manager support.
         Currently requires enable_infiniband=True.
     enable_nvlink: bool, default None
         Set environment variables to enable UCX NVLink support. Implies
-        enable_tcp=True.
+        enable_tcp=True. Leave as ``None`` to use automatic UCX transport selection.
 
     Example
     -------

--- a/docs/source/examples/best-practices.rst
+++ b/docs/source/examples/best-practices.rst
@@ -92,13 +92,15 @@ when Dask needed to move data back-and-forth between workers. This setup results
     ================================================================================
 
 
-To compare, we'll now change the ``procotol`` from ``tcp`` to ``ucx``:
+To compare, we'll now change the ``protocol`` from ``tcp`` to ``ucx`` and let
+UCX select the available transports automatically:
 
     python local_cudf_merge.py -d 0,1 -p ucx -c 50_000_000 --rmm-pool-size 30GB
 
 
 
-With UCX and NVLink, we greatly reduced the wall clock time to: ``347.43 ms +/- 5.41 ms``.::
+With automatic UCX transport selection on a system with NVLink, we greatly
+reduced the wall clock time to: ``347.43 ms +/- 5.41 ms``.::
 
     ================================================================================
     Wall clock                | Throughput

--- a/docs/source/examples/ucx.rst
+++ b/docs/source/examples/ucx.rst
@@ -1,8 +1,14 @@
 Enabling UCX communication
 ==========================
 
-A CUDA cluster using UCX communication can be started automatically with LocalCUDACluster or manually with the ``dask cuda worker`` CLI tool.
-In either case, a ``dask.distributed.Client`` must be made for the worker cluster using the same Dask UCX configuration; see `UCX Integration -- Configuration <../../ucx/#configuration>`_ for details on all available options.
+A CUDA cluster using UCX communication can be started automatically with
+LocalCUDACluster or manually with the ``dask cuda worker`` CLI tool. Prefer
+automatic UCX transport selection for routine deployments; set individual UCX
+transport flags only for transport-specific benchmarking. In either case, a
+``dask.distributed.Client`` must be made for the worker cluster using the same
+Dask UCX configuration; see
+`UCX Integration -- Configuration <../../ucx/#configuration>`_ for details on
+all available options.
 
 LocalCUDACluster with Automatic Configuration
 ---------------------------------------------
@@ -29,8 +35,11 @@ To connect a client to a cluster with automatically-configured UCX and an RMM po
 LocalCUDACluster with Manual Configuration
 ------------------------------------------
 
-When using LocalCUDACluster with UCX communication and manual configuration, all required UCX configuration is handled through arguments supplied at construction; see `API -- Cluster <../../api/#cluster>`_ for a complete list of these arguments.
-To connect a client to a cluster with all supported transports and an RMM pool:
+When benchmarking specific UCX transports with LocalCUDACluster, explicit
+transport configuration is handled through arguments supplied at construction;
+see `API -- Cluster <../../api/#cluster>`_ for a complete list of these
+arguments. To connect a client to a cluster with all supported transports
+enabled manually and an RMM pool:
 
 .. code-block:: python
 
@@ -124,14 +133,17 @@ Alternatively, the ``with dask.config.set`` statement from the example above may
 ``dask cuda worker`` with Manual Configuration
 ----------------------------------------------
 
-When using ``dask cuda worker`` with UCX communication and manual configuration, the scheduler, workers, and client must all be started manually, each using the same UCX configuration.
+When benchmarking specific UCX transports with ``dask cuda worker``, the
+scheduler, workers, and client must all be started manually, each using the
+same UCX configuration.
 
 Scheduler
 ^^^^^^^^^
 
 UCX configuration options will need to be specified for ``dask scheduler`` as environment variables; see `Dask Configuration -- Environment Variables <https://docs.dask.org/en/latest/configuration.html#environment-variables>`_ for more details on the mapping between environment variables and options.
 
-To start a Dask scheduler using UCX with all supported transports and an gigabyte RMM pool:
+To start a Dask scheduler using UCX with all supported transports selected
+manually and a one-gigabyte RMM pool:
 
 .. code-block:: bash
 
@@ -148,8 +160,10 @@ We communicate to the scheduler that we will be using UCX with the ``--protocol`
 Workers
 ^^^^^^^
 
-All UCX configuration options have analogous options in ``dask cuda worker``; see `API -- Worker <../../api/#worker>`_ for a complete list of these options.
-To start a cluster with all supported transports and an RMM pool:
+All UCX configuration options have analogous options in ``dask cuda worker``;
+see `API -- Worker <../../api/#worker>`_ for a complete list of these options.
+To start workers with all supported transports selected manually and an RMM
+pool:
 
 .. code-block:: bash
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -19,6 +19,9 @@ To create a Dask-CUDA cluster using all available GPUs and connect a Dask.distri
 .. tip::
 
    Be sure to include an ``if __name__ == "__main__":`` block when using :py:class:`dask_cuda.LocalCUDACluster` in a standalone Python script. See `standalone Python scripts <https://docs.dask.org/en/stable/scheduling.html#standalone-python-scripts>`_ for more details.
+   In scripts, tests, or repeated interactive experiments, context managers are
+   a convenient way to stop local workers promptly when the cluster is no longer
+   needed.
 
 ``dask cuda worker``
 --------------------

--- a/docs/source/ucx.rst
+++ b/docs/source/ucx.rst
@@ -32,6 +32,11 @@ A memory pool also prevents the Dask scheduler from deserializing CUDA data, whi
 Configuration
 -------------
 
+For most Dask-CUDA deployments, prefer automatic UCX transport selection:
+start the cluster with the UCX protocol and leave individual transports unset.
+Manual transport selection is still supported, but should generally be reserved
+for transport-specific benchmarking.
+
 UCX Configuration can be provided via:
 
 1. **YAML configuration files**: `distributed-ucxx.yaml`
@@ -50,7 +55,11 @@ The configuration schema is defined in `distributed-ucxx-schema.yaml <https://gi
 Example Configuration
 ~~~~~~~~~~~~~~~~~~~~~
 
-New schema (recommended):
+The following examples show the current schema for manual transport selection.
+Use them when benchmarking specific transports; routine Dask-CUDA deployment
+should prefer automatic selection instead.
+
+New schema:
 
 .. code-block:: yaml
 
@@ -87,7 +96,7 @@ Legacy schema (may be removed in the future):
 Environment Variables
 ~~~~~~~~~~~~~~~~~~~~~
 
-New schema (recommended):
+New schema:
 
 .. code-block:: bash
 
@@ -106,7 +115,7 @@ Legacy schema (may be removed in the future):
 Python Configuration
 ~~~~~~~~~~~~~~~~~~~~
 
-New schema (recommended):
+New schema:
 
 .. code-block:: python
 
@@ -148,30 +157,45 @@ Automatic
 
 Beginning with Dask-CUDA 22.02 and assuming UCX >= 1.11.1, specifying UCX transports is now optional.
 
-A local cluster can now be started with ``LocalCUDACluster(protocol="ucx")``, implying automatic UCX transport selection (``UCX_TLS=all``). Starting a cluster separately -- scheduler, workers and client as different processes -- is also possible, as long as Dask scheduler is created with ``dask scheduler --protocol="ucx"`` and connecting a ``dask cuda worker`` to the scheduler will imply automatic UCX transport selection, but that requires the Dask scheduler and client to be started with ``DASK_DISTRIBUTED_UCXX__CREATE_CUDA_CONTEXT=True``. See `Enabling UCX communication <../examples/ucx/>`_ for more details examples of UCX usage with automatic configuration.
+A local cluster can be started with ``LocalCUDACluster(protocol="ucx")``,
+which uses automatic UCX transport selection (``UCX_TLS=all``). Starting a
+cluster separately -- scheduler, workers and client as different processes --
+is also possible, as long as Dask scheduler is created with
+``dask scheduler --protocol="ucx"`` and connecting a ``dask cuda worker`` to
+the scheduler will imply automatic UCX transport selection, but that requires
+the Dask scheduler and client to be started with
+``DASK_DISTRIBUTED_UCXX__CREATE_CUDA_CONTEXT=True``. See
+`Enabling UCX communication <../examples/ucx/>`_ for more detailed examples
+of UCX usage with automatic configuration.
 
-Configuring transports manually is still possible, please refer to the subsection below.
+Configuring transports manually is still possible for benchmarking; see the
+subsection below.
 
 Manual
 ^^^^^^
 
-In addition to installations of UCX and UCXX on your system, for manual configuration several options must be specified within your Dask configuration to enable the integration.
-Typically, these will affect ``UCX_TLS`` and ``UCX_SOCKADDR_TLS_PRIORITY``, environment variables used by UCX to decide what transport methods to use and which to prioritize, respectively.
-However, some will affect related libraries, such as RMM:
+Manual transport selection can be useful when comparing specific transports. In
+addition to installations of UCX and UCXX on your system, several options may be
+specified within your Dask configuration to choose transports explicitly.
+Typically, these affect
+``UCX_TLS`` and ``UCX_SOCKADDR_TLS_PRIORITY``, environment variables used by
+UCX to decide what transport methods to use and which to prioritize,
+respectively. Some also affect related libraries, such as RMM:
 
-- ``distributed-ucxx.cuda_copy: true`` -- **required.**
+- ``distributed-ucxx.cuda_copy: true`` -- enable CUDA transfers over UCX
+  when selecting transports manually.
 
-  Adds ``cuda_copy`` to ``UCX_TLS``, enabling CUDA transfers over UCX.
+  Adds ``cuda_copy`` to ``UCX_TLS``.
 
-- ``distributed-ucxx.tcp: true`` -- **required.**
+- ``distributed-ucxx.tcp: true`` -- include TCP over UCX.
 
   Adds ``tcp`` to ``UCX_TLS``, enabling TCP transfers over UCX; this is required for very small transfers which are inefficient for NVLink and InfiniBand.
 
-- ``distributed-ucxx.nvlink: true`` -- **required for NVLink.**
+- ``distributed-ucxx.nvlink: true`` -- include NVLink for same-node benchmark comparisons.
 
   Adds ``cuda_ipc`` to ``UCX_TLS``, enabling NVLink transfers over UCX; affects intra-node communication only.
 
-- ``distributed-ucxx.infiniband: true`` -- **required for InfiniBand.**
+- ``distributed-ucxx.infiniband: true`` -- include InfiniBand for multi-node benchmark comparisons.
 
   Adds ``rc`` to ``UCX_TLS``, enabling InfiniBand transfers over UCX.
 


### PR DESCRIPTION
The docs now present `protocol="ucx"` with automatic transport selection as the normal path, while manual UCX config examples are explicitly benchmark-oriented. Benchmark CLIs and result metadata now distinguish automatic vs manual UCX transport selection, with tests covering the default automatic behavior.
