### PR TITLE
ensure nightly builds always produce new packages

### DIFF
--- a/.github/workflows/build-ucxx.yaml
+++ b/.github/workflows/build-ucxx.yaml
@@ -53,11 +53,15 @@ concurrency:
 permissions: {}
 
 jobs:
+  build-details:
+    uses: rapidsai/shared-workflows/.github/workflows/compute-build-details.yaml@main
   conda-python-build:
+    needs: [build-details]
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
+      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       script: ci/build_python.sh

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,6 +31,8 @@ concurrency:
   cancel-in-progress: true
 permissions: {}
 jobs:
+  build-details:
+    uses: rapidsai/shared-workflows/.github/workflows/compute-build-details.yaml@main
   conda-python-build:
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,10 +34,12 @@ jobs:
   build-details:
     uses: rapidsai/shared-workflows/.github/workflows/compute-build-details.yaml@main
   conda-python-build:
+    needs: [build-details]
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
+      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       script: ci/build_python.sh
@@ -87,10 +89,12 @@ jobs:
       packages: read
       pull-requests: read
   wheel-build:
+    needs: [build-details]
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
+      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       branch: ${{ inputs.branch }}
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,6 +8,8 @@ concurrency:
   cancel-in-progress: true
 permissions: {}
 jobs:
+  build-details:
+    uses: rapidsai/shared-workflows/.github/workflows/compute-build-details.yaml@main
   pr-builder:
     needs:
       - check-nightly-ci

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,6 +12,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/compute-build-details.yaml@main
   pr-builder:
     needs:
+      - build-details
       - check-nightly-ci
       - checks
       - conda-python-build
@@ -60,11 +61,12 @@ jobs:
     permissions:
       contents: read
   conda-python-build:
-    needs: checks
+    needs: [build-details, checks]
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
       build_type: pull-request
+      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       script: ci/build_python.sh
       pure-conda: true
     permissions:
@@ -103,11 +105,12 @@ jobs:
       packages: read
       pull-requests: read
   wheel-build:
-    needs: checks
+    needs: [build-details, checks]
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       build_type: pull-request
+      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       script: "ci/build_wheel.sh"
       package-name: dask-cuda
       package-type: python

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,8 +8,6 @@ concurrency:
   cancel-in-progress: true
 permissions: {}
 jobs:
-  build-details:
-    uses: rapidsai/shared-workflows/.github/workflows/compute-build-details.yaml@main
   pr-builder:
     needs:
       - build-details
@@ -37,6 +35,8 @@ jobs:
         # since other jobs depend on it.
         if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
         uses: rapidsai/shared-actions/telemetry-dispatch-stash-base-env-vars@main
+  build-details:
+    uses: rapidsai/shared-workflows/.github/workflows/compute-build-details.yaml@main
   check-nightly-ci:
     runs-on: ubuntu-latest
     permissions:

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-source rapids-date-string
+source rapids-datetime-string
 
 rapids-print-env
 

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-source rapids-date-string
+source rapids-datetime-string
 source rapids-init-pip
 
 rapids-generate-version > ./VERSION

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -7,7 +7,8 @@ set -euo pipefail
 source rapids-datetime-string
 source rapids-init-pip
 
-rapids-generate-version > ./VERSION
+RAPIDS_VERSION_SUFFIX=".post${RAPIDS_DATETIME_STRING}" \
+  rapids-generate-version > ./VERSION
 
 RAPIDS_PIP_WHEEL_ARGS=(
   -w "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"

--- a/conda/recipes/dask-cuda/recipe.yaml
+++ b/conda/recipes/dask-cuda/recipe.yaml
@@ -5,7 +5,7 @@ schema_version: 1
 context:
   version: ${{ env.get("RAPIDS_PACKAGE_VERSION") }}
   minor_version: ${{ (version | split("."))[:2] | join(".") }}
-  datetime_string: '${{ env.get("RAPIDS_DATE_STRING") }}'
+  datetime_string: '${{ env.get("RAPIDS_DATETIME_STRING") }}'
   py_version: ${{ env.get("RAPIDS_PY_VERSION") }}
   py_buildstring: ${{ py_version | version_to_buildstring }}
   head_rev: '${{ git.head_rev(".")[:8] }}'
@@ -19,7 +19,7 @@ source:
 
 build:
   noarch: python
-  string: py${{ py_buildstring }}_${{ date_string }}_${{ head_rev }}
+  string: py${{ py_buildstring }}_${{ datetime_string }}_${{ head_rev }}
   script:
     content: |
       python -m pip install . -vv

--- a/conda/recipes/dask-cuda/recipe.yaml
+++ b/conda/recipes/dask-cuda/recipe.yaml
@@ -5,7 +5,7 @@ schema_version: 1
 context:
   version: ${{ env.get("RAPIDS_PACKAGE_VERSION") }}
   minor_version: ${{ (version | split("."))[:2] | join(".") }}
-  date_string: '${{ env.get("RAPIDS_DATE_STRING") }}'
+  datetime_string: '${{ env.get("RAPIDS_DATE_STRING") }}'
   py_version: ${{ env.get("RAPIDS_PY_VERSION") }}
   py_buildstring: ${{ py_version | version_to_buildstring }}
   head_rev: '${{ git.head_rev(".")[:8] }}'


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/218

* uses the new patterns for versioning nightly packages (see https://github.com/rapidsai/shared-workflows/pull/603), to ensure they're always uploaded on new builds. 

For wheels:

```text
# before
26.10.0a55 

# after
26.10.0a55.post260803200854
```

And for conda:

```text
# before
26.10.0a55[build=cuda12_260803_9da146ef]

# after
26.10.0a55[build=cuda12_260803200854_9da146ef]
```

Other changes:

* updates `changed-files` lists to avoid triggering test jobs in PR CI when only `.github/workflows/{build,test}.yaml` are changed

## Notes for Reviewers

### How I tested this

See https://github.com/rapidsai/cugraph-gnn/pull/508
