### PR TITLE
refactor: switch to `rapids-artifact-name` for consistent artifact naming

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -122,7 +122,7 @@ jobs:
       date: ${{ inputs.date }}
       package-name: dask-cuda
       package-type: python
-      publish-wheel-search-key: "dask-cuda_wheel"
+      publish-wheel-search-key: "dask-cuda_wheel_python_dask-cuda"
     permissions:
       actions: read
       contents: read

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 
 rapids-logger "Downloading artifacts from previous jobs"
-PYTHON_CHANNEL=$(rapids-download-from-github "$(rapids-package-name "conda_python" dask-cuda --pure)")
+PYTHON_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_python dask-cuda dask-cuda --pure --arch any)")
 
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -25,5 +25,5 @@ rattler-build build --recipe conda/recipes/dask-cuda \
 # tracked in https://github.com/prefix-dev/rattler-build/issues/1424
 rm -rf "$RAPIDS_CONDA_BLD_OUTPUT_DIR"/build_cache
 
-RAPIDS_PACKAGE_NAME="$(rapids-package-name conda_python dask-cuda --pure)"
+RAPIDS_PACKAGE_NAME="$(rapids-artifact-name conda_python dask-cuda dask-cuda --pure --arch any)"
 export RAPIDS_PACKAGE_NAME

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -25,5 +25,5 @@ rapids-pip-retry wheel \
 
 ./ci/validate_wheel.sh "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
 
-RAPIDS_PACKAGE_NAME="$(rapids-package-name wheel_python dask-cuda --pure)"
+RAPIDS_PACKAGE_NAME="$(rapids-artifact-name wheel_python dask-cuda dask-cuda --pure --arch any)"
 export RAPIDS_PACKAGE_NAME

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -10,7 +10,7 @@ rapids-logger "Configuring conda strict channel priority"
 conda config --set channel_priority strict
 
 rapids-logger "Downloading artifacts from previous jobs"
-PYTHON_CHANNEL=$(rapids-download-from-github "$(rapids-package-name "conda_python" dask-cuda --pure)")
+PYTHON_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_python dask-cuda dask-cuda --pure --arch any)")
 
 rapids-logger "Generate Python testing dependencies"
 rapids-dependency-file-generator \

--- a/ci/test_python_ucxx.sh
+++ b/ci/test_python_ucxx.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -10,7 +10,7 @@ rapids-logger "Configuring conda strict channel priority"
 conda config --set channel_priority strict
 
 rapids-logger "Downloading artifacts from previous jobs"
-PYTHON_CHANNEL=$(rapids-download-from-github "$(rapids-package-name "conda_python" dask-cuda --pure)")
+PYTHON_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_python dask-cuda dask-cuda --pure --arch any)")
 
 rapids-logger "Generate Python testing dependencies"
 rapids-dependency-file-generator \

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -9,7 +9,7 @@ source rapids-init-pip
 RAPIDS_CUDA_MAJOR="${RAPIDS_CUDA_VERSION%%.*}"
 export RAPIDS_CUDA_MAJOR
 
-DASK_CUDA_WHEELHOUSE=$(rapids-download-from-github "$(rapids-package-name "wheel_python" "dask-cuda" --pure)")
+DASK_CUDA_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_python dask-cuda dask-cuda --pure --arch any)")
 
 # generate constraints (possibly pinning to oldest supported versions of dependencies)
 rapids-generate-pip-constraints py_test "${PIP_CONSTRAINT}"


### PR DESCRIPTION
This PR swaps in `rapids-artifact-name` for `rapids-package-name` everywhere, and also removes any legacy named artifacts. All artifacts now follow the same naming convention (and that convention can be updated/expanded from a central location). Part of rapidsai/build-planning#270