### PR TITLE
enforce 'yamllint' checks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,10 +2,11 @@
 dask_cuda/  @rapidsai/daskcuda-python-codeowners
 
 #CI code owners
-/.github/                @rapidsai/ci-codeowners
 /ci/                     @rapidsai/ci-codeowners
+/.github/                @rapidsai/ci-codeowners
 /.pre-commit-config.yaml @rapidsai/ci-codeowners
 /.shellcheckrc           @rapidsai/ci-codeowners
+/.yamllint.yaml          @rapidsai/ci-codeowners
 
 #packaging code owners
 /.devcontainer/    @rapidsai/packaging-codeowners

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,10 +82,7 @@ repos:
         exclude: |
           (?x)^(
             [.]github/labeler[.]yml$|
-            conda/environments/.*|
-            cpp/[.]clang-format$|
-            cpp/[.]clang-tidy$|
-            .*xfail\-.*yaml$
+            conda/environments/.*
           )
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
     rev: v1.24.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,82 +2,95 @@
 # SPDX-License-Identifier: Apache-2.0
 
 repos:
-      - repo: https://github.com/pre-commit/pre-commit-hooks
-        rev: v6.0.0
-        hooks:
-              - id: trailing-whitespace
-              - id: end-of-file-fixer
-      - repo: https://github.com/astral-sh/ruff-pre-commit
-        rev: v0.14.4
-        hooks:
-          - id: ruff-check
-            args: [--fix]
-          - id: ruff-format
-      - repo: https://github.com/codespell-project/codespell
-        rev: v2.4.1
-        hooks:
-              - id: codespell
-                exclude: |
-                  (?x)^(
-                    .*test.*|
-                    ^CHANGELOG.md$|
-                  )
-      - repo: https://github.com/pre-commit/mirrors-mypy
-        rev: 'v1.18.2'
-        hooks:
-              - id: mypy
-                additional_dependencies: [types-cachetools]
-                args: ["--module=dask_cuda", "--ignore-missing-imports"]
-                pass_filenames: false
-      - repo: https://github.com/rapidsai/pre-commit-hooks
-        rev: v1.4.3
-        hooks:
-            - id: verify-alpha-spec
-            - id: verify-copyright
-              args: [--fix, --spdx]
-              files: |
-                (?x)
-                  [.](cmake|cpp|cu|cuh|h|hpp|sh|pxd|py|pyx|rs|java)$|
-                  CMakeLists[.]txt$|
-                  CMakeLists_standalone[.]txt$|
-                  meta[.]yaml$|
-                  pyproject[.]toml$|
-                  setup[.]cfg$|
-                  recipe[.]yaml$|
-                  ^[.]pre-commit-config[.]yaml$|
-                  dependencies[.]yaml$|
-                  pytest[.]ini$|
-                  Makefile$|
-                  [.]flake8$
-            - id: verify-pyproject-license
-            - id: verify-hardcoded-version
-            - id: verify-hardcoded-version
-              name: verify-hardcoded-version-ucxx
-              args: [--fix, --version-file=UCXX_VERSION]
-              exclude: |
-                (?x)
-                  (^|/)devcontainer[.]json$|
-                  (^|/)dependencies[.]yaml$|
-                  ^[.]github/(workflows|ISSUE_TEMPLATE)/|
-                  (^|/)pom[.]xml$|
-                  ^[.]pre-commit-config[.]yaml$|
-                  ^conda/environments/|
-                  (^|/)VERSION$|
-                  (^|/)RAPIDS_BRANCH$|
-                  [.](md|rst|avro|parquet|png|orc|gz|pkl|sas7bdat)$
-      - repo: https://github.com/rapidsai/dependency-file-generator
-        rev: v1.20.0
-        hooks:
-            - id: rapids-dependency-file-generator
-              args: ["--clean", "--warn-all", "--strict"]
-      - repo: https://github.com/shellcheck-py/shellcheck-py
-        rev: v0.11.0.1
-        hooks:
-          - id: shellcheck
-      - repo: https://github.com/zizmorcore/zizmor-pre-commit
-        rev: v1.24.1
-        hooks:
-          - id: zizmor
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.4
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        exclude: |
+          (?x)^(
+            .*test.*|
+            ^CHANGELOG.md$|
+          )
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v1.18.2'
+    hooks:
+      - id: mypy
+        additional_dependencies: [types-cachetools]
+        args: ["--module=dask_cuda", "--ignore-missing-imports"]
+        pass_filenames: false
+  - repo: https://github.com/rapidsai/pre-commit-hooks
+    rev: v1.4.3
+    hooks:
+      - id: verify-alpha-spec
+      - id: verify-copyright
+        args: [--fix, --spdx]
+        files: |
+          (?x)
+            [.](cmake|cpp|cu|cuh|h|hpp|sh|pxd|py|pyx|rs|java)$|
+            CMakeLists[.]txt$|
+            CMakeLists_standalone[.]txt$|
+            meta[.]yaml$|
+            pyproject[.]toml$|
+            setup[.]cfg$|
+            recipe[.]yaml$|
+            ^[.]pre-commit-config[.]yaml$|
+            dependencies[.]yaml$|
+            pytest[.]ini$|
+            Makefile$|
+            [.]flake8$
+      - id: verify-pyproject-license
+      - id: verify-hardcoded-version
+      - id: verify-hardcoded-version
+        name: verify-hardcoded-version-ucxx
+        args: [--fix, --version-file=UCXX_VERSION]
+        exclude: |
+          (?x)
+            (^|/)devcontainer[.]json$|
+            (^|/)dependencies[.]yaml$|
+            ^[.]github/(workflows|ISSUE_TEMPLATE)/|
+            (^|/)pom[.]xml$|
+            ^[.]pre-commit-config[.]yaml$|
+            ^conda/environments/|
+            (^|/)VERSION$|
+            (^|/)RAPIDS_BRANCH$|
+            [.](md|rst|avro|parquet|png|orc|gz|pkl|sas7bdat)$
+  - repo: https://github.com/rapidsai/dependency-file-generator
+    rev: v1.20.0
+    hooks:
+      - id: rapids-dependency-file-generator
+        args: ["--clean", "--warn-all", "--strict"]
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+        additional_dependencies: [pyyaml]
+        exclude: |
+          (?x)^(
+            [.]github/labeler[.]yml$|
+            conda/environments/.*|
+            cpp/[.]clang-format$|
+            cpp/[.]clang-tidy$|
+            .*xfail\-.*yaml$
+          )
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.24.1
+    hooks:
+      - id: zizmor
 
 default_language_version:
-      python: python3
+  python: python3

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+extends: default
+
+rules:
+  anchors:
+    forbid-undeclared-aliases: true
+    forbid-duplicated-anchors: true
+    forbid-unused-anchors: true
+  braces:
+    forbid: false
+    min-spaces-inside: 0
+    # allow 1 space for jinja templating in conda recipes
+    max-spaces-inside: 1
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  brackets: enable
+  colons:
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments: disable
+  comments-indentation: disable
+  document-end: disable
+  document-start: disable
+  key-duplicates:
+    forbid-duplicated-merge-keys: true
+  line-length: disable
+  truthy:
+    allowed-values: ['false', 'true']
+    # having problematic value in keys is rare... and also
+    # GitHub Actions' choie of 'on:' triggers this check
+    # ref: https://github.com/adrienverge/yamllint/issues/430
+    check-keys: false


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/305

Proposes enforcing `yamllint` checks here. My primary motivation is to catch correctness issues in `dependencies.yaml` files, like duplicate entries silently resolving to the last one or indentation mistakes leading to filters being ignored.

But this also has some side benefits for consistency, which makes it a bit easier to write automation.