### PR TITLE
Turn on autosectionlabel in sphinx docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,6 +46,7 @@ version = ".".join(release.split(".")[:2])
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.autosectionlabel",
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
     "sphinx.ext.githubpages",
@@ -55,6 +56,9 @@ extensions = [
     "numpydoc",
     "sphinx_click",
 ]
+
+# Disambiguate section anchors across documents
+autosectionlabel_prefix_document = True
 
 numpydoc_show_class_members = False
 


### PR DESCRIPTION
This will allow linking to arbitrary sections through intersphinx inventories. Without these one can only link to a given page or some kind of object name.