### PR TITLE
Build and test with CUDA 13.3.0

### DIFF
--- a/.github/workflows/build-ucxx.yaml
+++ b/.github/workflows/build-ucxx.yaml
@@ -55,7 +55,7 @@ permissions: {}
 jobs:
   conda-python-build:
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@cuda-13.3.0
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ permissions: {}
 jobs:
   conda-python-build:
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@cuda-13.3.0
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -51,7 +51,7 @@ jobs:
     if: github.ref_type == 'branch'
     needs: [conda-python-build]
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@cuda-13.3.0
     with:
       arch: "amd64"
       branch: ${{ inputs.branch }}
@@ -72,7 +72,7 @@ jobs:
     secrets:
       CONDA_RAPIDSAI_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_NIGHTLY_TOKEN }}
       CONDA_RAPIDSAI_TOKEN: ${{ secrets.CONDA_RAPIDSAI_TOKEN }}
-    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@cuda-13.3.0
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -86,7 +86,7 @@ jobs:
       pull-requests: read
   wheel-build:
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@cuda-13.3.0
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -114,7 +114,7 @@ jobs:
     secrets:
       CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
       RAPIDSAI_PYPI_TOKEN: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@cuda-13.3.0
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,7 +18,7 @@ jobs:
       - wheel-build
       - wheel-tests
       - telemetry-setup
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@cuda-13.3.0
     with:
       needs: ${{ toJSON(needs) }}
     permissions:
@@ -52,7 +52,7 @@ jobs:
           target-branch: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}
   checks:
     needs: telemetry-setup
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@cuda-13.3.0
     with:
       ignored_pr_jobs: telemetry-summarize
     permissions:
@@ -60,7 +60,7 @@ jobs:
   conda-python-build:
     needs: checks
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@cuda-13.3.0
     with:
       build_type: pull-request
       script: ci/build_python.sh
@@ -74,7 +74,7 @@ jobs:
   conda-python-tests:
     needs: conda-python-build
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@cuda-13.3.0
     with:
       build_type: pull-request
       script: ci/test_python.sh
@@ -87,7 +87,7 @@ jobs:
   docs-build:
     needs: conda-python-build
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@cuda-13.3.0
     with:
       build_type: pull-request
       node_type: "gpu-l4-latest-1"
@@ -103,7 +103,7 @@ jobs:
   wheel-build:
     needs: checks
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@cuda-13.3.0
     with:
       build_type: pull-request
       script: "ci/build_wheel.sh"
@@ -124,7 +124,7 @@ jobs:
   wheel-tests:
     needs: wheel-build
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@cuda-13.3.0
     with:
       build_type: pull-request
       script: "ci/test_wheel.sh"

--- a/.github/workflows/test-ucxx.yaml
+++ b/.github/workflows/test-ucxx.yaml
@@ -44,7 +44,7 @@ permissions: {}
 jobs:
   conda-python-ucxx-tests:
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@cuda-13.3.0
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ permissions: {}
 jobs:
   conda-python-tests:
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@cuda-13.3.0
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
@@ -39,7 +39,7 @@ jobs:
       pull-requests: read
   wheel-tests:
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@cuda-13.3.0
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/trigger-breaking-change-alert.yaml
+++ b/.github/workflows/trigger-breaking-change-alert.yaml
@@ -18,7 +18,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'breaking')
     permissions:
       contents: read
-    uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@cuda-13.3.0
     secrets:
       slack-webhook-url: ${{ secrets.NV_SLACK_BREAKING_CHANGE_NOTIFIER_APP }}
     with:

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - cuda-core>=0.3.2
 - cuda-nvcc-impl
 - cuda-nvrtc
-- cuda-version=13.2
+- cuda-version=13.3
 - cudf==26.8.*,>=0.0.0a0
 - dask-cudf==26.8.*,>=0.0.0a0
 - distributed-ucxx==0.51.*,>=0.0.0a0
@@ -31,4 +31,4 @@ dependencies:
 - sphinx-click>=2.7.1
 - sphinx-rtd-theme>=0.5.1
 - zict>=2.0.0
-name: all_cuda-132_arch-x86_64
+name: all_cuda-133_arch-aarch64

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - cuda-core>=0.3.2
 - cuda-nvcc-impl
 - cuda-nvrtc
-- cuda-version=13.2
+- cuda-version=13.3
 - cudf==26.8.*,>=0.0.0a0
 - dask-cudf==26.8.*,>=0.0.0a0
 - distributed-ucxx==0.51.*,>=0.0.0a0
@@ -31,4 +31,4 @@ dependencies:
 - sphinx-click>=2.7.1
 - sphinx-rtd-theme>=0.5.1
 - zict>=2.0.0
-name: all_cuda-132_arch-aarch64
+name: all_cuda-133_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -6,7 +6,7 @@ files:
   all:
     output: conda
     matrix:
-      cuda: ["12.9", "13.2"]
+      cuda: ["12.9", "13.3"]
       arch: [x86_64, aarch64]
     includes:
       - build_python
@@ -150,6 +150,10 @@ dependencies:
               cuda: "13.2"
             packages:
               - cuda-version=13.2
+          - matrix:
+              cuda: "13.3"
+            packages:
+              - cuda-version=13.3
       - output_types: requirements
         matrices:
           # if use_cuda_wheels=false is provided, do not add dependencies on any CUDA wheels
@@ -200,6 +204,11 @@ dependencies:
               use_cuda_wheels: "true"
             packages:
               - cuda-toolkit==13.2.*
+          - matrix:
+              cuda: "13.3"
+              use_cuda_wheels: "true"
+            packages:
+              - cuda-toolkit==13.3.*
   cuda:
     common:
       - output_types: conda

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -16,7 +16,7 @@ To install the latest version of Dask-CUDA along with the CUDA Toolkit:
 
 .. code-block:: bash
 
-    conda install -c rapidsai -c conda-forge dask-cuda cuda-version=13.2
+    conda install -c rapidsai -c conda-forge dask-cuda cuda-version=13.3
 
 UCXX Support
 ~~~~~~~~~~~~
@@ -25,7 +25,7 @@ To install the distributed-ucxx package to support accelerated communications wi
 
 .. code-block:: bash
 
-    conda install -c rapidsai -c conda-forge dask-cuda cuda-version=13.2 distributed-ucxx
+    conda install -c rapidsai -c conda-forge dask-cuda cuda-version=13.3 distributed-ucxx
 
 Pip
 ---


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/286

* uses CUDA 13.3.0 to build and test
* updates to CUDA 13.3.0 devcontainers

## Notes for Reviewers

This switches GitHub Actions workflows to the `cuda-13.3.0` branch from here: https://github.com/rapidsai/shared-workflows/pull/574

A future round of PRs will revert that back to `main`, once all of RAPIDS is migrated.

