### PR TITLE
remove workaround for cuda-core<0.5.1, test against oldest cuda-core in UCXX tests

### DIFF
--- a/ci/test_python_ucxx.sh
+++ b/ci/test_python_ucxx.sh
@@ -16,7 +16,7 @@ rapids-logger "Generate Python testing dependencies"
 rapids-dependency-file-generator \
   --output conda \
   --file-key test_python \
-  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" \
+  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION};dependencies=${RAPIDS_DEPENDENCIES}" \
   --prepend-channel "${PYTHON_CHANNEL}" \
   | tee env.yaml
 

--- a/dask_cuda/initialize.py
+++ b/dask_cuda/initialize.py
@@ -6,13 +6,7 @@ import os
 
 import click
 
-try:
-    from cuda.core import Device
-except ImportError:
-    # Remove when cuda-core>=0.5
-    import cuda.core.experimental
-
-    Device = cuda.core.experimental.Device
+from cuda.core import Device
 
 import dask
 from distributed.diagnostics.nvml import (

--- a/dask_cuda/tests/test_initialize.py
+++ b/dask_cuda/tests/test_initialize.py
@@ -268,12 +268,7 @@ def _test_cuda_context_warning_with_subprocess_warnings(protocol):
         # Problematic library that creates CUDA context at import time
         import os
 
-        try:
-            from cuda.core import Device
-        except ImportError:
-            # cuda-core < 0.5
-            import cuda.core.experimental
-            Device = cuda.core.experimental.Device
+        from cuda.core import Device
 
         try:
             # Create CUDA context at import time, this will be inherited by subprocesses

--- a/dask_cuda/tests/test_utils.py
+++ b/dask_cuda/tests/test_utils.py
@@ -7,15 +7,7 @@ from unittest.mock import patch
 import pynvml
 import pytest
 
-try:
-    from cuda.core import Device
-except ImportError:
-    # Remove when cuda-core>=0.5
-    import cuda.core.experimental
-
-    Device = cuda.core.experimental.Device
-
-
+from cuda.core import Device
 from dask.config import canonical_name
 
 from dask_cuda.utils import (


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/285

This project is already not depending on `cuda-python` and carrying the same `cuda-core` floor I'm proposing across RAPIDS (`>=0.5.1`), and it's already testing against oldest `cuda-core` in most places:

https://github.com/rapidsai/dask-cuda/blob/467fad08c868b0e99dea2441dc2f17f10923c526/dependencies.yaml#L294-L296

This proposes a few other small changes related to that dependency:

* removes a workaround for `cuda-core<0.5` (unnecessary since the project requires `cuda-core>=0.5.1`)
* threads `RAPIDS_DEPENDENCIES` through the UCXX tests too